### PR TITLE
fix: sync config schemas with Pydantic models

### DIFF
--- a/devflow/config/schemas/enterprise.schema.json
+++ b/devflow/config/schemas/enterprise.schema.json
@@ -15,6 +15,16 @@
       "description": "Override any fields from backend configs (backends/*.json). Example: {\"field_mappings\": {\"components\": {\"required_for\": [\"Bug\", \"Story\"]}}}",
       "additionalProperties": true
     },
+    "jira_issue_templates": {
+      "type": ["object", "null"],
+      "description": "Default issue templates for different issue types (e.g., {\"Bug\": \"...\", \"Story\": \"...\", \"Task\": \"...\", \"Epic\": \"...\", \"Spike\": \"...\"})",
+      "additionalProperties": {"type": "string"}
+    },
+    "github_issue_types": {
+      "type": ["array", "null"],
+      "items": {"type": "string"},
+      "description": "Allowed GitHub/GitLab issue types (e.g., [\"bug\", \"enhancement\", \"task\", \"spike\", \"epic\", \"story\"])"
+    },
     "model_provider": {
       "type": ["object", "null"],
       "description": "Model provider configuration enforced by enterprise",

--- a/devflow/config/schemas/organization.schema.json
+++ b/devflow/config/schemas/organization.schema.json
@@ -9,6 +9,46 @@
       "type": ["string", "null"],
       "description": "JIRA project key (e.g., 'PROJ', 'ENG', 'MYAPP'). Required for ticket creation."
     },
+    "transitions": {
+      "type": "object",
+      "description": "Organization workflow transition policies",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of source statuses",
+            "default": ["New", "To Do"]
+          },
+          "to": {
+            "type": "string",
+            "description": "Target status for automatic transitions (when prompt=false)",
+            "default": ""
+          },
+          "prompt": {
+            "type": "boolean",
+            "description": "Whether to prompt user for transition",
+            "default": false
+          },
+          "on_fail": {
+            "type": "string",
+            "description": "Action on transition failure",
+            "default": "warn"
+          },
+          "options": {
+            "type": ["array", "null"],
+            "items": {"type": "string"},
+            "description": "Deprecated - transitions now fetched dynamically from JIRA API"
+          }
+        }
+      }
+    },
+    "parent_field_mapping": {
+      "type": ["object", "null"],
+      "description": "Organization issue hierarchy policy - maps issue types to parent field names (e.g., {\"story\": \"epic_link\", \"sub-task\": \"parent\"})",
+      "additionalProperties": {"type": "string"}
+    },
     "sync_filters": {
       "type": "object",
       "description": "Filters for JIRA ticket synchronization",
@@ -18,16 +58,30 @@
           "status": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "List of JIRA statuses to sync (e.g., ['To Do', 'In Progress'])"
+            "description": "List of JIRA statuses to sync (e.g., ['To Do', 'In Progress'])",
+            "default": ["New", "To Do", "In Progress"]
           },
           "required_fields": {
-            "type": "array",
-            "items": {"type": "string"},
-            "description": "List of required fields for ticket creation"
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "List of required fields for all issue types"
+              },
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {"type": "string"}
+                },
+                "description": "Required fields per issue type (e.g., {\"Bug\": [\"sprint\"], \"Story\": [\"sprint\", \"story_points\"]})"
+              }
+            ]
           },
           "assignee": {
             "type": "string",
-            "description": "Assignee filter: 'currentUser()' for user's tickets, specific username, or null for all"
+            "description": "Assignee filter: 'currentUser()' for user's tickets, specific username, or null for all",
+            "default": "currentUser()"
           }
         },
         "required": ["status", "required_fields", "assignee"],
@@ -41,6 +95,40 @@
     "status_totals_field": {
       "type": ["string", "null"],
       "description": "Field to sum for totals in status dashboard (e.g., 'points', 'story_points', 'effort'). None means no totals."
+    },
+    "hierarchical_config_source": {
+      "type": ["string", "null"],
+      "description": "URL or path to hierarchical config files (ENTERPRISE.md, ORGANIZATION.md, TEAM.md, USER.md). Supports file://, http://, https://. Example: 'https://github.com/ansible-saas/devflow-for-red-hatters/configs' or 'file:///path/to/configs'"
+    },
+    "jira_issue_templates": {
+      "type": ["object", "null"],
+      "description": "Issue templates for different issue types (e.g., {\"Bug\": \"...\", \"Story\": \"...\", \"Task\": \"...\", \"Epic\": \"...\", \"Spike\": \"...\"})",
+      "additionalProperties": {"type": "string"}
+    },
+    "github_repository": {
+      "type": ["string", "null"],
+      "description": "GitHub repository in owner/repo format (e.g., 'ansible-saas/devaiflow')"
+    },
+    "github_auto_close_on_complete": {
+      "type": "boolean",
+      "description": "Auto-close GitHub issues when session completes",
+      "default": false
+    },
+    "github_default_labels": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Organization-level default labels for GitHub issues",
+      "default": []
+    },
+    "github_issue_templates": {
+      "type": ["object", "null"],
+      "description": "Issue templates for different issue types (e.g., {\"Bug\": \"...\", \"Story\": \"...\"})",
+      "additionalProperties": {"type": "string"}
+    },
+    "github_issue_types": {
+      "type": ["array", "null"],
+      "items": {"type": "string"},
+      "description": "Override enterprise-level GitHub/GitLab issue types (e.g., [\"bug\", \"enhancement\", \"documentation\"])"
     },
     "model_provider": {
       "type": ["object", "null"],

--- a/devflow/config/schemas/team.schema.json
+++ b/devflow/config/schemas/team.schema.json
@@ -34,6 +34,22 @@
       "enum": ["claude", "github-copilot", null],
       "description": "AI agent backend enforced by team (e.g., 'claude', 'github-copilot'). Use null to allow users to choose."
     },
+    "jira_issue_templates": {
+      "type": ["object", "null"],
+      "description": "Team-specific issue template overrides (e.g., {\"Bug\": \"...\", \"Story\": \"...\"})",
+      "additionalProperties": {"type": "string"}
+    },
+    "github_default_labels": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Team-level default labels for GitHub issues",
+      "default": []
+    },
+    "github_issue_templates": {
+      "type": ["object", "null"],
+      "description": "Team-specific GitHub issue template overrides (e.g., {\"Bug\": \"...\", \"Story\": \"...\"})",
+      "additionalProperties": {"type": "string"}
+    },
     "model_provider": {
       "type": ["object", "null"],
       "description": "Model provider configuration for team",


### PR DESCRIPTION
## Problem

Config validation was failing with 'Additional properties are not allowed' errors for fields that were actually supported by the Pydantic models but missing from the JSON schemas.

This caused user configs to be incorrectly flagged as invalid, leading to potential config corruption when validation tried to auto-fix issues.

## Root Cause

The JSON schemas (*.schema.json) were not updated when fields were moved/added to the Pydantic models in previous commits:
- f88e2bd: moved `transitions`/`parent_field_mapping` to OrganizationConfig
- 6cee14f: added `github_issue_types`
- 2356be4: added `jira_issue_templates`
- cc733f8: added `model_provider`

Since the schemas have `"additionalProperties": false`, they rejected these valid fields.

## Changes

### organization.schema.json
- Added `transitions` (workflow transition policies)
- Added `parent_field_mapping` (issue hierarchy mapping)
- Added `hierarchical_config_source` (config file source URL)
- Added `jira_issue_templates` (issue templates)
- Added `github_repository`, `github_auto_close_on_complete`, `github_default_labels`, `github_issue_templates`, `github_issue_types`
- Fixed `required_fields` in sync_filters to accept both array and object format

### team.schema.json
- Added `jira_issue_templates`
- Added `github_default_labels`, `github_issue_templates`

### enterprise.schema.json
- Added `jira_issue_templates`
- Added `github_issue_types`

## Testing

- ✅ Validated against existing user configs that were previously failing
- ✅ `daf config show --validate` now passes without errors
- ✅ All schemas properly aligned with Pydantic models

## Deployment considerations
- [x] This code change is ready for deployment on its own