### PR TITLE
AAP-61078: Migrate update checker from GitLab releases to PyPI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -957,7 +957,10 @@ daf --help
 ### Installation
 
 ```bash
-# Install from local directory
+# Install from PyPI (recommended for users)
+pip install devaiflow
+
+# Install from local directory (for contributors)
 pip install .
 
 # Install in editable mode (for development)
@@ -967,7 +970,7 @@ pip install -e .
 pip uninstall devaiflow
 
 # Upgrade to latest version
-pip install --upgrade .
+pip install --upgrade devaiflow
 ```
 
 ## Implementation Phases
@@ -1681,7 +1684,7 @@ When a new version is available, you'll see:
 ```
 ╭─ Update Available ──────────────────────────────────────────╮
 │  A new version of daf is available: 1.1.0 (current: 1.0.0)  │
-│  Run pip install --upgrade --force-reinstall .               │
+│  Run pip install --upgrade devaiflow                        │
 ╰─────────────────────────────────────────────────────────────╯
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Each session is an **isolated workspace** with its own:
 
 ```bash
 # Install
-pip install .
+pip install devaiflow
 
 # Authenticate GitHub CLI
 gh auth login

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -400,7 +400,7 @@ Use this checklist for each release:
 - [ ] Bump version to next dev cycle (`X.Y+1.0-dev`)
 - [ ] Update AGENTS.md "Completed Enhancements" section
 - [ ] Announce release (if applicable)
-- [ ] (Future) Publish to PyPI
+- [ ] Publish to PyPI (see [docs/publishing-to-pypi.md](docs/publishing-to-pypi.md))
 
 ### Hotfix (if needed)
 - [ ] Create hotfix branch from release tag

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -92,7 +92,7 @@ Before sharing session exports with teammates:
 
 ### 4. Keep Software Updated
 
-- Regularly update DevAIFlow: `pip install --upgrade --force-reinstall .`
+- Regularly update DevAIFlow: `pip install --upgrade devaiflow`
 - Subscribe to GitHub releases for security notifications
 - Review CHANGELOG.md for security-related updates
 

--- a/devflow/utils/update_checker.py
+++ b/devflow/utils/update_checker.py
@@ -276,7 +276,7 @@ def show_update_notification(latest_version: str) -> None:
     console.print()
     console.print(f"[yellow]╭─ Update Available ──────────────────────────────────────────╮[/yellow]")
     console.print(f"[yellow]│[/yellow]  A new version of daf is available: [green]{latest_version}[/green] (current: {__version__})  [yellow]│[/yellow]")
-    console.print(f"[yellow]│[/yellow]  Run [cyan]pip install --upgrade --force-reinstall .[/cyan]               [yellow]│[/yellow]")
+    console.print(f"[yellow]│[/yellow]  Run [cyan]pip install --upgrade devaiflow[/cyan]                        [yellow]│[/yellow]")
     console.print(f"[yellow]╰─────────────────────────────────────────────────────────────╯[/yellow]")
     console.print()
 

--- a/docs/02-installation.md
+++ b/docs/02-installation.md
@@ -662,6 +662,14 @@ ls $DEVAIFLOW_HOME/config.json
 
 ## Upgrading
 
+### Upgrading from PyPI (recommended)
+
+```bash
+pip install --upgrade devaiflow
+```
+
+### Upgrading from source
+
 ```bash
 cd ~/development/workspace/devaiflow
 git pull  # Get latest code
@@ -760,7 +768,7 @@ Install DAF_AGENTS.md to repository? [y/n] (y):
 
 **Auto-Upgrade Detection**
 
-When you upgrade the daf package (via `pip install --upgrade --force-reinstall .`), the bundled DAF_AGENTS.md may contain improvements:
+When you upgrade the daf package (via `pip install --upgrade devaiflow`), the bundled DAF_AGENTS.md may contain improvements:
 - New command documentation
 - Updated JIRA Wiki markup guidance
 - Improved workflow instructions

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -539,7 +539,7 @@ def test_show_update_notification(capsys):
     captured = capsys.readouterr()
     assert "Update Available" in captured.out
     assert "2.0.0" in captured.out
-    assert "pip install --upgrade --force-reinstall" in captured.out
+    assert "pip install --upgrade devaiflow" in captured.out
 
 
 def test_show_network_warning(capsys):


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-61078>

## Description
This PR migrates the update checker from GitLab releases to PyPI, allowing users to check for new versions via the Python Package Index instead of GitLab API. This change simplifies the update checking process and aligns with standard Python package distribution practices.

Additionally, this PR includes several improvements:
- Enhanced JIRA error messaging to provide clearer feedback when authentication tokens expire
- Fixed IntPrompt default parameter type in CLI to prevent type-related issues
- Improved branch tracking to prevent unnecessary sync prompts after branch creation

Documentation has been updated across multiple files (README.md, AGENTS.md, RELEASING.md, SECURITY.md, installation docs) to reflect the PyPI-based installation and update checking.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Install the package and verify the update checker uses PyPI instead of GitLab:
   - Run the CLI and observe any update notifications
   - Check that `devflow/utils/update_checker.py` correctly queries PyPI API
3. Test JIRA token expiration handling:
   - Configure JIRA integration with an expired token
   - Verify clear error messaging is displayed
4. Test CLI IntPrompt with default values to ensure no type errors occur
5. Create a new branch and verify no unnecessary sync prompts appear after creation
6. Run the test suite: `pytest tests/test_update_checker.py tests/test_jira_token_expiration.py tests/test_branch_*.py tests/test_open_command.py`

### Scenarios tested
- Update checker successfully queries PyPI for latest version information
- JIRA client provides clear error messages when tokens are expired
- CLI prompts handle default integer values correctly without type errors
- Branch creation tracks source branch properly and doesn't trigger sync prompts immediately after creation
- All existing functionality remains intact with comprehensive test coverage

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: