### PR TITLE
itdove/devaiflow#174: docs: Improve JIRA Cloud authentication setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,17 @@ daf complete owner-repo-123
 ### With JIRA (Alternative)
 
 ```bash
-# Export environment variables for JIRA
-export JIRA_URL="https://jira.example.com"
+# For Atlassian Cloud (https://yourcompany.atlassian.net):
+# 1. Create base64-encoded credentials: echo -n "email:token" | base64
+# 2. Set environment variables
+export JIRA_AUTH_TYPE=basic
+export JIRA_API_TOKEN=<BASE64_ENCODED_CREDENTIALS>
+export JIRA_URL="https://yourcompany.atlassian.net"
+
+# For Self-Hosted JIRA:
+export JIRA_AUTH_TYPE=Bearer
 export JIRA_API_TOKEN=<YOUR_JIRA_PAT>
+export JIRA_URL="https://jira.example.com"
 
 # Initialize and sync
 daf init

--- a/docs/02-installation.md
+++ b/docs/02-installation.md
@@ -348,34 +348,55 @@ The tool uses the JIRA REST API directly - no additional CLI tools are needed!
 
 ### 1. Get JIRA API Token
 
-**For Atlassian Cloud:**
+**For Atlassian Cloud (https://yourcompany.atlassian.net):**
+
 1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
 2. Click "Create API token"
 3. Give it a name (e.g., "DevAIFlow")
 4. Copy the token (you won't see it again!)
 
 **For Enterprise JIRA or Self-Hosted:**
+
 1. Go to your JIRA instance → Profile → Personal Access Tokens
 2. Create a new token
 3. Copy the token value
 
 ### 2. Configure Environment Variables
 
+> **⚠️ IMPORTANT:** Authentication setup differs between Cloud and Self-Hosted JIRA.
+
+**For Atlassian Cloud:**
+
 Add these to your shell profile (`~/.bashrc`, `~/.zshrc`, `~/.profile`, etc.):
 
 ```bash
-# Required: JIRA API Token
-export JIRA_API_TOKEN="your-api-token-here"
+# Step 1: Create base64-encoded credentials (email:token)
+# Replace with YOUR email and token from step 1
+echo -n "user@company.com:your-api-token" | base64
 
-# Optional: JIRA URL (defaults to https://jira.example.com)
-export JIRA_URL="https://jira.example.com"
-
-# Optional: Enable debug logging for JIRA API calls (troubleshooting)
-export DEVAIFLOW_DEBUG=1
+# Step 2: Add to shell profile
+# CRITICAL: JIRA_AUTH_TYPE=basic is required for Cloud
+export JIRA_AUTH_TYPE=basic
+export JIRA_API_TOKEN="<base64-output-from-above>"
+export JIRA_URL="https://yourcompany.atlassian.net"
 ```
 
-**For jira-cli config fallback:**
-The tool can also read the JIRA URL from `~/.config/.jira/.config.yml` if you have jira-cli installed, but this is not required.
+**For Self-Hosted JIRA:**
+
+Add these to your shell profile:
+
+```bash
+# For self-hosted JIRA, use Bearer authentication
+export JIRA_AUTH_TYPE=Bearer
+export JIRA_API_TOKEN="your-personal-access-token"
+export JIRA_URL="https://jira.example.com"
+```
+
+**Optional debugging:**
+```bash
+# Enable debug logging for JIRA API calls (troubleshooting)
+export DEVAIFLOW_DEBUG=1
+```
 
 **Reload your shell:**
 ```bash
@@ -385,11 +406,15 @@ source ~/.zshrc  # or ~/.bashrc, ~/.profile, etc.
 ### 3. Verify JIRA Setup
 
 ```bash
-# Test by listing your sessions
+# Test authentication with curl
+curl -H "Authorization: Basic $JIRA_API_TOKEN" \
+     "$JIRA_URL/rest/api/2/myself"
+
+# If successful, test DevAIFlow integration
 daf sync --dry-run
 ```
 
-If this shows your JIRA tickets, the integration is working!
+✅ If this shows your JIRA tickets, the integration is working!
 
 ## Configuring DevAIFlow
 

--- a/docs/05-2-jira-integration.md
+++ b/docs/05-2-jira-integration.md
@@ -79,57 +79,77 @@ DevAIFlow supports two authentication methods depending on your JIRA deployment 
 
 Atlassian Cloud requires **Basic Authentication** with base64-encoded credentials.
 
-**Step 1: Get Your JIRA Email Address**
+> **⚠️ CRITICAL:** JIRA Cloud authentication requires three key elements:
+> 1. Base64-encoded credentials combining `email:token`
+> 2. `JIRA_AUTH_TYPE=basic` environment variable
+> 3. Your JIRA Cloud URL (e.g., `https://yourcompany.atlassian.net`)
+>
+> Missing any of these will result in authentication failures.
+
+**Step 1: Configure JIRA URL in DevAIFlow**
+
+First, ensure your JIRA URL is configured. Check your current configuration:
+
+```bash
+# Check if JIRA URL is already configured
+daf config show | grep -i jira
+```
+
+If not configured or incorrect, set it:
+
+```bash
+# Set via environment variable (required)
+export JIRA_URL="https://yourcompany.atlassian.net"
+```
+
+**Step 2: Get Your JIRA Email Address**
 
 Use the email address associated with your Atlassian account (e.g., `user@company.com`).
 
-**Step 2: Generate API Token**
+**Step 3: Generate API Token**
 
 1. Go to: https://id.atlassian.com/manage-profile/security/api-tokens
 2. Click **Create API token**
 3. Give it a name (e.g., "DevAIFlow CLI")
 4. Copy the generated token (you won't see it again)
 
-**Step 3: Create Base64-Encoded Credentials**
+**Step 4: Create Base64-Encoded Credentials**
 
-Combine your email and API token with a colon, then encode to base64:
+> **IMPORTANT:** You must combine your email and API token with a colon (`:`) **before** encoding to base64.
+
+Replace `user@company.com` with your email and `your-api-token` with the token from Step 3:
 
 ```bash
+# Replace with YOUR email and token
 echo -n "user@company.com:your-api-token" | base64
 ```
 
-This outputs a base64 string (this becomes your JIRA_API_TOKEN).
+This outputs a base64 string. **Save this output** - it becomes your `JIRA_API_TOKEN`.
 
-**Step 4: Configure Environment Variables**
+Example output format:
+```
+dXNlckBjb21wYW55LmNvbTp5b3VyLWFwaS10b2tlbg==
+```
+
+**Step 5: Configure Environment Variables**
+
+> **⚠️ CRITICAL:** The `JIRA_AUTH_TYPE=basic` variable is **required** for JIRA Cloud.
+> Without this, authentication will fail even with correct credentials.
 
 ```bash
-# Set authentication type to basic
+# CRITICAL: Set authentication type to basic for JIRA Cloud
 export JIRA_AUTH_TYPE=basic
 
-# Set the base64-encoded credentials (paste output from step 3)
-export JIRA_API_TOKEN="your-jira-token"
+# Set the base64-encoded credentials (paste output from Step 4)
+export JIRA_API_TOKEN="dXNlckBjb21wYW55LmNvbTp5b3VyLWFwaS10b2tlbg=="
 
 # Set your Atlassian Cloud URL
 export JIRA_URL="https://yourcompany.atlassian.net"
 ```
 
-**Step 5: Add to Shell Profile (Permanent)**
-
-Add these to your `~/.zshrc` or `~/.bashrc`:
-
-```bash
-# JIRA Configuration (Atlassian Cloud)
-export JIRA_AUTH_TYPE=basic
-export JIRA_API_TOKEN="your-jira-token"
-export JIRA_URL="https://yourcompany.atlassian.net"
-```
-
-Then reload:
-```bash
-source ~/.zshrc  # or source ~/.bashrc
-```
-
 **Step 6: Verify Authentication**
+
+Test the connection **before** making it permanent:
 
 ```bash
 # Test API access
@@ -137,7 +157,27 @@ curl -H "Authorization: Basic $JIRA_API_TOKEN" \
      "$JIRA_URL/rest/api/2/myself"
 ```
 
-If successful, you'll see your user profile data.
+✅ **Success:** You'll see your user profile data in JSON format.
+❌ **Failure:** Check that:
+- Your JIRA_API_TOKEN is the base64 output from Step 4
+- JIRA_AUTH_TYPE is set to `basic`
+- JIRA_URL matches your Atlassian Cloud URL
+
+**Step 7: Make It Permanent**
+
+Once verified, add these to your `~/.zshrc` or `~/.bashrc`:
+
+```bash
+# JIRA Configuration (Atlassian Cloud)
+export JIRA_AUTH_TYPE=basic
+export JIRA_API_TOKEN="dXNlckBjb21wYW55LmNvbTp5b3VyLWFwaS10b2tlbg=="
+export JIRA_URL="https://yourcompany.atlassian.net"
+```
+
+Then reload:
+```bash
+source ~/.zshrc  # or source ~/.bashrc
+```
 
 ### Self-Hosted JIRA (On-Premise)
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
This PR does not need a corresponding Jira item.

## Description
This PR improves the JIRA Cloud authentication setup instructions in the documentation to better clarify the differences between JIRA Cloud and JIRA Self-Hosted authentication configurations. The changes update three documentation files to provide clearer guidance on setting up authentication for different JIRA deployment types.

The documentation now more explicitly differentiates between Cloud and Self-Hosted authentication requirements, making it easier for users to configure the appropriate authentication method for their JIRA instance.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Review the changes in `README.md`, `docs/02-installation.md`, and `docs/05-2-jira-integration.md`
3. Verify that the Cloud vs Self-Hosted authentication instructions are clearly distinguished
4. Follow the updated authentication setup instructions for JIRA Cloud to ensure they are accurate and complete
5. Check that all markdown formatting renders correctly
6. Verify any links or references are correct and functional

### Scenarios tested
- Reviewed all three documentation files for clarity and accuracy
- Verified markdown formatting renders correctly
- Confirmed authentication setup instructions are complete for both Cloud and Self-Hosted scenarios

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: