### PR TITLE
AAP-63925: refactor: remove legacy migration code from paths module

### DIFF
--- a/devflow/utils/paths.py
+++ b/devflow/utils/paths.py
@@ -1,130 +1,14 @@
 """Path utilities for DevAIFlow."""
 
 import os
-import shutil
-import sys
 from pathlib import Path
-
-
-def _migrate_claude_sessions_to_daf(old_dir: Path, new_dir: Path) -> bool:
-    """Migrate data from .claude-sessions to .daf-sessions.
-
-    This is a one-time migration that copies:
-    - sessions/ directory (all session data)
-    - backends/ directory (backend configurations)
-    - config.json (main configuration)
-    - organization.json (organization settings)
-    - team.json (team settings)
-    - templates.json (session templates)
-    - mocks/ directory (mock data, if exists)
-
-    Args:
-        old_dir: Path to .claude-sessions
-        new_dir: Path to .daf-sessions
-
-    Returns:
-        True if migration was performed, False if skipped
-    """
-    # Check if migration marker exists
-    migration_marker = new_dir / ".migrated"
-    if migration_marker.exists():
-        return False
-
-    # Check if old directory has sessions
-    old_sessions_dir = old_dir / "sessions"
-    if not old_sessions_dir.exists():
-        return False
-
-    # Check if new directory already has sessions (skip migration)
-    new_sessions_dir = new_dir / "sessions"
-    if new_sessions_dir.exists() and list(new_sessions_dir.iterdir()):
-        return False
-
-    # Perform migration
-    try:
-        # Ensure new directory exists
-        new_dir.mkdir(parents=True, exist_ok=True)
-
-        # Migrate sessions directory
-        if old_sessions_dir.exists():
-            if new_sessions_dir.exists():
-                shutil.rmtree(new_sessions_dir)
-            shutil.copytree(old_sessions_dir, new_sessions_dir)
-
-        # Migrate backends directory
-        old_backends = old_dir / "backends"
-        new_backends = new_dir / "backends"
-        if old_backends.exists():
-            if new_backends.exists():
-                shutil.rmtree(new_backends)
-            shutil.copytree(old_backends, new_backends)
-
-        # Migrate config.json
-        old_config = old_dir / "config.json"
-        new_config = new_dir / "config.json"
-        if old_config.exists():
-            shutil.copy2(old_config, new_config)
-
-        # Migrate organization.json
-        old_organization = old_dir / "organization.json"
-        new_organization = new_dir / "organization.json"
-        if old_organization.exists():
-            shutil.copy2(old_organization, new_organization)
-
-        # Migrate team.json
-        old_team = old_dir / "team.json"
-        new_team = new_dir / "team.json"
-        if old_team.exists():
-            shutil.copy2(old_team, new_team)
-
-        # Migrate templates.json
-        old_templates = old_dir / "templates.json"
-        new_templates = new_dir / "templates.json"
-        if old_templates.exists():
-            shutil.copy2(old_templates, new_templates)
-
-        # Migrate sessions.json (session metadata)
-        old_sessions_json = old_dir / "sessions.json"
-        new_sessions_json = new_dir / "sessions.json"
-        if old_sessions_json.exists():
-            shutil.copy2(old_sessions_json, new_sessions_json)
-
-        # Migrate mocks directory (if exists)
-        old_mocks = old_dir / "mocks"
-        new_mocks = new_dir / "mocks"
-        if old_mocks.exists():
-            if new_mocks.exists():
-                shutil.rmtree(new_mocks)
-            shutil.copytree(old_mocks, new_mocks)
-
-        # Create migration marker
-        migration_marker.touch()
-
-        # Print success message (suppress in JSON mode)
-        if "--json" not in sys.argv:
-            print(
-                f"✓ Migrated sessions from {old_dir} to {new_dir}",
-                file=sys.stderr
-            )
-
-        return True
-
-    except Exception as e:
-        # If migration fails, print error but don't crash
-        if "--json" not in sys.argv:
-            print(
-                f"Warning: Failed to migrate sessions: {e}",
-                file=sys.stderr
-            )
-        return False
 
 
 def get_cs_home() -> Path:
     """Get the DevAIFlow home directory.
 
     Returns the directory specified by DEVAIFLOW_HOME environment variable,
-    or defaults to ~/.daf-sessions for new installations (with backward
-    compatibility for existing ~/.claude-sessions installations).
+    or defaults to ~/.daf-sessions.
 
     The DEVAIFLOW_HOME variable supports:
     - Tilde expansion (e.g., ~/custom/path)
@@ -135,13 +19,9 @@ def get_cs_home() -> Path:
         Path to DevAIFlow home directory
 
     Examples:
-        >>> # With DEVAIFLOW_HOME not set (new installation)
+        >>> # With DEVAIFLOW_HOME not set
         >>> get_cs_home()
         PosixPath('/home/user/.daf-sessions')
-
-        >>> # With existing ~/.claude-sessions (backward compatibility)
-        >>> get_cs_home()
-        PosixPath('/home/user/.claude-sessions')
 
         >>> # With DEVAIFLOW_HOME set to custom path
         >>> os.environ['DEVAIFLOW_HOME'] = '~/my-sessions'
@@ -153,26 +33,8 @@ def get_cs_home() -> Path:
     if devaiflow_home:
         return Path(devaiflow_home).expanduser().resolve()
 
-    # Default: Search for directories in priority order
-    # 1. ~/.daf-sessions (new default)
-    # 2. ~/.claude-sessions (backward compatibility)
-    new_default = Path.home() / ".daf-sessions"
-    old_default = Path.home() / ".claude-sessions"
-
-    # Attempt one-time migration from .claude-sessions to .daf-sessions
-    if new_default.exists() and old_default.exists():
-        _migrate_claude_sessions_to_daf(old_default, new_default)
-
-    # Use new default if it exists
-    if new_default.exists():
-        return new_default
-
-    # Fall back to old default if it exists (backward compat)
-    if old_default.exists():
-        return old_default
-
-    # Neither exists - use new default for new installations
-    return new_default
+    # Default to ~/.daf-sessions
+    return Path.home() / ".daf-sessions"
 
 
 def is_mock_mode() -> bool:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 import pytest
 
-from devflow.utils.paths import get_cs_home, is_mock_mode, _migrate_claude_sessions_to_daf
+from devflow.utils.paths import get_cs_home, is_mock_mode
 
 
-def test_get_cs_home_default_new_installation(monkeypatch, tmp_path):
-    """Test get_cs_home returns ~/.daf-sessions for new installations."""
+def test_get_cs_home_default(monkeypatch, tmp_path):
+    """Test get_cs_home returns ~/.daf-sessions by default."""
     # Ensure environment variable is not set
     monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
 
@@ -26,47 +26,6 @@ def test_get_cs_home_default_new_installation(monkeypatch, tmp_path):
 
     # Restore original
     monkeypatch.setattr(Path, "home", original_home)
-
-
-def test_get_cs_home_default_backward_compat(monkeypatch, tmp_path):
-    """Test get_cs_home returns ~/.claude-sessions if it exists (backward compat)."""
-    # Ensure environment variable is not set
-    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
-
-    # Mock Path.home() to use tmp_path
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
-
-    # Create old directory (existing installation)
-    old_dir = tmp_path / ".claude-sessions"
-    old_dir.mkdir()
-
-    result = get_cs_home()
-
-    # Should use old directory for backward compatibility
-    assert result == old_dir
-    assert isinstance(result, Path)
-
-
-def test_get_cs_home_priority_daf_over_claude(monkeypatch, tmp_path):
-    """Test that ~/.daf-sessions takes priority over ~/.claude-sessions when both exist."""
-    # Ensure environment variable is not set
-    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
-
-    # Mock Path.home() to use tmp_path
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
-
-    # Create both directories
-    new_dir = tmp_path / ".daf-sessions"
-    old_dir = tmp_path / ".claude-sessions"
-    new_dir.mkdir()
-    old_dir.mkdir()
-
-    result = get_cs_home()
-
-    # Should use new directory (takes priority)
-    assert result == new_dir
-    assert result != old_dir
-    assert isinstance(result, Path)
 
 
 def test_get_cs_home_with_devaiflow_home(monkeypatch, tmp_path):
@@ -132,8 +91,6 @@ def test_get_cs_home_with_absolute_path(monkeypatch, tmp_path):
 def test_get_cs_home_consistency(monkeypatch, tmp_path):
     """Test get_cs_home returns same value on multiple calls."""
     monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
-    monkeypatch.delenv("CLAUDE_SESSION_HOME", raising=False)
-    monkeypatch.delenv("CS_HOME", raising=False)
 
     # Mock Path.home() to use tmp_path to avoid side effects
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -148,8 +105,6 @@ def test_get_cs_home_with_complex_path(monkeypatch, tmp_path):
     """Test get_cs_home handles complex paths with spaces and special chars."""
     complex_path = tmp_path / "my sessions" / "test-env"
     monkeypatch.setenv("DEVAIFLOW_HOME", str(complex_path))
-    monkeypatch.delenv("CLAUDE_SESSION_HOME", raising=False)
-    monkeypatch.delenv("CS_HOME", raising=False)
 
     result = get_cs_home()
 
@@ -179,160 +134,3 @@ def test_is_mock_mode_with_daf_set_to_zero(monkeypatch):
     monkeypatch.setenv("DAF_MOCK_MODE", "0")
 
     assert is_mock_mode() is False
-
-
-# Tests for _migrate_claude_sessions_to_daf()
-
-
-def test_migrate_claude_sessions_to_daf_success(tmp_path, capsys):
-    """Test migration from .claude-sessions to .daf-sessions copies all files."""
-    old_dir = tmp_path / ".claude-sessions"
-    new_dir = tmp_path / ".daf-sessions"
-
-    # Create old directory structure
-    old_dir.mkdir()
-    (old_dir / "sessions").mkdir()
-    (old_dir / "backends").mkdir()
-    (old_dir / "config.json").write_text('{"repos": {"workspace": "~/dev"}}')
-    (old_dir / "organization.json").write_text('{"jira_project": "PROJ", "sync_filters": {"sync": {}}}')
-    (old_dir / "team.json").write_text('{"jira_workstream": "Platform"}')
-    (old_dir / "templates.json").write_text('{}')
-    (old_dir / "sessions.json").write_text('{"sessions": {}}')
-    (old_dir / "mocks").mkdir()
-
-    # Create new directory (to trigger migration check)
-    new_dir.mkdir()
-
-    # Perform migration
-    result = _migrate_claude_sessions_to_daf(old_dir, new_dir)
-
-    # Verify migration was performed
-    assert result is True
-
-    # Verify all files were copied
-    assert (new_dir / "sessions").exists()
-    assert (new_dir / "backends").exists()
-    assert (new_dir / "config.json").exists()
-    assert (new_dir / "organization.json").exists()
-    assert (new_dir / "team.json").exists()
-    assert (new_dir / "templates.json").exists()
-    assert (new_dir / "sessions.json").exists()
-    assert (new_dir / "mocks").exists()
-    assert (new_dir / ".migrated").exists()
-
-    # Verify file contents
-    assert (new_dir / "organization.json").read_text() == '{"jira_project": "PROJ", "sync_filters": {"sync": {}}}'
-    assert (new_dir / "team.json").read_text() == '{"jira_workstream": "Platform"}'
-
-    # Verify success message
-    captured = capsys.readouterr()
-    assert "Migrated sessions" in captured.err
-
-
-def test_migrate_claude_sessions_already_migrated(tmp_path):
-    """Test migration skips if .migrated marker exists."""
-    old_dir = tmp_path / ".claude-sessions"
-    new_dir = tmp_path / ".daf-sessions"
-
-    # Create directories
-    old_dir.mkdir()
-    new_dir.mkdir()
-    (new_dir / ".migrated").touch()
-
-    # Perform migration
-    result = _migrate_claude_sessions_to_daf(old_dir, new_dir)
-
-    # Verify migration was skipped
-    assert result is False
-
-
-def test_migrate_claude_sessions_no_old_sessions(tmp_path):
-    """Test migration skips if old sessions directory doesn't exist."""
-    old_dir = tmp_path / ".claude-sessions"
-    new_dir = tmp_path / ".daf-sessions"
-
-    # Create old directory but no sessions
-    old_dir.mkdir()
-    new_dir.mkdir()
-
-    # Perform migration
-    result = _migrate_claude_sessions_to_daf(old_dir, new_dir)
-
-    # Verify migration was skipped
-    assert result is False
-
-
-def test_migrate_claude_sessions_new_sessions_exist(tmp_path):
-    """Test migration skips if new directory already has sessions."""
-    old_dir = tmp_path / ".claude-sessions"
-    new_dir = tmp_path / ".daf-sessions"
-
-    # Create directories with sessions
-    old_dir.mkdir()
-    (old_dir / "sessions").mkdir()
-    new_dir.mkdir()
-    (new_dir / "sessions").mkdir()
-    (new_dir / "sessions" / "existing-session").mkdir()
-
-    # Perform migration
-    result = _migrate_claude_sessions_to_daf(old_dir, new_dir)
-
-    # Verify migration was skipped
-    assert result is False
-
-
-def test_migrate_claude_sessions_partial_files(tmp_path, capsys):
-    """Test migration handles missing optional files gracefully."""
-    old_dir = tmp_path / ".claude-sessions"
-    new_dir = tmp_path / ".daf-sessions"
-
-    # Create old directory with only some files
-    old_dir.mkdir()
-    (old_dir / "sessions").mkdir()
-    (old_dir / "config.json").write_text('{}')
-    # organization.json and team.json are missing (optional)
-
-    # Create new directory
-    new_dir.mkdir()
-
-    # Perform migration
-    result = _migrate_claude_sessions_to_daf(old_dir, new_dir)
-
-    # Verify migration was performed
-    assert result is True
-
-    # Verify required files were copied
-    assert (new_dir / "sessions").exists()
-    assert (new_dir / "config.json").exists()
-    assert (new_dir / ".migrated").exists()
-
-    # Verify optional files are not present (as expected)
-    assert not (new_dir / "organization.json").exists()
-    assert not (new_dir / "team.json").exists()
-
-
-def test_migrate_claude_sessions_json_mode_no_output(tmp_path, capsys, monkeypatch):
-    """Test migration suppresses output in JSON mode."""
-    import sys
-    monkeypatch.setattr(sys, "argv", ["daf", "sync", "--json"])
-
-    old_dir = tmp_path / ".claude-sessions"
-    new_dir = tmp_path / ".daf-sessions"
-
-    # Create old directory structure
-    old_dir.mkdir()
-    (old_dir / "sessions").mkdir()
-    (old_dir / "config.json").write_text('{}')
-
-    # Create new directory
-    new_dir.mkdir()
-
-    # Perform migration
-    result = _migrate_claude_sessions_to_daf(old_dir, new_dir)
-
-    # Verify migration was performed
-    assert result is True
-
-    # Verify no output in JSON mode
-    captured = capsys.readouterr()
-    assert "Migrated sessions" not in captured.err


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-63925>

## Description
This PR removes unnecessary migration code from the paths module that was handling the transition from `.claude-sessions` to `.daf-sessions`. The migration code is no longer needed as all users should have migrated by now.

The changes include:
- Removed the `_migrate_claude_to_daf` function from `devflow/utils/paths.py`
- Removed migration logic that automatically moved files from old `.claude-sessions` directory to new `.daf-sessions` directory
- Updated tests to reflect the removal of migration code

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run the test suite: `pytest tests/test_paths.py`
3. Verify that the paths module correctly uses `.daf-sessions` directory
4. Confirm that no migration-related code is present in the paths module
5. Test normal DAF session operations to ensure they work correctly with `.daf-sessions`

### Scenarios tested
- All unit tests in `tests/test_paths.py` pass successfully
- Path resolution works correctly for `.daf-sessions` directory
- No regression in existing functionality

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: