### PR TITLE
fix(ui): sanitize widget IDs to handle special characters

### DIFF
--- a/devflow/ui/config_tui.py
+++ b/devflow/ui/config_tui.py
@@ -51,6 +51,28 @@ from devflow.jira.utils import get_field_with_alias
 console = Console()
 
 
+def _sanitize_widget_id(config_key: str) -> str:
+    """Sanitize a config key to create a valid Textual widget ID.
+
+    Textual widget IDs must match: [a-zA-Z][a-zA-Z0-9_-]*
+    This means only letters, numbers, underscores, and hyphens are allowed.
+
+    Args:
+        config_key: Configuration key (e.g., "jira.custom_field_defaults.ack'd_status")
+
+    Returns:
+        Sanitized string with only valid characters (dots, apostrophes, etc. replaced with underscores)
+
+    Examples:
+        "jira.url" -> "jira_url"
+        "ack'd_status" -> "ack_d_status"
+        "should've_been" -> "should_ve_been"
+    """
+    import re
+    # Replace any character that's not alphanumeric, underscore, or hyphen with underscore
+    return re.sub(r'[^a-zA-Z0-9_-]', '_', config_key)
+
+
 def _is_vertex_ai_available() -> bool:
     """Check if GCP Vertex AI is being used for Claude.
 
@@ -255,7 +277,7 @@ class ConfigInput(Container):
             value=self._value,
             placeholder=self._help_text if not self._value else "",
             validators=validators,
-            id=f"input_{self.config_key.replace('.', '_')}",
+            id=f"input_{_sanitize_widget_id(self.config_key)}",
         )
 
         if self._help_text:
@@ -263,7 +285,7 @@ class ConfigInput(Container):
 
     def get_value(self) -> str:
         """Get current input value."""
-        input_widget = self.query_one(f"#input_{self.config_key.replace('.', '_')}", Input)
+        input_widget = self.query_one(f"#input_{_sanitize_widget_id(self.config_key)}", Input)
         return input_widget.value.strip()
 
 
@@ -324,7 +346,7 @@ class ConfigCheckbox(Container):
         yield Label(self._label)
         with Horizontal():
             checkbox_value = self._value if self._value is not None else False
-            yield Checkbox(value=checkbox_value, id=f"checkbox_{self.config_key.replace('.', '_')}")
+            yield Checkbox(value=checkbox_value, id=f"checkbox_{_sanitize_widget_id(self.config_key)}")
             if self._value is None:
                 yield Label("[dim](not set - will prompt)[/dim]")
 
@@ -333,7 +355,7 @@ class ConfigCheckbox(Container):
 
     def get_value(self) -> bool:
         """Get current checkbox value."""
-        checkbox = self.query_one(f"#checkbox_{self.config_key.replace('.', '_')}", Checkbox)
+        checkbox = self.query_one(f"#checkbox_{_sanitize_widget_id(self.config_key)}", Checkbox)
         return checkbox.value
 
 
@@ -399,7 +421,7 @@ class ConfigSelect(Container):
             options=self._choices,
             value=self._value if self._value else Select.BLANK,
             allow_blank=self._allow_blank,
-            id=f"select_{self.config_key.replace('.', '_')}",
+            id=f"select_{_sanitize_widget_id(self.config_key)}",
         )
 
         if self._help_text:
@@ -407,7 +429,7 @@ class ConfigSelect(Container):
 
     def get_value(self) -> Optional[str]:
         """Get current select value."""
-        select = self.query_one(f"#select_{self.config_key.replace('.', '_')}", Select)
+        select = self.query_one(f"#select_{_sanitize_widget_id(self.config_key)}", Select)
         return select.value if select.value != Select.BLANK else None
 
 
@@ -2839,7 +2861,7 @@ class ConfigTUI(App):
         """Collect all values from input widgets and update config."""
         # Helper to convert config key to valid ID
         def key_to_id(prefix: str, key: str) -> str:
-            return f"#{prefix}_{key.replace('.', '_')}"
+            return f"#{prefix}_{_sanitize_widget_id(key)}"
 
         # JIRA settings (only in Simple mode)
         if not self.advanced_mode:

--- a/tests/test_config_tui.py
+++ b/tests/test_config_tui.py
@@ -15,6 +15,7 @@ from devflow.ui.config_tui import (
     AddContextFileScreen,
     ConfigTUI,
     run_config_tui,
+    _sanitize_widget_id,
 )
 from devflow.config.models import Config, JiraConfig, RepoConfig, ContextFile
 
@@ -81,6 +82,34 @@ def test_non_empty_validator():
 
     result = validator.validate("   ")
     assert not result.is_valid
+
+
+def test_sanitize_widget_id():
+    """Test widget ID sanitization for special characters."""
+    # Test normal cases with dots
+    assert _sanitize_widget_id("jira.url") == "jira_url"
+    assert _sanitize_widget_id("jira.custom_field_defaults.workstream") == "jira_custom_field_defaults_workstream"
+
+    # Test apostrophes (the bug we're fixing)
+    assert _sanitize_widget_id("ack'd_status") == "ack_d_status"
+    assert _sanitize_widget_id("jira.custom_field_defaults.ack'd_status") == "jira_custom_field_defaults_ack_d_status"
+    assert _sanitize_widget_id("should've_been_found") == "should_ve_been_found"
+    assert _sanitize_widget_id("sdlc_stage_when_should've_been_found") == "sdlc_stage_when_should_ve_been_found"
+
+    # Test other special characters
+    assert _sanitize_widget_id("field with spaces") == "field_with_spaces"
+    assert _sanitize_widget_id("field-with-dashes") == "field-with-dashes"  # Hyphens are allowed
+    assert _sanitize_widget_id("field_with_underscores") == "field_with_underscores"  # Underscores are allowed
+    assert _sanitize_widget_id("field(with)parens") == "field_with_parens"
+    assert _sanitize_widget_id("field@with#symbols") == "field_with_symbols"
+
+    # Test that result starts with valid character (already prefixed in actual use)
+    result = _sanitize_widget_id("test.field")
+    assert result[0].isalpha() or result[0] == '_'
+
+    # Test complex real-world example
+    assert _sanitize_widget_id("jira.custom_field_defaults.sdlc_stage_when_should've_been_found") == \
+           "jira_custom_field_defaults_sdlc_stage_when_should_ve_been_found"
 
 
 # ============================================================================


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-XXXX>
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR fixes an issue with widget ID sanitization in the configuration TUI. As the configuration service becomes more parametrizable, widget IDs need to properly handle special characters that may appear in configuration keys or parameter names. 

The changes ensure that widget IDs are properly sanitized before being used in the TUI, preventing errors when configuration parameters contain special characters like dashes, dots, or other non-alphanumeric characters.

Test coverage has been added to verify the sanitization behavior.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run the test suite to verify widget ID sanitization: `pytest tests/test_config_tui.py`
3. Launch the configuration TUI with parameters containing special characters (e.g., `config-option`, `config.setting`, `config_param`)
4. Verify that the TUI renders correctly without widget ID errors
5. Interact with configuration options that have special characters in their names
6. Confirm that all widgets function properly and no ID-related exceptions are raised

### Scenarios tested
- Widget IDs with dashes, dots, underscores, and other special characters
- Configuration parameters with mixed alphanumeric and special character names
- Edge cases with consecutive special characters

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: