### PR TITLE
AAP-64349: feat: strengthen command format guidance in ticket creation prompt

### DIFF
--- a/devflow/cli/commands/jira_new_command.py
+++ b/devflow/cli/commands/jira_new_command.py
@@ -955,7 +955,12 @@ def _build_ticket_creation_prompt(
     ])
 
     prompt_parts.extend([
+        "⚠️  CRITICAL: Use EXACTLY this command format (do not modify syntax):",
+        "",
         example_command,
+        "",
+        "⚠️  The command above is the EXACT format you MUST use. Do not attempt alternative formats.",
+        "   Use this template precisely, filling in your analysis and findings.",
         "",
         parent_note,
     ])


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-64349>

## Description
Enhanced the Claude prompt in the `daf jira new` command to provide stronger guidance on using the `daf jira create` command format after collecting ticket requirements. This change improves the AI assistant's behavior by emphasizing that it should output the specific command format rather than attempting to execute the ticket creation directly.

The update modifies the prompt instructions in `devflow/cli/commands/jira_new_command.py` to more clearly communicate the expected command structure and workflow when creating JIRA tickets through the daf CLI.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run `daf jira new` to initiate the ticket creation workflow
3. Observe Claude's interaction during the requirements gathering process
4. Verify that Claude outputs the correct `daf jira create` command format after collecting necessary information
5. Confirm the command format follows the expected pattern with all required parameters

### Scenarios tested
- Verified that the enhanced prompt correctly guides Claude to output the `daf jira create` command format
- Confirmed that the prompt changes do not break existing JIRA integration workflows
- Tested that the strengthened guidance improves consistency in command output

## Deployment considerations
- [x] This code change is ready for deployment on its own