### PR TITLE
itdove/devaiflow#148: Add recap summary at end of daf sync showing all synced tickets

### DIFF
--- a/devflow/cli/commands/sync_command.py
+++ b/devflow/cli/commands/sync_command.py
@@ -24,7 +24,7 @@ def render_sync_recap_table(synced_tickets: List[Dict[str, str]]) -> None:
 
     Args:
         synced_tickets: List of dictionaries with keys:
-            - issue_key: Issue identifier (e.g., "PROJ-12345", "owner/repo#123")
+            - session_name: Session name (what users use with 'daf open')
             - title: Issue title/summary (will be truncated if too long)
             - action: "CREATED" or "UPDATED"
             - backend: "JIRA", "GitHub", or "GitLab"
@@ -34,14 +34,14 @@ def render_sync_recap_table(synced_tickets: List[Dict[str, str]]) -> None:
 
     # Create Rich Table
     table = Table(show_header=True, header_style="bold cyan")
-    table.add_column("Issue Key", style="cyan", no_wrap=True)
+    table.add_column("Session Name", style="cyan", no_wrap=True)
     table.add_column("Title", style="white", no_wrap=True)
     table.add_column("Action", style="green", no_wrap=True)
     table.add_column("Backend", style="blue", no_wrap=True)
 
     # Add rows
     for ticket in synced_tickets:
-        issue_key = ticket["issue_key"]
+        session_name = ticket["session_name"]
         title = ticket["title"]
         action = ticket["action"]
         backend = ticket["backend"]
@@ -57,7 +57,7 @@ def render_sync_recap_table(synced_tickets: List[Dict[str, str]]) -> None:
         else:  # UPDATED
             action_display = f"[cyan]{action}[/cyan]"
 
-        table.add_row(issue_key, title, action_display, backend)
+        table.add_row(session_name, title, action_display, backend)
 
     # Render the table
     console.print()
@@ -300,7 +300,7 @@ def sync_jira(
 
             # Track for recap table
             synced_tickets.append({
-                "issue_key": issue_key,
+                "session_name": issue_key,  # For JIRA, session name == issue key
                 "title": issue_summary or issue_key,
                 "action": "CREATED",
                 "backend": "JIRA"
@@ -343,7 +343,7 @@ def sync_jira(
                     # Track for recap table
                     issue_summary = ticket.get("summary", issue_key)
                     synced_tickets.append({
-                        "issue_key": issue_key,
+                        "session_name": issue_key,  # For JIRA, session name == issue key
                         "title": issue_summary,
                         "action": "UPDATED",
                         "backend": "JIRA"
@@ -576,7 +576,7 @@ def sync_github_repository(
                 # Track for recap table
                 if synced_tickets is not None:
                     synced_tickets.append({
-                        "issue_key": issue_key,
+                        "session_name": session_name,  # Use converted session name, not issue key
                         "title": issue_summary or issue_key,
                         "action": "CREATED",
                         "backend": "GitHub"
@@ -609,7 +609,7 @@ def sync_github_repository(
                         if synced_tickets is not None:
                             issue_summary = ticket.get('summary', issue_key)
                             synced_tickets.append({
-                                "issue_key": issue_key,
+                                "session_name": session.name,  # Use actual session name from session object
                                 "title": issue_summary,
                                 "action": "UPDATED",
                                 "backend": "GitHub"
@@ -739,7 +739,7 @@ def sync_multi_backend(
 
                         # Track for recap table
                         synced_tickets.append({
-                            "issue_key": issue_key,
+                            "session_name": issue_key,  # For JIRA, session name == issue key
                             "title": issue_summary,
                             "action": "CREATED",
                             "backend": "JIRA"
@@ -763,7 +763,7 @@ def sync_multi_backend(
                                 # Track for recap table
                                 issue_summary = ticket.get("summary", issue_key)
                                 synced_tickets.append({
-                                    "issue_key": issue_key,
+                                    "session_name": issue_key,  # For JIRA, session name == issue key
                                     "title": issue_summary,
                                     "action": "UPDATED",
                                     "backend": "JIRA"


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
This PR does not need a corresponding Jira item.

GitHub Issue: <https://github.com/itdove/devaiflow/issues/148>

## Description
This PR adds a recap summary table at the end of the `daf sync` command that displays all synced tickets in a formatted table. The recap provides users with a clear overview of what tickets were synchronized during the command execution.

The implementation includes:
- New recap table functionality in the sync command that displays session name, title, and status for each synced ticket
- Refactored terminology from `issue_key` to `session_name` for improved clarity and consistency
- Proper formatting using the rich library's Table component for better readability

This enhancement improves the user experience by providing immediate feedback about sync operations without requiring users to run additional commands to verify what was synced.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Ensure you have a DevAIFlow environment configured with multiple active sessions
3. Run `daf sync` command
4. Verify that a recap table appears at the end of the sync output
5. Confirm the recap table displays columns for session name, title, and status
6. Verify that all synced tickets are listed in the recap table
7. Test with different scenarios: single ticket sync, multiple ticket sync, and no tickets to sync

### Scenarios tested
- Syncing multiple active sessions and verifying all sessions appear in the recap table
- Verifying the table formatting displays correctly with varying title lengths
- Confirming session_name is displayed instead of the previous issue_key terminology
- Testing with merge scenarios from main branch to ensure compatibility

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: