### PR TITLE
feat(note): enable daf note command inside Claude Code sessions

### DIFF
--- a/devflow/cli/commands/note_command.py
+++ b/devflow/cli/commands/note_command.py
@@ -7,14 +7,13 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.prompt import Prompt
 
-from devflow.cli.utils import get_session_with_prompt, add_jira_comment, require_outside_claude
+from devflow.cli.utils import get_session_with_prompt, add_jira_comment
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
 
 console = Console()
 
 
-@require_outside_claude
 def add_note(identifier: Optional[str] = None, note: Optional[str] = None, sync_to_jira: bool = False, latest: bool = False) -> None:
     """Add a note to a session.
 

--- a/tests/test_note_command.py
+++ b/tests/test_note_command.py
@@ -396,3 +396,29 @@ def test_view_notes_displays_chronological_order(temp_daf_home):
     third_pos = content.index("Third note")
 
     assert first_pos < second_pos < third_pos
+
+
+def test_add_note_works_inside_claude_session(temp_daf_home, monkeypatch):
+    """Test that add_note works when AI_AGENT_SESSION_ID is set (inside Claude Code)."""
+    # Set AI_AGENT_SESSION_ID to simulate being inside a Claude Code session
+    monkeypatch.setenv("AI_AGENT_SESSION_ID", "test-claude-session-id")
+
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session = session_manager.create_session(
+        name="claude-session",
+        goal="Test inside Claude",
+        working_directory="test-dir",
+        project_path="/path/to/project",
+        ai_agent_session_id="test-claude-session-id",
+    )
+
+    # This should NOT raise SystemExit - it should work inside Claude Code
+    add_note(identifier="claude-session", note="Note from inside Claude Code")
+
+    # Verify note was added
+    notes_file = config_loader.get_session_dir("claude-session") / "notes.md"
+    assert notes_file.exists()
+    content = notes_file.read_text()
+    assert "Note from inside Claude Code" in content


### PR DESCRIPTION
## Summary

Removes the `@require_outside_claude` decorator from `add_note()` to allow adding notes from within Claude Code sessions.

## Problem

Issue #162 reported that the `daf note` command was blocked when running inside Claude Code sessions due to the `@require_outside_claude` decorator.

## Solution

- Removed the `@require_outside_claude` decorator from `add_note()` function
- The note command is safe to run inside AI sessions as it only appends to a markdown file
- Added test to verify `add_note` works when `AI_AGENT_SESSION_ID` is set

## Changes

- `devflow/cli/commands/note_command.py`: Removed decorator, updated import
- `tests/test_note_command.py`: Added test for Claude Code session compatibility

## Testing

All 17 tests in `test_note_command.py` pass, including the new test that verifies the command works inside Claude Code sessions.

============================= test session starts ==============================
platform darwin -- Python 3.14.2, pytest-9.0.2, pluggy-1.6.0 -- /opt/homebrew/opt/python@3.14/bin/python3.14
cachedir: .pytest_cache
rootdir: /private/tmp/devaiflow
configfile: pytest.ini
plugins: anyio-4.12.1, cov-7.0.0
collecting ... collected 17 items

tests/test_note_command.py::test_add_note_with_identifier PASSED         [  5%]
tests/test_note_command.py::test_add_note_no_sessions PASSED             [ 11%]
tests/test_note_command.py::test_add_note_uses_last_active_when_no_identifier PASSED [ 17%]
tests/test_note_command.py::test_add_note_prompts_for_text_when_not_provided PASSED [ 23%]
tests/test_note_command.py::test_add_note_syncs_to_jira_when_requested PASSED [ 29%]
tests/test_note_command.py::test_add_note_sync_to_jira_without_issue_key PASSED [ 35%]
tests/test_note_command.py::test_add_note_handles_no_session_found PASSED [ 41%]
tests/test_note_command.py::test_add_note_to_session_with_multiple_in_group PASSED [ 47%]
tests/test_note_command.py::test_view_notes_with_existing_notes PASSED   [ 52%]
tests/test_note_command.py::test_view_notes_no_notes_file PASSED         [ 58%]
tests/test_note_command.py::test_view_notes_no_sessions PASSED           [ 64%]
tests/test_note_command.py::test_view_notes_uses_last_active_when_no_identifier PASSED [ 70%]
tests/test_note_command.py::test_view_notes_with_latest_flag PASSED      [ 76%]
tests/test_note_command.py::test_view_notes_with_issue_key PASSED        [ 82%]
tests/test_note_command.py::test_view_notes_handles_no_session_found PASSED [ 88%]
tests/test_note_command.py::test_view_notes_displays_chronological_order PASSED [ 94%]
tests/test_note_command.py::test_add_note_works_inside_claude_session PASSED [100%]

======================= 17 passed, 10 warnings in 0.68s ========================

Fixes #162