### PR TITLE
fix: correct affects-versions field formatting for JIRA bug creation

### DIFF
--- a/devflow/cli/commands/jira_update_command.py
+++ b/devflow/cli/commands/jira_update_command.py
@@ -35,8 +35,14 @@ def build_field_value(field_info: Dict[str, Any], value: str, field_mapper: Jira
         # For URL fields, return as-is
         return value
     elif schema == "array" or field_type == "array":
+        # Check if this is a version field (affects_version/s, fix_version/s, etc.)
+        field_id = field_info.get("id", "")
+        field_name = field_info.get("name", "")
+        if field_id == "versions" or field_id == "fixVersions" or "version" in field_name.lower():
+            # Version fields expect array of objects with "name" property
+            return [{"name": value}]
         # Multi-select field (like workstream)
-        if "option" in schema or "select" in schema:
+        elif "option" in schema or "select" in schema:
             return [{"value": value}]
         else:
             # Array of strings


### PR DESCRIPTION
## Description

Fixed two critical issues preventing bug creation with the `--affects-versions` flag in `daf jira create bug`:

**Issue 1: Incorrect field mapping**
- Affected version was being added to `required_custom_fields` with key `"affected_version"`
- Field mapper had no mapping for `"affected_version"` (only `"affects_version/s"`)
- Result: Field was never added to JIRA payload

**Fix 1:**
- Pass affected_version as system field `"versions"` instead
- Add to `system_fields_with_version` dict before calling `_get_required_system_fields()`
- Ensures proper field ID mapping in JIRA API

**Issue 2: Incorrect array formatting**
- JIRA version fields expect: `[{"name": "version-string"}]`
- Code was sending: `["version-string"]` (array of strings)
- Result: JIRA validation error "expected Object"

**Fix 2:**
- Enhanced `build_field_value()` in `jira_update_command.py`
- Added version field detection (checks `field_id == "versions"` or `"fixVersions"`)
- Returns properly formatted objects: `[{"name": value}]`

## Testing

### Steps to test
1. Pull down the PR
2. Run: `pip install -e .`
3. Test bug creation:
   ```bash
   daf jira create bug \
     --summary "Test bug" \
     --affects-versions ansible-saas-ga \
     --components ansible-saas \
     --description "Test description"
   ```
4. Verify bug is created successfully with affects-versions field populated

### Scenarios tested
- [x] Bug creation with `--affects-versions` flag (successfully created AAP-64886)
- [x] All existing unit tests pass (39 tests in test_jira_create_commands.py)
- [x] All jira_update_command tests pass (30 tests)

## Deployment considerations
- [x] This code change is ready for deployment on its own
- No database migrations required
- No configuration changes required
- Backward compatible with existing JIRA field mappings

## Related Issues
- Fixes the template issue that was blocking JIRA bug creation
- Resolves AAP-64886 (The -w flag workspace bug) which required this fix to create the ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>