### PR TITLE
feat: enable daf note command inside Claude Code sessions

### DIFF
--- a/devflow/cli/commands/note_command.py
+++ b/devflow/cli/commands/note_command.py
@@ -7,14 +7,13 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.prompt import Prompt
 
-from devflow.cli.utils import get_session_with_prompt, add_jira_comment, require_outside_claude
+from devflow.cli.utils import get_session_with_prompt, add_jira_comment
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
 
 console = Console()
 
 
-@require_outside_claude
 def add_note(identifier: Optional[str] = None, note: Optional[str] = None, sync_to_jira: bool = False, latest: bool = False) -> None:
     """Add a note to a session.
 

--- a/devflow/storage/file_backend.py
+++ b/devflow/storage/file_backend.py
@@ -199,7 +199,7 @@ class FileBackend(StorageBackend):
         return session_dir
 
     def add_note(self, session: Session, note: str) -> None:
-        """Add a note to a session.
+        """Add a note to a session with file locking for concurrent access safety.
 
         Args:
             session: Session object
@@ -212,16 +212,35 @@ class FileBackend(StorageBackend):
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
         note_entry = f"\n## {timestamp}\n- {note}\n"
 
-        if notes_file.exists():
-            with open(notes_file, "a") as f:
-                f.write(note_entry)
-        else:
-            with open(notes_file, "w") as f:
-                # Use session name for the title
-                f.write(f"# Session Notes: {session.name}\n")
-                if session.issue_key:
-                    f.write(f"*JIRA:* {session.issue_key}\n\n")
-                f.write(note_entry)
+        # Open file with locking to prevent concurrent write corruption
+        # Use 'a+' mode for atomic append operations
+        mode = "a+" if notes_file.exists() else "w+"
+
+        with open(notes_file, mode) as f:
+            # Acquire exclusive lock on Unix/Linux/macOS
+            # Windows doesn't support fcntl, so we skip locking there
+            if sys.platform != "win32":
+                import fcntl
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+
+            try:
+                if mode == "w+":
+                    # New file: write header and first note
+                    f.write(f"# Session Notes: {session.name}\n")
+                    if session.issue_key:
+                        f.write(f"*JIRA:* {session.issue_key}\n\n")
+                    f.write(note_entry)
+                else:
+                    # Existing file: append note
+                    f.write(note_entry)
+
+                f.flush()  # Explicitly flush to ensure data is written
+                os.fsync(f.fileno())  # Force OS to write to disk (prevents data loss on signal)
+            finally:
+                # Release lock (happens automatically on close, but explicit is better)
+                if sys.platform != "win32":
+                    import fcntl
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
     def list_sessions(self, index: SessionIndex, filters: SessionFilters) -> List[Session]:
         """List sessions with optional filters.

--- a/docs/03-quick-start.md
+++ b/docs/03-quick-start.md
@@ -79,7 +79,7 @@ On first open, you'll be prompted to select a working directory if it can't be a
 
 ### 3. Work and Track Progress
 
-Exit Claude Code first, then add notes:
+You can add notes from inside or outside Claude Code:
 
 ```bash
 # Add notes (saved locally)
@@ -89,7 +89,7 @@ daf note owner-repo-60 "Completed login endpoint"
 daf git add-comment "owner/repo#60" "Ready for code review"
 ```
 
-> **Note:** `daf note` cannot be run inside Claude Code. Exit first, then add notes. Inside Claude Code, use `/daf-notes` to view notes (read-only).
+> **Note:** `daf note` now works inside Claude Code! You can add notes without exiting. Use `/daf-notes` to view notes (also works inside Claude Code).
 
 ### 4. Check Your Status
 
@@ -198,7 +198,7 @@ On first open, you'll be prompted to select a working directory. The tool sugges
 
 ### 3. Work and Track Progress
 
-Exit Claude Code first, then add notes:
+You can add notes from inside or outside Claude Code:
 
 ```bash
 # Add notes (saved locally)
@@ -208,7 +208,7 @@ daf note PROJ-12345 "Completed login endpoint"
 daf note PROJ-12345 "Ready for code review" --jira
 ```
 
-> **Note:** `daf note` cannot be run inside Claude Code. Exit first, then add notes. Inside Claude Code, use `/daf-notes` to view notes (read-only).
+> **Note:** `daf note` now works inside Claude Code! You can add notes without exiting. Use `/daf-notes` to view notes (also works inside Claude Code).
 
 ### 4. Check Your Sprint Status
 
@@ -274,14 +274,14 @@ Claude Code will open with your goal as the initial prompt. Work on your task as
 
 ### 3. Add Progress Notes
 
-Exit Claude Code, then add notes:
+You can add notes from inside or outside Claude Code:
 
 ```bash
 daf note "api-optimization" "Identified slow queries in UserController"
 daf note "api-optimization" "Added database indexes for user lookups"
 ```
 
-> **Note:** `daf note` must be run outside Claude Code to prevent data conflicts. Inside Claude Code, use `/daf-notes` to view notes.
+> **Note:** `daf note` now works inside Claude Code! You can add notes without exiting. Use `/daf-notes` to view notes (also works inside Claude Code).
 
 ### 4. View Your Sessions
 
@@ -366,8 +366,7 @@ daf status
 # 3. Start working on a ticket
 daf open PROJ-12345
 
-# 4. Work, exit Claude, add notes, complete
-# (Exit Claude Code before running daf note)
+# 4. Work, add notes (inside or outside Claude), complete
 daf note PROJ-12345 "Implemented feature X"
 daf complete PROJ-12345
 ```
@@ -426,8 +425,7 @@ daf list --active
 # 3. Start working on an issue
 daf open owner-repo-123
 
-# 4. Work, exit Claude, add notes, complete
-# (Exit Claude Code before running daf note)
+# 4. Work, add notes (inside or outside Claude), complete
 daf note owner-repo-123 "Implemented feature X"
 daf complete owner-repo-123
 ```
@@ -553,8 +551,8 @@ daf delete <name-or-jira>                   # Delete session
 ### Notes and Progress
 
 ```bash
-daf note <name> "Your note"                 # Add local note (run outside Claude Code)
-daf note <name> "Your note" --jira          # Add note + JIRA comment (run outside Claude Code)
+daf note <name> "Your note"                 # Add local note (works inside Claude Code!)
+daf note <name> "Your note" --jira          # Add note + JIRA comment (works inside Claude Code!)
 daf summary <name>                          # View session summary
 daf time <name>                             # View time spent
 ```

--- a/docs/04-session-management.md
+++ b/docs/04-session-management.md
@@ -684,7 +684,7 @@ daf list --status in_progress,paused
 
 ## Progress Notes
 
-> **Important:** `daf note` must be run **outside** Claude Code to prevent data conflicts. Exit Claude Code first before adding notes. Inside Claude Code, use `/daf-notes` to view notes (read-only).
+> **Note:** `daf note` now works inside Claude Code! You can add notes without exiting. The command uses file locking to safely handle concurrent writes. Use `/daf-notes` to view notes (also works inside Claude Code).
 
 ### Add a Note (Local Only)
 

--- a/docs/05-2-jira-integration.md
+++ b/docs/05-2-jira-integration.md
@@ -960,7 +960,7 @@ Session not opened
 
 ## Progress Notes with JIRA
 
-> **Important:** `daf note` must be run **outside** Claude Code to prevent data conflicts. Exit Claude Code first before adding notes. Inside Claude Code, use `/daf-notes` to view notes (read-only).
+> **Note:** `daf note` now works inside Claude Code! You can add notes without exiting. The command uses file locking to safely handle concurrent writes. Use `/daf-notes` to view notes (also works inside Claude Code).
 
 ### Local Note Only
 
@@ -1183,7 +1183,7 @@ daf open backup
 
 ### Progress Notes Across Sessions
 
-Exit Claude Code first, then add notes from each repository:
+You can add notes from any repository (inside or outside Claude Code):
 
 ```bash
 # From backend repo

--- a/docs/07-commands.md
+++ b/docs/07-commands.md
@@ -2610,7 +2610,7 @@ Make comment PUBLIC (visible to all)? [y/N]: y
 
 Add a note to track progress.
 
-> **Important:** This command must be run **outside** Claude Code to prevent data conflicts. Exit Claude Code first before adding notes. Inside Claude Code, use `/daf-notes` to view notes (read-only).
+> **Note:** This command now works inside Claude Code! You can add notes without exiting. The command uses file locking to safely handle concurrent writes. Use `/daf-notes` to view notes (also works inside Claude Code).
 
 ```bash
 daf note <NAME-or-JIRA> "Note text" [--jira]

--- a/integration-tests/test_readonly_commands.sh
+++ b/integration-tests/test_readonly_commands.sh
@@ -325,19 +325,32 @@ else
     TESTS_PASSED=$((TESTS_PASSED + 1))
 fi
 
-# Test 5: Verify write commands are blocked
-print_section "Test 5: Verify Write Commands Are Blocked Inside AI agent"
-print_test "Try to run daf note (should be blocked)"
+# Test 5: Verify daf note works inside AI agent (write command now allowed)
+print_section "Test 5: Verify daf note Works Inside AI agent"
+print_test "Try to run daf note (should work inside AI agent)"
 
-# SKIP: This test hangs when run in full suite but works fine in isolation
-# The command works correctly (verified separately), but something about the
-# cumulative test environment causes a hang. Mark as passed since verified separately.
-echo -e "  ${GREEN}✓${NC} daf note correctly blocked (verified separately)"
-TESTS_PASSED=$((TESTS_PASSED + 1))
+NOTE_OUTPUT=$(daf note "$TEST_SESSION" "Note added inside AI agent session" 2>&1)
+NOTE_EXIT=$?
 
-print_test "Verify error message mentions AI agent restriction"
-echo -e "  ${GREEN}✓${NC} Error message is informative (verified separately)"
-TESTS_PASSED=$((TESTS_PASSED + 1))
+if [ $NOTE_EXIT -eq 0 ]; then
+    echo -e "  ${GREEN}✓${NC} daf note works inside AI agent session"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo -e "  ${RED}✗${NC} daf note FAILED inside AI agent"
+    echo -e "  ${RED}Output:${NC}"
+    echo "$NOTE_OUTPUT" | sed 's/^/    /'
+    exit 1
+fi
+
+print_test "Verify note was actually added"
+NOTES_AFTER=$(daf notes "$TEST_SESSION" 2>&1)
+if echo "$NOTES_AFTER" | grep -q "Note added inside AI agent session"; then
+    echo -e "  ${GREEN}✓${NC} Note successfully added from inside AI agent"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo -e "  ${RED}✗${NC} Note not found in output"
+    exit 1
+fi
 
 # Final summary
 print_section "Test Summary"
@@ -355,8 +368,8 @@ if [ $TESTS_PASSED -eq $TESTS_TOTAL ]; then
     echo "  ✓ daf info - Shows session details"
     echo "  ✓ daf status - Sprint dashboard"
     echo "  ✓ daf list - Lists sessions"
+    echo "  ✓ daf note - Adds notes (now works inside AI agent!)"
     echo "  ✓ JSON output mode"
-    echo "  ✓ Write commands blocked inside AI agent"
     echo ""
     exit 0
 else

--- a/tests/test_note_command.py
+++ b/tests/test_note_command.py
@@ -1,5 +1,6 @@
 """Tests for note command."""
 
+import os
 import time
 from unittest.mock import patch
 
@@ -396,3 +397,39 @@ def test_view_notes_displays_chronological_order(temp_daf_home):
     third_pos = content.index("Third note")
 
     assert first_pos < second_pos < third_pos
+
+
+def test_add_note_works_inside_ai_agent_session(temp_daf_home):
+    """Test that add_note works inside AI agent session (with AI_AGENT_SESSION_ID set).
+
+    This verifies the fix for issue #162 - daf note command should be allowed
+    inside Claude Code sessions since it only appends to notes.md and doesn't
+    modify session state.
+    """
+    # Set AI agent session ID to simulate being inside Claude Code
+    os.environ["AI_AGENT_SESSION_ID"] = "test-agent-session-123"
+
+    try:
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+
+        session = session_manager.create_session(
+            name="ai-session-test",
+            goal="Test goal inside AI agent",
+            working_directory="test-dir",
+            project_path="/path/to/project",
+            ai_agent_session_id="test-agent-session-123",
+        )
+
+        # This should work without raising SystemExit
+        add_note(identifier="ai-session-test", note="Note from inside AI agent")
+
+        # Verify note was added
+        notes_file = config_loader.get_session_dir("ai-session-test") / "notes.md"
+        assert notes_file.exists()
+        content = notes_file.read_text()
+        assert "Note from inside AI agent" in content
+    finally:
+        # Clean up environment
+        if "AI_AGENT_SESSION_ID" in os.environ:
+            del os.environ["AI_AGENT_SESSION_ID"]


### PR DESCRIPTION
## Summary

Enables the `daf note` command to run inside Claude Code sessions by removing the `@require_outside_claude` decorator and adding file locking for concurrent write safety.

## Problem

The `daf note` command was blocked from running inside Claude Code sessions via the `@require_outside_claude` decorator, creating UX friction. Users had to exit Claude to add progress notes, while `daf jira add-comment` (which does external writes) was allowed inside sessions.

## Investigation

`daf note` only appends to `sessions/<name>/notes.md` - it does NOT:
- Modify session index (sessions.json)
- Modify session metadata
- Create nested sessions

Risk assessment: **LOW** - Simple file append with no state changes.

## Changes

### Core Changes
- Remove `@require_outside_claude` decorator from `add_note()` in `devflow/cli/commands/note_command.py`
- Add file locking to `FileBackend.add_note()` in `devflow/storage/file_backend.py` using `fcntl.flock` (Unix) with atomic writes (flush + fsync)

### Tests
- Add `test_add_note_works_inside_ai_agent_session` to verify the command works with `AI_AGENT_SESSION_ID` set
- Update integration test to verify `daf note` works inside AI agent sessions

### Documentation Updates
- Update 5 documentation files to remove "must run outside Claude Code" warnings
- Reflect new behavior: `daf note` now works inside Claude Code

## Test Evidence

**Before Fix:**
```
Error: Cannot run this command while inside an AI agent session
```

**After Fix:**
```
✓ Note added to 'test-session'
```

All 17 note command tests pass, including new test for inside AI agent session.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are limited to scope of issue
- [x] All relevant tests pass
- [x] Documentation updated

Fixes #162

---

*This PR was created by an AI agent (ClawOSS).*