### PR TITLE
itdove/devaiflow#187: Add explicit file permission guidance to multi-project session prompts based on session_type

### DIFF
--- a/devflow/cli/commands/new_command.py
+++ b/devflow/cli/commands/new_command.py
@@ -186,6 +186,13 @@ def _generate_initial_prompt(
         prompt += f"   • This session spans {len(other_projects)} projects with SHARED CONTEXT\n"
         prompt += f"   • Projects: {', '.join(other_projects)}\n"
         prompt += f"   • You can make changes in ANY of these projects\n"
+
+        # Add explicit file permission guidance based on session_type
+        if session_type == "development":
+            prompt += f"   • File Permissions: You can EDIT files in any of these project directories\n"
+        else:  # ticket_creation or investigation
+            prompt += f"   • File Permissions: You can only READ files in these directories - DO NOT edit any files\n"
+
         prompt += f"\n   ✅ ADVANTAGES:\n"
         prompt += f"   • All changes are coordinated in a single conversation\n"
         prompt += f"   • You can update frontend to match backend API changes\n"
@@ -202,6 +209,13 @@ def _generate_initial_prompt(
         prompt += f"   • YOU ARE CURRENTLY IN: {current_project}\n"
         prompt += f"   • Other projects in this session: {', '.join(other_projects)}\n"
         prompt += f"\n   🚨 CRITICAL: Only make changes in the '{current_project}' project!\n"
+
+        # Add explicit file permission guidance based on session_type
+        if session_type == "development":
+            prompt += f"   • File Permissions: You can EDIT files in '{current_project}' directory only\n"
+        else:  # ticket_creation or investigation
+            prompt += f"   • File Permissions: You can only READ files in '{current_project}' directory - DO NOT edit any files\n"
+
         prompt += f"\n   WHY THIS MATTERS:\n"
         prompt += f"   • Each project has its OWN git repository and branch\n"
         prompt += f"   • The other projects ({', '.join(other_projects)}) may be on DIFFERENT branches\n"

--- a/tests/test_multiproject_prompt.py
+++ b/tests/test_multiproject_prompt.py
@@ -1,5 +1,6 @@
 """Test for multi-project session initial prompt generation."""
 
+import pytest
 from devflow.cli.commands.new_command import _generate_initial_prompt
 
 
@@ -72,3 +73,141 @@ def test_multiproject_without_project_paths_falls_back():
 
     # Should not crash or include project-level section
     assert "Also read project-level context files for each project:" not in prompt
+
+
+class TestMultiProjectFilePermissions:
+    """Test file permission guidance in multi-project prompts (Issue #187)."""
+
+    def test_new_mode_development_session_shows_edit_permissions(self):
+        """Test new mode development session shows EDIT permissions."""
+        prompt = _generate_initial_prompt(
+            name="test-session",
+            goal="Test development",
+            session_type="development",
+            is_multi_project=True,
+            other_projects=["backend-api", "frontend-app"],
+            workspace="/workspace",
+        )
+
+        # Should show multi-project session marker
+        assert "⚠️  MULTI-PROJECT SESSION:" in prompt
+
+        # Should show EDIT permissions for development sessions
+        assert "File Permissions: You can EDIT files in any of these project directories" in prompt
+
+        # Should NOT show read-only guidance
+        assert "DO NOT edit any files" not in prompt
+
+    def test_new_mode_ticket_creation_session_shows_read_only_permissions(self):
+        """Test new mode ticket creation session shows READ-ONLY permissions."""
+        prompt = _generate_initial_prompt(
+            name="test-session",
+            goal="Test ticket creation",
+            session_type="ticket_creation",
+            is_multi_project=True,
+            other_projects=["backend-api", "frontend-app"],
+            workspace="/workspace",
+        )
+
+        # Should show multi-project session marker
+        assert "⚠️  MULTI-PROJECT SESSION:" in prompt
+
+        # Should show READ-ONLY permissions for ticket_creation sessions
+        assert "File Permissions: You can only READ files in these directories - DO NOT edit any files" in prompt
+
+        # Should NOT show edit permissions
+        assert "You can EDIT files" not in prompt
+
+    def test_new_mode_investigation_session_shows_read_only_permissions(self):
+        """Test new mode investigation session shows READ-ONLY permissions."""
+        prompt = _generate_initial_prompt(
+            name="test-session",
+            goal="Test investigation",
+            session_type="investigation",
+            is_multi_project=True,
+            other_projects=["backend-api", "frontend-app"],
+            workspace="/workspace",
+        )
+
+        # Should show multi-project session marker
+        assert "⚠️  MULTI-PROJECT SESSION:" in prompt
+
+        # Should show READ-ONLY permissions for investigation sessions
+        assert "File Permissions: You can only READ files in these directories - DO NOT edit any files" in prompt
+
+        # Should NOT show edit permissions
+        assert "You can EDIT files" not in prompt
+
+    def test_old_mode_development_session_shows_edit_permissions(self):
+        """Test old mode development session shows EDIT permissions."""
+        prompt = _generate_initial_prompt(
+            name="test-session",
+            goal="Test development",
+            session_type="development",
+            current_project="backend-api",
+            other_projects=["frontend-app", "database"],
+            workspace="/workspace",
+        )
+
+        # Should show old mode multi-project marker
+        assert "⚠️  MULTI-PROJECT SESSION SCOPE:" in prompt
+
+        # Should show EDIT permissions for development sessions
+        assert "File Permissions: You can EDIT files in 'backend-api' directory only" in prompt
+
+        # Should NOT show read-only guidance
+        assert "DO NOT edit any files" not in prompt
+
+    def test_old_mode_ticket_creation_session_shows_read_only_permissions(self):
+        """Test old mode ticket creation session shows READ-ONLY permissions."""
+        prompt = _generate_initial_prompt(
+            name="test-session",
+            goal="Test ticket creation",
+            session_type="ticket_creation",
+            current_project="backend-api",
+            other_projects=["frontend-app", "database"],
+            workspace="/workspace",
+        )
+
+        # Should show old mode multi-project marker
+        assert "⚠️  MULTI-PROJECT SESSION SCOPE:" in prompt
+
+        # Should show READ-ONLY permissions for ticket_creation sessions
+        assert "File Permissions: You can only READ files in 'backend-api' directory - DO NOT edit any files" in prompt
+
+        # Should NOT show edit permissions
+        assert "You can EDIT files" not in prompt
+
+    def test_old_mode_investigation_session_shows_read_only_permissions(self):
+        """Test old mode investigation session shows READ-ONLY permissions."""
+        prompt = _generate_initial_prompt(
+            name="test-session",
+            goal="Test investigation",
+            session_type="investigation",
+            current_project="backend-api",
+            other_projects=["frontend-app", "database"],
+            workspace="/workspace",
+        )
+
+        # Should show old mode multi-project marker
+        assert "⚠️  MULTI-PROJECT SESSION SCOPE:" in prompt
+
+        # Should show READ-ONLY permissions for investigation sessions
+        assert "File Permissions: You can only READ files in 'backend-api' directory - DO NOT edit any files" in prompt
+
+        # Should NOT show edit permissions
+        assert "You can EDIT files" not in prompt
+
+    def test_single_project_does_not_show_file_permissions(self):
+        """Test single-project sessions don't show file permission guidance."""
+        prompt = _generate_initial_prompt(
+            name="test-session",
+            goal="Test single project",
+            session_type="development",
+            is_multi_project=False,
+            project_path="/workspace/backend-api",
+        )
+
+        # Should NOT show multi-project markers or file permissions
+        assert "⚠️  MULTI-PROJECT SESSION:" not in prompt
+        assert "File Permissions:" not in prompt


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://redhat.atlassian.net/browse/itdove/devaiflow#187>

## Description
This PR adds explicit file permission guidance to multi-project session prompts based on the session type. The enhancement improves the clarity of file permission requirements when working with multi-project sessions by tailoring the guidance to the specific session type being used.

Changes include:
- Updated `devflow/cli/commands/new_command.py` to include session-type-specific file permission guidance in generated prompts
- Added comprehensive tests in `tests/test_multiproject_prompt.py` to verify the permission guidance is correctly included for different session types

This change helps developers understand the file permission requirements upfront when initiating multi-project sessions, reducing confusion and potential permission-related issues.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Install the updated devflow package locally (`pip install -e .`)
3. Create a new multi-project session using the CLI: `devflow new <session-name> --session-type <type>`
4. Verify that the generated session prompt includes explicit file permission guidance appropriate to the session type
5. Test with different session types to ensure guidance is tailored appropriately
6. Run the test suite: `pytest tests/test_multiproject_prompt.py -v`
7. Verify all tests pass

### Scenarios tested
- Multi-project session creation with various session types
- Validation that file permission guidance appears in generated prompts
- Unit tests covering the new prompt generation logic

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: