### PR TITLE
itdove/devaiflow#135: Enhance branch selection to validate and retry on invalid input instead of falling back to default

### DIFF
--- a/devflow/utils/temp_directory.py
+++ b/devflow/utils/temp_directory.py
@@ -84,34 +84,46 @@ def _prompt_for_branch_selection(repo_path: Path) -> Optional[str]:
         else:
             console_print(f"  {idx}. {branch}")
 
-    # Prompt user for selection
+    # Prompt user for selection with validation loop
     try:
-        choice = Prompt.ask(
-            "\nEnter selection",
-            default="1" if default_branch else None,
-            show_default=True
-        )
+        while True:
+            choice = Prompt.ask(
+                "\nEnter selection",
+                default="1" if default_branch else None,
+                show_default=True
+            )
 
-        # Parse selection (can be number or branch name)
-        try:
-            # Try to parse as number
-            selection_num = int(choice)
-            if 1 <= selection_num <= len(branches):
-                selected_branch = branches[selection_num - 1]
-            else:
-                console_print(f"[yellow]⚠[/yellow] Invalid selection: {choice}")
+            # Allow cancel
+            if choice.lower() in ['cancel', 'q']:
                 console_print(f"[dim]Using default branch: {default_branch}[/dim]")
-                selected_branch = default_branch
-        except ValueError:
-            # Not a number, treat as branch name
-            if choice in branches:
-                selected_branch = choice
-            else:
-                console_print(f"[yellow]⚠[/yellow] Branch '{choice}' not found")
-                console_print(f"[dim]Using default branch: {default_branch}[/dim]")
-                selected_branch = default_branch
+                return default_branch
 
-        return selected_branch
+            # Parse selection (can be number or branch name)
+            selected_branch = None
+
+            # Try to parse as number first
+            try:
+                selection_num = int(choice)
+                if 1 <= selection_num <= len(branches):
+                    selected_branch = branches[selection_num - 1]
+                else:
+                    console_print(f"[red]✗[/red] Invalid selection: {choice}")
+                    console_print("[dim]Please try again or type 'cancel' to use default[/dim]")
+                    continue
+            except ValueError:
+                # Not a number, treat as branch name
+                if choice in branches:
+                    selected_branch = choice
+                else:
+                    console_print(f"[red]✗[/red] Branch '{choice}' not found in available branches")
+                    console_print("[dim]Please try again or type 'cancel' to use default[/dim]")
+                    continue
+
+            # Valid selection made
+            if selected_branch:
+                console_print(f"[green]✓[/green] Selected branch: {selected_branch}")
+                return selected_branch
+
     except (KeyboardInterrupt, EOFError):
         console_print("\n[dim]Branch selection cancelled, using default[/dim]")
         return default_branch

--- a/tests/test_temp_directory_utils.py
+++ b/tests/test_temp_directory_utils.py
@@ -448,15 +448,59 @@ class TestPromptForBranchSelection:
             # User entered branch name directly
             assert result == "release/2.5"
 
-    def test_invalid_selection_falls_back_to_default(self, mock_git_repo):
-        """Test that invalid selection falls back to default branch."""
+    def test_invalid_number_retries_then_succeeds(self, mock_git_repo):
+        """Test that invalid number selection prompts again, then succeeds with valid input."""
         with patch("devflow.utils.temp_directory.is_mock_mode", return_value=False), \
              patch("devflow.utils.temp_directory.is_json_mode", return_value=False), \
              patch("devflow.utils.temp_directory.GitUtils.get_remote_names", return_value=["origin"]), \
              patch("devflow.utils.temp_directory.GitUtils.list_remote_branches", return_value=["develop", "main", "release/2.5"]), \
-             patch("devflow.utils.temp_directory.Prompt.ask", return_value="99"):
+             patch("devflow.utils.temp_directory.Prompt.ask", side_effect=["99", "2"]):
             result = _prompt_for_branch_selection(mock_git_repo)
-            # Invalid selection should fall back to default (main)
+            # First input "99" is invalid, second input "2" selects "main"
+            assert result == "main"
+
+    def test_invalid_name_retries_then_succeeds(self, mock_git_repo):
+        """Test that invalid branch name prompts again, then succeeds with valid input."""
+        with patch("devflow.utils.temp_directory.is_mock_mode", return_value=False), \
+             patch("devflow.utils.temp_directory.is_json_mode", return_value=False), \
+             patch("devflow.utils.temp_directory.GitUtils.get_remote_names", return_value=["origin"]), \
+             patch("devflow.utils.temp_directory.GitUtils.list_remote_branches", return_value=["develop", "main", "release/2.5"]), \
+             patch("devflow.utils.temp_directory.Prompt.ask", side_effect=["nonexistent-branch", "main"]):
+            result = _prompt_for_branch_selection(mock_git_repo)
+            # First input "nonexistent-branch" is invalid, second input "main" succeeds
+            assert result == "main"
+
+    def test_cancel_returns_default(self, mock_git_repo):
+        """Test that typing 'cancel' returns default branch."""
+        with patch("devflow.utils.temp_directory.is_mock_mode", return_value=False), \
+             patch("devflow.utils.temp_directory.is_json_mode", return_value=False), \
+             patch("devflow.utils.temp_directory.GitUtils.get_remote_names", return_value=["origin"]), \
+             patch("devflow.utils.temp_directory.GitUtils.list_remote_branches", return_value=["develop", "main", "release/2.5"]), \
+             patch("devflow.utils.temp_directory.Prompt.ask", return_value="cancel"):
+            result = _prompt_for_branch_selection(mock_git_repo)
+            # Should return default branch (main)
+            assert result == "main"
+
+    def test_q_returns_default(self, mock_git_repo):
+        """Test that typing 'q' returns default branch."""
+        with patch("devflow.utils.temp_directory.is_mock_mode", return_value=False), \
+             patch("devflow.utils.temp_directory.is_json_mode", return_value=False), \
+             patch("devflow.utils.temp_directory.GitUtils.get_remote_names", return_value=["origin"]), \
+             patch("devflow.utils.temp_directory.GitUtils.list_remote_branches", return_value=["develop", "main", "release/2.5"]), \
+             patch("devflow.utils.temp_directory.Prompt.ask", return_value="q"):
+            result = _prompt_for_branch_selection(mock_git_repo)
+            # Should return default branch (main)
+            assert result == "main"
+
+    def test_multiple_retries_then_cancel(self, mock_git_repo):
+        """Test that multiple invalid attempts followed by cancel returns default."""
+        with patch("devflow.utils.temp_directory.is_mock_mode", return_value=False), \
+             patch("devflow.utils.temp_directory.is_json_mode", return_value=False), \
+             patch("devflow.utils.temp_directory.GitUtils.get_remote_names", return_value=["origin"]), \
+             patch("devflow.utils.temp_directory.GitUtils.list_remote_branches", return_value=["develop", "main", "release/2.5"]), \
+             patch("devflow.utils.temp_directory.Prompt.ask", side_effect=["invalid1", "99", "cancel"]):
+            result = _prompt_for_branch_selection(mock_git_repo)
+            # After two invalid attempts, cancel should return default (main)
             assert result == "main"
 
     def test_keyboard_interrupt_returns_default(self, mock_git_repo):


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://github.com/itdove/devaiflow/issues/135>
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR enhances the branch selection functionality to implement input validation with retry logic instead of silently falling back to default values when invalid input is provided. This improves user experience by allowing users to correct mistakes rather than unexpectedly using default branches.

The changes include:
- Refactored branch selection logic in `devflow/utils/temp_directory.py` to add input validation loop with retry capability
- Added comprehensive test coverage for the new validation logic in `tests/test_temp_directory_utils.py`
- Added demo files (`demos/demo-commands.txt` and `demos/demo-github-workflow.sh`) to illustrate the enhanced workflow

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run the test suite to verify the new validation logic: `pytest tests/test_temp_directory_utils.py`
3. Execute the demo workflow script: `./demos/demo-github-workflow.sh`
4. Test branch selection manually by providing invalid branch names and verify the retry prompt appears
5. Verify that valid branch names are accepted and the workflow proceeds correctly

### Scenarios tested
- Branch selection with invalid input triggers retry prompt
- Branch selection with valid input proceeds without retry
- Multiple retry attempts until valid input is provided
- Demo workflow executes successfully with new validation logic

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: