### PR TITLE
Based on the git diff, here's a commit message in conventional commit format:

### DIFF
--- a/devflow/cli/commands/jira_update_command.py
+++ b/devflow/cli/commands/jira_update_command.py
@@ -227,7 +227,7 @@ def update_jira_issue(
             # Filter applies to BOTH discovered fields AND fallback fields
             non_editable_fields = {
                 "attachment", "issuelinks", "linked_issues",
-                "component/s",  # Red Hat JIRA specific
+                "component/s", "components",  # Server & cloud variants (both non-editable during update)
             }
             editable_mappings = {
                 field_name: field_info

--- a/devflow/jira/field_mapper.py
+++ b/devflow/jira/field_mapper.py
@@ -336,7 +336,8 @@ class JiraFieldMapper:
             # This prevents errors like "Field does not support update 'attachment'"
             operations = field_data.get("operations", [])
             if not operations:
-                # Skip non-editable fields (e.g., attachment, issuelinks, component/s)
+                # Skip non-editable fields (e.g., attachment, issuelinks, component/s or components)
+                # Note: component/s (server) was renamed to components (cloud), both are non-editable during update
                 continue
 
             # Get field name from all_fields or use the one from editmeta

--- a/devflow/ui/config_tui.py
+++ b/devflow/ui/config_tui.py
@@ -45,6 +45,7 @@ from rich.text import Text
 from devflow.config.loader import ConfigLoader
 from devflow.config.models import Config, JiraTransitionConfig, ContextFile, WorkspaceDefinition
 from devflow.jira.client import JiraClient
+from devflow.jira.utils import get_field_with_alias
 
 
 console = Console()
@@ -1165,7 +1166,8 @@ class ConfigTUI(App):
             # Get available components from field mappings
             component_choices = []
             if self.config.jira.field_mappings:
-                component_field = self.config.jira.field_mappings.get("component/s") or self.config.jira.field_mappings.get("components")
+                # Check for either component/s (server) or components (cloud)
+                component_field = get_field_with_alias(self.config.jira.field_mappings, "components")
                 if component_field and "allowed_values" in component_field:
                     # Extract component names from allowed_values
                     # allowed_values can be simple strings, dicts, or JSON-serialized strings


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-63460>

## Description
This PR addresses backward compatibility issues with JIRA Cloud API field naming changes. In JIRA Cloud, the fields `component/s` and `affects_version/s` have been renamed to `components` and `affects_versions`. 

The changes implement automatic field name detection and normalization to support both legacy and new field naming conventions. This allows the devflow tool to work seamlessly with both JIRA Cloud (new naming) and JIRA Server/Data Center (legacy naming) instances without requiring users to modify their configurations.

**Technical changes:**
- Updated field mapper to handle both `component/s` → `components` and `affects_version/s` → `affects_versions` naming patterns
- Added automatic field name normalization in JIRA utilities
- Modified create and update commands to use normalized field names
- Updated configuration TUI to support both naming conventions
- Added comprehensive test coverage for field name normalization

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Configure devflow with a JIRA Cloud instance
3. Create a new JIRA issue using `daf jira create` and specify components and affects_versions fields
4. Verify the issue is created successfully with the correct components and versions
5. Update an existing issue using `daf jira update` with components/versions changes
6. Test with a JIRA Server/Data Center instance using the legacy field names (component/s, affects_version/s)
7. Verify both naming conventions work without requiring configuration changes
8. Run the test suite: `pytest tests/test_jira_utils.py -v`

### Scenarios tested
- JIRA field mapping with both cloud (components/affects_versions) and legacy (component/s/affects_version/s) naming
- Creating issues with component and version fields in JIRA Cloud
- Updating issues with normalized field names
- Backward compatibility with existing configurations using legacy field names

## Deployment considerations
- [x] This code change is ready for deployment on its own