### PR TITLE
itdove/devaiflow#146: Auto-suggest project/repository when opening sessions created by daf sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Auto-suggest repository when opening GitHub/GitLab synced sessions (#146)
+  - Automatically extracts repository name from GitHub/GitLab issue keys (e.g., `owner/repo#123`)
+  - Highlights matching repository in working directory selection prompt with "(from issue)" label
+  - Defaults to suggested repository if found in workspace
+  - Improves UX by reducing manual repository selection for synced issues
+  - Only affects GitHub/GitLab sessions; JIRA sessions behave as before
 - Branch selection prompt when cloning to temporary directory (#128)
   - Interactive prompt to select which branch to checkout after cloning for analysis
   - Lists all available remote branches from `upstream` (preferred) or `origin`

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -38,6 +38,51 @@ from devflow.utils.daf_agents_validation import (
 console = Console()
 
 
+def _extract_repository_from_issue_key(issue_key: str, issue_tracker: Optional[str]) -> Optional[str]:
+    """Extract repository name from GitHub/GitLab issue key.
+
+    Args:
+        issue_key: Issue key (e.g., "owner/repo#123", "#123", "PROJ-123")
+        issue_tracker: Issue tracker type ("github", "gitlab", "jira", etc.)
+
+    Returns:
+        Repository name (e.g., "repo") if extractable, None otherwise
+
+    Examples:
+        >>> _extract_repository_from_issue_key("itdove/devaiflow#146", "github")
+        'devaiflow'
+        >>> _extract_repository_from_issue_key("#123", "github")
+        None
+        >>> _extract_repository_from_issue_key("PROJ-123", "jira")
+        None
+    """
+    # Only process GitHub/GitLab issues
+    if not issue_tracker or issue_tracker not in ["github", "gitlab"]:
+        return None
+
+    if not issue_key:
+        return None
+
+    # Check if issue key contains owner/repo format
+    # Format: owner/repo#123
+    if "/" in issue_key and "#" in issue_key:
+        # Extract the part between / and #
+        try:
+            # Split on / to get [owner, repo#123]
+            parts = issue_key.split("/")
+            if len(parts) >= 2:
+                # Get the last part which should be "repo#123"
+                repo_with_number = parts[-1]
+                # Split on # to get [repo, 123]
+                repo = repo_with_number.split("#")[0]
+                return repo if repo else None
+        except (IndexError, ValueError):
+            return None
+
+    # Issue key doesn't contain repository info (e.g., "#123")
+    return None
+
+
 def _set_terminal_title(session) -> None:
     """Set terminal window/tab title using ANSI escape sequences.
 
@@ -1872,13 +1917,21 @@ def _prompt_for_working_directory(session, config_loader, session_manager, selec
 
     console.print(f"\n[bold]Select working directory for session:[/bold] {session.name}")
     if session.issue_key:
-        console.print(f"[dim]JIRA: {session.issue_key}[/dim]")
+        console.print(f"[dim]Issue: {session.issue_key}[/dim]")
     if session.goal:
         console.print(f"[dim]Goal: {session.goal}[/dim]")
+
+    # Try to extract repository suggestion from issue key (GitHub/GitLab)
+    suggested_repo = None
+    if session.issue_key and session.issue_tracker:
+        suggested_repo = _extract_repository_from_issue_key(session.issue_key, session.issue_tracker)
+        if suggested_repo:
+            console.print(f"[cyan]ℹ Issue repository:[/cyan] {suggested_repo} (from {session.issue_key})")
 
     # Try to detect available repositories from config
     config = config_loader.load_config()
     repo_options = []
+    suggested_repo_index = None
 
     if config and config.repos:
         # Use selected workspace if provided, otherwise fall back to default
@@ -1899,16 +1952,28 @@ def _prompt_for_working_directory(session, config_loader, session_manager, selec
                     directories = [d for d in workspace.iterdir() if d.is_dir() and not d.name.startswith('.')]
                     # Filter to only include git repositories
                     git_repos = [d.name for d in directories if GitUtils.is_git_repository(d)]
-                    repo_options = sorted(git_repos)
+
+                    # Sort repositories, but put suggested repo first if it exists
+                    if suggested_repo and suggested_repo in git_repos:
+                        # Move suggested repo to front
+                        git_repos.remove(suggested_repo)
+                        repo_options = [suggested_repo] + sorted(git_repos)
+                        suggested_repo_index = 0  # First item
+                    else:
+                        repo_options = sorted(git_repos)
 
                     if repo_options:
                         console.print(f"\n[bold]Available repositories ({len(repo_options)}):[/bold]")
-                        for i, repo in enumerate(repo_options, 1):  # Show all repositories
-                            console.print(f"  {i}. {repo}")
+                        for i, repo in enumerate(repo_options, 1):
+                            # Highlight suggested repository
+                            if suggested_repo and repo == suggested_repo:
+                                console.print(f"  {i}. {repo} [dim](from issue)[/dim]")
+                            else:
+                                console.print(f"  {i}. {repo}")
                 except Exception as e:
                     console.print(f"[yellow]Warning: Could not scan workspace: {e}[/yellow]")
 
-    # Prompt for working directory
+    # Prompt for working directory with default suggestion
     console.print(f"\n[bold]Select working directory:[/bold]")
     if repo_options:
         console.print(f"  • Enter a number (1-{len(repo_options)}) to select from the list above")
@@ -1920,7 +1985,13 @@ def _prompt_for_working_directory(session, config_loader, session_manager, selec
         console.print(f"  • Enter an absolute path (starting with / or ~)")
         console.print(f"  • Enter 'cancel' or 'q' to exit")
 
-    selection = Prompt.ask("Selection")
+    # Set default to suggested repository if found
+    default_value = None
+    if suggested_repo_index is not None:
+        default_value = str(suggested_repo_index + 1)  # 1-indexed for display
+        selection = Prompt.ask("Selection", default=default_value)
+    else:
+        selection = Prompt.ask("Selection")
 
     # Validate input is not empty
     if not selection or selection.strip() == "":

--- a/tests/test_github_repo_suggestion.py
+++ b/tests/test_github_repo_suggestion.py
@@ -1,0 +1,232 @@
+"""Tests for GitHub/GitLab repository auto-suggestion in daf open command."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from devflow.cli.commands.open_command import _extract_repository_from_issue_key, _prompt_for_working_directory
+from devflow.config.loader import ConfigLoader
+from devflow.session.manager import SessionManager
+
+
+class TestExtractRepositoryFromIssueKey:
+    """Tests for extracting repository name from GitHub/GitLab issue keys."""
+
+    def test_extract_from_github_issue_with_owner_repo(self):
+        """Test extracting repository from full GitHub issue key."""
+        result = _extract_repository_from_issue_key("itdove/devaiflow#146", "github")
+        assert result == "devaiflow"
+
+    def test_extract_from_gitlab_issue_with_owner_repo(self):
+        """Test extracting repository from full GitLab issue key."""
+        result = _extract_repository_from_issue_key("myorg/myproject#42", "gitlab")
+        assert result == "myproject"
+
+    def test_extract_with_nested_groups(self):
+        """Test extracting repository from GitLab issue with nested groups."""
+        result = _extract_repository_from_issue_key("org/subgroup/project#99", "gitlab")
+        assert result == "project"
+
+    def test_extract_from_issue_without_owner(self):
+        """Test that extraction returns None for issue key without owner/repo."""
+        result = _extract_repository_from_issue_key("#123", "github")
+        assert result is None
+
+    def test_extract_from_jira_key(self):
+        """Test that extraction returns None for JIRA keys."""
+        result = _extract_repository_from_issue_key("PROJ-12345", "jira")
+        assert result is None
+
+    def test_extract_with_none_issue_tracker(self):
+        """Test that extraction returns None when issue_tracker is None."""
+        result = _extract_repository_from_issue_key("owner/repo#123", None)
+        assert result is None
+
+    def test_extract_with_empty_issue_key(self):
+        """Test that extraction returns None for empty issue key."""
+        result = _extract_repository_from_issue_key("", "github")
+        assert result is None
+
+    def test_extract_with_none_issue_key(self):
+        """Test that extraction returns None for None issue key."""
+        result = _extract_repository_from_issue_key(None, "github")
+        assert result is None
+
+    def test_extract_with_unsupported_tracker(self):
+        """Test that extraction returns None for unsupported issue trackers."""
+        result = _extract_repository_from_issue_key("owner/repo#123", "bitbucket")
+        assert result is None
+
+    def test_extract_with_special_characters_in_repo_name(self):
+        """Test extracting repository with special characters."""
+        result = _extract_repository_from_issue_key("org/my-project.app#1", "github")
+        assert result == "my-project.app"
+
+    def test_extract_with_malformed_issue_key(self):
+        """Test that extraction handles malformed issue keys gracefully."""
+        # Missing issue number
+        result = _extract_repository_from_issue_key("owner/repo#", "github")
+        assert result == "repo"
+
+        # Multiple # symbols (take first)
+        result = _extract_repository_from_issue_key("owner/repo#123#456", "github")
+        assert result == "repo"
+
+    def test_extract_case_sensitivity(self):
+        """Test that repository name case is preserved."""
+        result = _extract_repository_from_issue_key("owner/DevAIFlow#1", "github")
+        assert result == "DevAIFlow"
+
+    def test_extract_with_numeric_repo_name(self):
+        """Test extracting repository with numeric name."""
+        result = _extract_repository_from_issue_key("org/project-123#5", "github")
+        assert result == "project-123"
+
+
+class TestGitHubRepoSuggestionIntegration:
+    """Integration tests for GitHub/GitLab repository auto-suggestion."""
+
+    @pytest.fixture
+    def workspace_with_devaiflow(self, tmp_path):
+        """Create a workspace with devaiflow repository."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        # Create devaiflow repo
+        devaiflow_repo = workspace / "devaiflow"
+        devaiflow_repo.mkdir()
+        subprocess.run(["git", "init"], cwd=devaiflow_repo, capture_output=True, check=True)
+
+        # Create other repos
+        for repo_name in ["backend-api", "frontend-app"]:
+            repo_path = workspace / repo_name
+            repo_path.mkdir()
+            subprocess.run(["git", "init"], cwd=repo_path, capture_output=True, check=True)
+
+        return workspace
+
+    @pytest.fixture
+    def config_loader_with_workspace(self, workspace_with_devaiflow, temp_daf_home):
+        """Create config loader with workspace."""
+        from devflow.config.models import WorkspaceDefinition
+
+        config_loader = ConfigLoader()
+        config_loader.create_default_config()
+
+        config = config_loader.load_config()
+        config.repos.workspaces = [
+            WorkspaceDefinition(name="default", path=str(workspace_with_devaiflow))
+        ]
+        config.repos.last_used_workspace = "default"
+        config_loader.save_config(config)
+
+        return config_loader
+
+    @pytest.fixture
+    def github_session(self, temp_daf_home, config_loader_with_workspace):
+        """Create a GitHub session from daf sync."""
+        session_manager = SessionManager(config_loader_with_workspace)
+
+        # Create a session that was created by daf sync
+        session = session_manager.create_session(
+            name="itdove-devaiflow-146",
+            goal="Auto-suggest project/repository when opening sessions",
+            issue_key="itdove/devaiflow#146",
+            # No project_path - simulates session created by daf sync
+        )
+
+        # Set issue_tracker manually (this would be done by daf sync)
+        session.issue_tracker = "github"
+        session_manager.update_session(session)
+
+        return session
+
+    def test_github_session_suggests_devaiflow_repo(
+        self, workspace_with_devaiflow, config_loader_with_workspace, github_session, monkeypatch, capsys
+    ):
+        """Test that opening a GitHub session suggests the matching repository."""
+        from rich.prompt import Prompt
+        from rich.console import Console
+
+        # Mock Prompt.ask to simulate selecting the default (devaiflow)
+        monkeypatch.setattr(Prompt, "ask", lambda prompt, default=None: default or "1")
+
+        # Create session manager
+        session_manager = SessionManager(config_loader_with_workspace)
+
+        # Call the function
+        result = _prompt_for_working_directory(
+            session=github_session,
+            config_loader=config_loader_with_workspace,
+            session_manager=session_manager,
+        )
+
+        # Verify: Returns True (successfully set working directory)
+        assert result is True
+
+        # Verify: Session was updated with devaiflow path
+        updated_session = session_manager.get_session(github_session.name)
+        assert updated_session.active_conversation is not None
+        assert "devaiflow" in updated_session.active_conversation.project_path
+
+    def test_jira_session_no_suggestion(self, workspace_with_devaiflow, config_loader_with_workspace, temp_daf_home, monkeypatch):
+        """Test that JIRA sessions do not show repository suggestions."""
+        from rich.prompt import Prompt
+
+        # Create a JIRA session
+        session_manager = SessionManager(config_loader_with_workspace)
+        jira_session = session_manager.create_session(
+            name="proj-12345",
+            goal="JIRA task",
+            issue_key="PROJ-12345",
+            # No project_path
+        )
+
+        # Set issue_tracker manually
+        jira_session.issue_tracker = "jira"
+        session_manager.update_session(jira_session)
+
+        # Mock Prompt.ask to simulate selecting first repository
+        monkeypatch.setattr(Prompt, "ask", lambda prompt, default=None: "1")
+
+        # Call the function
+        result = _prompt_for_working_directory(
+            session=jira_session,
+            config_loader=config_loader_with_workspace,
+            session_manager=session_manager,
+        )
+
+        # Verify: Returns True but no suggestion was shown
+        assert result is True
+
+    def test_github_session_repo_not_in_workspace(
+        self, tmp_path, config_loader_with_workspace, temp_daf_home, monkeypatch
+    ):
+        """Test handling when suggested repository doesn't exist in workspace."""
+        from rich.prompt import Prompt
+
+        # Create session with issue for a repo that doesn't exist in workspace
+        session_manager = SessionManager(config_loader_with_workspace)
+        session = session_manager.create_session(
+            name="org-nonexistent-1",
+            goal="Test",
+            issue_key="org/nonexistent#1",
+        )
+
+        # Set issue_tracker manually
+        session.issue_tracker = "github"
+        session_manager.update_session(session)
+
+        # Mock Prompt.ask to simulate selecting first repository
+        monkeypatch.setattr(Prompt, "ask", lambda prompt, default=None: "1")
+
+        # Call the function
+        result = _prompt_for_working_directory(
+            session=session,
+            config_loader=config_loader_with_workspace,
+            session_manager=session_manager,
+        )
+
+        # Verify: Returns True (still works, just no suggestion)
+        assert result is True


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://github.com/itdove/devaiflow/issues/146>
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR adds automatic repository suggestion functionality when opening sessions that were created via `daf sync` from GitHub or GitLab issues. 

When a user opens a session that was synced from a GitHub or GitLab issue, the system now automatically extracts the repository information from the issue key and suggests the appropriate project/repository. This eliminates the need for users to manually specify the repository when opening synced sessions.

**Changes:**
- Enhanced `open_command.py` to parse GitHub/GitLab issue keys and auto-suggest repositories
- Added logic to extract organization/project and repository name from issue references
- Implemented test coverage for GitHub repository suggestion functionality
- Updated CHANGELOG.md to document the new feature

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Create a session using `daf sync` with a GitHub issue (e.g., `daf sync itdove/devaiflow#146`)
3. Open the session using `daf open`
4. Verify that the repository is automatically suggested based on the issue key
5. Repeat with a GitLab issue to verify cross-platform support
6. Run the test suite: `pytest tests/test_github_repo_suggestion.py`

### Scenarios tested
- Repository auto-suggestion from GitHub issue keys with organization/repo format
- Test coverage validates the parsing and suggestion logic
- Manual verification of the open command with synced sessions

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: