### PR TITLE
itdove/devaiflow#171: Move DAF_AGENTS.md storage to DEVAIFLOW_HOME for multi-project sessions

### DIFF
--- a/devflow/utils/context_files.py
+++ b/devflow/utils/context_files.py
@@ -18,6 +18,7 @@ def load_hierarchical_context_files(config: Optional['Config'] = None) -> list[t
     - Organization: ORGANIZATION.md
     - Team: TEAM.md
     - User: USER.md
+    - DAF_AGENTS.md: daf tool usage guide
 
     Only returns files that physically exist on disk.
     Paths are resolved relative to DEVAIFLOW_HOME.
@@ -58,5 +59,10 @@ def load_hierarchical_context_files(config: Optional['Config'] = None) -> list[t
     user_path = cs_home / "USER.md"
     if user_path.exists() and user_path.is_file():
         context_files.append((str(user_path), "personal notes and preferences"))
+
+    # DAF_AGENTS context (daf tool usage guide)
+    daf_agents_path = cs_home / "DAF_AGENTS.md"
+    if daf_agents_path.exists() and daf_agents_path.is_file():
+        context_files.append((str(daf_agents_path), "daf tool usage guide"))
 
     return context_files

--- a/devflow/utils/daf_agents_validation.py
+++ b/devflow/utils/daf_agents_validation.py
@@ -183,14 +183,15 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
     """Validate that required context files exist before launching Claude.
 
     Checks for DAF_AGENTS.md in this order:
-    1. Repository directory (project-specific customization)
-    2. Workspace directory (shared across projects)
-    3. Offer to auto-install bundled DAF_AGENTS.md if not found
+    1. DEVAIFLOW_HOME directory (centralized, recommended)
+    2. Repository directory (project-specific customization, backward compatibility)
+    3. Workspace directory (shared across projects, backward compatibility)
+    4. Offer to auto-install bundled DAF_AGENTS.md if not found
 
     If found, checks if installed version is outdated and prompts for upgrade.
 
     For ticket_creation and investigation sessions with temp directories:
-    - Checks workspace directory only (temp directory doesn't persist)
+    - Checks DEVAIFLOW_HOME first, then workspace (temp directory doesn't persist)
     - Does not try to install to temp directory
 
     Args:
@@ -201,7 +202,7 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
         True if DAF_AGENTS.md is found or successfully installed, False otherwise
     """
     # For ticket_creation and investigation sessions with temp directories,
-    # only check workspace (temp directory is transient and gets deleted)
+    # check DEVAIFLOW_HOME first, then workspace (temp directory is transient and gets deleted)
     active_conv = session.active_conversation
     is_temp_session = (
         session.session_type in ("ticket_creation", "investigation") and
@@ -210,7 +211,20 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
     )
 
     if is_temp_session:
-        # For temp directory sessions, only check workspace (don't try to install to temp dir)
+        # Check DEVAIFLOW_HOME first (centralized location)
+        from devflow.utils.paths import get_cs_home
+        cs_home = get_cs_home()
+        daf_agents_home = cs_home / "DAF_AGENTS.md"
+
+        if daf_agents_home.exists():
+            console.print(f"[dim]✓ Found DAF_AGENTS.md in DEVAIFLOW_HOME (centralized)[/dim]")
+            console.print(f"[dim]  Location: {daf_agents_home}[/dim]")
+            # Check if upgrade is needed
+            if not _check_and_upgrade_daf_agents(daf_agents_home, "DEVAIFLOW_HOME"):
+                return False
+            return True
+
+        # Check workspace as fallback for backward compatibility
         config = config_loader.load_config()
         if config and config.repos and config.repos.get_default_workspace_path():
             workspace_path = config.repos.get_default_workspace_path()
@@ -225,58 +239,69 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
                     if not _check_and_upgrade_daf_agents(cs_agents_workspace, "workspace"):
                         return False
                     return True
-                else:
-                    # Not found in workspace - offer to install there
-                    console.print(f"\n[yellow]⚠ DAF_AGENTS.md not found[/yellow]")
-                    console.print(f"\n[dim]DAF_AGENTS.md provides daf tool usage instructions to Claude.[/dim]")
-                    console.print(f"\nSearched locations:")
-                    console.print(f"  1. Workspace:  {cs_agents_workspace}")
-                    console.print(f"\n[dim]Note: Cannot install to temporary directory (session_type: {session.session_type})[/dim]")
 
-                    from devflow.utils import is_mock_mode
-                    mock_mode = is_mock_mode()
+        # Not found - offer to install to DEVAIFLOW_HOME (recommended location)
+        console.print(f"\n[yellow]⚠ DAF_AGENTS.md not found[/yellow]")
+        console.print(f"\n[dim]DAF_AGENTS.md provides daf tool usage instructions to Claude.[/dim]")
+        console.print(f"\nSearched locations:")
+        console.print(f"  1. DEVAIFLOW_HOME: {daf_agents_home}")
+        if config and config.repos and config.repos.get_default_workspace_path():
+            console.print(f"  2. Workspace:      {cs_agents_workspace}")
+        console.print(f"\n[dim]Note: Cannot install to temporary directory (session_type: {session.session_type})[/dim]")
 
-                    should_install = True
-                    if not mock_mode:
-                        console.print(f"\n[bold]Install DAF_AGENTS.md to workspace?[/bold]")
-                        console.print(f"[dim]This will copy the bundled DAF_AGENTS.md to: {cs_agents_workspace}[/dim]")
-                        should_install = Confirm.ask("Install DAF_AGENTS.md to workspace?", default=True)
-                    else:
-                        console.print(f"[dim]Mock mode: Auto-installing DAF_AGENTS.md to {cs_agents_workspace}[/dim]")
+        from devflow.utils import is_mock_mode
+        mock_mode = is_mock_mode()
 
-                    if not should_install:
-                        console.print(f"\n[yellow]Cannot continue without DAF_AGENTS.md[/yellow]")
-                        console.print(f"\n[bold]Manual installation:[/bold]")
-                        console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {workspace_path}/")
-                        console.print(f"\nSee: https://github.com/itdove/devaiflow/blob/main/docs/02-installation.md")
-                        return False
+        should_install = True
+        if not mock_mode:
+            console.print(f"\n[bold]Install DAF_AGENTS.md to DEVAIFLOW_HOME?[/bold]")
+            console.print(f"[dim]This will copy the bundled DAF_AGENTS.md to: {daf_agents_home}[/dim]")
+            console.print(f"[dim]Recommended: Centralized location for all projects[/dim]")
+            should_install = Confirm.ask("Install DAF_AGENTS.md to DEVAIFLOW_HOME?", default=True)
+        else:
+            console.print(f"[dim]Mock mode: Auto-installing DAF_AGENTS.md to {daf_agents_home}[/dim]")
 
-                    # Install bundled DAF_AGENTS.md to workspace
-                    success, diagnostics = _install_bundled_cs_agents(cs_agents_workspace)
-                    if success:
-                        console.print(f"[green]✓ Installed DAF_AGENTS.md to workspace[/green]")
-                        console.print(f"[dim]  Location: {cs_agents_workspace}[/dim]")
-                        return True
-                    else:
-                        console.print(f"\n[red]✗ Failed to install DAF_AGENTS.md[/red]")
-                        if diagnostics:
-                            console.print(f"\n[yellow]Debug information:[/yellow]")
-                            for diag in diagnostics:
-                                console.print(f"[dim]{diag}[/dim]")
-                        console.print(f"\n[bold]Manual installation:[/bold]")
-                        console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {workspace_path}/")
-                        console.print(f"\nSee: https://github.com/itdove/devaiflow/blob/main/docs/02-installation.md")
-                        return False
+        if not should_install:
+            console.print(f"\n[yellow]Cannot continue without DAF_AGENTS.md[/yellow]")
+            console.print(f"\n[bold]Manual installation:[/bold]")
+            console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {cs_home}/")
+            console.print(f"\nSee: https://github.com/itdove/devaiflow/blob/main/docs/02-installation.md")
+            return False
 
-        # No workspace configured for temp session
-        console.print(f"\n[red]✗ Cannot proceed without workspace configured[/red]")
-        console.print(f"[dim]Temporary directory sessions require workspace to be configured[/dim]")
-        console.print(f"[dim]Run: daf config tui[/dim]")
-        return False
+        # Install bundled DAF_AGENTS.md to DEVAIFLOW_HOME
+        success, diagnostics = _install_bundled_cs_agents(daf_agents_home)
+        if success:
+            console.print(f"[green]✓ Installed DAF_AGENTS.md to DEVAIFLOW_HOME[/green]")
+            console.print(f"[dim]  Location: {daf_agents_home}[/dim]")
+            return True
+        else:
+            console.print(f"\n[red]✗ Failed to install DAF_AGENTS.md[/red]")
+            if diagnostics:
+                console.print(f"\n[yellow]Debug information:[/yellow]")
+                for diag in diagnostics:
+                    console.print(f"[dim]{diag}[/dim]")
+            console.print(f"\n[bold]Manual installation:[/bold]")
+            console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {cs_home}/")
+            console.print(f"\nSee: https://github.com/itdove/devaiflow/blob/main/docs/02-installation.md")
+            return False
 
-    # Multi-project session: check workspace directory only
+    # Multi-project session: check DEVAIFLOW_HOME first, then workspace
     # (Claude launches from workspace root for multi-project sessions)
     if active_conv and active_conv.is_multi_project:
+        # Check DEVAIFLOW_HOME first (centralized location)
+        from devflow.utils.paths import get_cs_home
+        cs_home = get_cs_home()
+        daf_agents_home = cs_home / "DAF_AGENTS.md"
+
+        if daf_agents_home.exists():
+            console.print(f"[dim]✓ Found DAF_AGENTS.md in DEVAIFLOW_HOME (centralized, multi-project)[/dim]")
+            console.print(f"[dim]  Location: {daf_agents_home}[/dim]")
+            # Check if upgrade is needed
+            if not _check_and_upgrade_daf_agents(daf_agents_home, "DEVAIFLOW_HOME"):
+                return False
+            return True
+
+        # Check workspace as fallback for backward compatibility
         workspace_path_from_session = active_conv.workspace_path
         if workspace_path_from_session:
             workspace_path = Path(workspace_path_from_session).expanduser()
@@ -290,36 +315,38 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
                     return False
                 return True
 
-            # Not found in workspace - offer to install there
-            console.print(f"\n[yellow]⚠ DAF_AGENTS.md not found in workspace[/yellow]")
+            # Not found - offer to install to DEVAIFLOW_HOME (recommended location)
+            console.print(f"\n[yellow]⚠ DAF_AGENTS.md not found[/yellow]")
             console.print(f"\n[dim]DAF_AGENTS.md provides daf tool usage instructions to Claude.[/dim]")
-            console.print(f"\nSearched location:")
-            console.print(f"  Workspace: {cs_agents_workspace}")
-            console.print(f"\n[dim]Note: Multi-project sessions use workspace-level DAF_AGENTS.md[/dim]")
+            console.print(f"\nSearched locations:")
+            console.print(f"  1. DEVAIFLOW_HOME: {daf_agents_home}")
+            console.print(f"  2. Workspace:      {cs_agents_workspace}")
+            console.print(f"\n[dim]Note: Multi-project sessions use DEVAIFLOW_HOME for centralized management[/dim]")
 
             from devflow.utils import is_mock_mode
             mock_mode = is_mock_mode()
 
             should_install = True
             if not mock_mode:
-                console.print(f"\n[bold]Install DAF_AGENTS.md to workspace?[/bold]")
-                console.print(f"[dim]This will copy the bundled DAF_AGENTS.md to: {cs_agents_workspace}[/dim]")
-                should_install = Confirm.ask("Install DAF_AGENTS.md to workspace?", default=True)
+                console.print(f"\n[bold]Install DAF_AGENTS.md to DEVAIFLOW_HOME?[/bold]")
+                console.print(f"[dim]This will copy the bundled DAF_AGENTS.md to: {daf_agents_home}[/dim]")
+                console.print(f"[dim]Recommended: Centralized location for all projects[/dim]")
+                should_install = Confirm.ask("Install DAF_AGENTS.md to DEVAIFLOW_HOME?", default=True)
             else:
-                console.print(f"[dim]Mock mode: Auto-installing DAF_AGENTS.md to {cs_agents_workspace}[/dim]")
+                console.print(f"[dim]Mock mode: Auto-installing DAF_AGENTS.md to {daf_agents_home}[/dim]")
 
             if not should_install:
                 console.print(f"\n[yellow]Cannot continue without DAF_AGENTS.md[/yellow]")
                 console.print(f"\n[bold]Manual installation:[/bold]")
-                console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {workspace_path}/")
+                console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {cs_home}/")
                 console.print(f"\nSee: https://github.com/itdove/devaiflow/blob/main/docs/02-installation.md")
                 return False
 
-            # Install bundled DAF_AGENTS.md to workspace
-            success, diagnostics = _install_bundled_cs_agents(cs_agents_workspace)
+            # Install bundled DAF_AGENTS.md to DEVAIFLOW_HOME
+            success, diagnostics = _install_bundled_cs_agents(daf_agents_home)
             if success:
-                console.print(f"[green]✓ Installed DAF_AGENTS.md to workspace[/green]")
-                console.print(f"[dim]  Location: {cs_agents_workspace}[/dim]")
+                console.print(f"[green]✓ Installed DAF_AGENTS.md to DEVAIFLOW_HOME[/green]")
+                console.print(f"[dim]  Location: {daf_agents_home}[/dim]")
                 return True
             else:
                 console.print(f"\n[red]✗ Failed to install DAF_AGENTS.md[/red]")
@@ -328,7 +355,7 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
                     for diag in diagnostics:
                         console.print(f"[dim]{diag}[/dim]")
                 console.print(f"\n[bold]Manual installation:[/bold]")
-                console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {workspace_path}/")
+                console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {cs_home}/")
                 console.print(f"\nSee: https://github.com/itdove/devaiflow/blob/main/docs/02-installation.md")
                 return False
 
@@ -336,23 +363,37 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
         console.print(f"\n[red]✗ Multi-project session missing workspace_path[/red]")
         return False
 
-    # Normal single-project session: check repository directory first, then workspace
+    # Normal single-project session: check DEVAIFLOW_HOME first, then repository, then workspace
     project_path = active_conv.project_path if active_conv else None
     if not project_path:
         return False
 
+    # Check DEVAIFLOW_HOME first (centralized location, recommended)
+    from devflow.utils.paths import get_cs_home
+    cs_home = get_cs_home()
+    daf_agents_home = cs_home / "DAF_AGENTS.md"
+
+    if daf_agents_home.exists():
+        console.print(f"[dim]✓ Found DAF_AGENTS.md in DEVAIFLOW_HOME (centralized)[/dim]")
+        console.print(f"[dim]  Location: {daf_agents_home}[/dim]")
+        # Check if upgrade is needed
+        if not _check_and_upgrade_daf_agents(daf_agents_home, "DEVAIFLOW_HOME"):
+            return False
+        return True
+
+    # Check repository directory (project-specific, backward compatibility)
     repo_path = Path(project_path)
     cs_agents_repo = repo_path / "DAF_AGENTS.md"
 
-    # Check repository directory first
     if cs_agents_repo.exists():
-        console.print(f"[dim]✓ Found DAF_AGENTS.md in repository[/dim]")
+        console.print(f"[dim]✓ Found DAF_AGENTS.md in repository (project-specific)[/dim]")
+        console.print(f"[dim]  Location: {cs_agents_repo}[/dim]")
         # Check if upgrade is needed
         if not _check_and_upgrade_daf_agents(cs_agents_repo, "repository"):
             return False
         return True
 
-    # Check workspace directory as fallback
+    # Check workspace directory as fallback (backward compatibility)
     config = config_loader.load_config()
     if config and config.repos and config.repos.get_default_workspace_path():
         workspace_path = config.repos.get_default_workspace_path()
@@ -372,13 +413,14 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
                 return False
             return True
 
-    # Not found - offer to install bundled DAF_AGENTS.md
+    # Not found - offer to install bundled DAF_AGENTS.md to DEVAIFLOW_HOME (recommended)
     console.print(f"\n[yellow]⚠ DAF_AGENTS.md not found[/yellow]")
     console.print(f"\n[dim]DAF_AGENTS.md provides daf tool usage instructions to Claude.[/dim]")
     console.print(f"\nSearched locations:")
-    console.print(f"  1. Repository: {cs_agents_repo}")
+    console.print(f"  1. DEVAIFLOW_HOME: {daf_agents_home}")
+    console.print(f"  2. Repository:     {cs_agents_repo}")
     if config and config.repos and config.repos.get_default_workspace_path():
-        console.print(f"  2. Workspace:  {cs_agents_workspace}")
+        console.print(f"  3. Workspace:      {cs_agents_workspace}")
 
     # Offer to install bundled DAF_AGENTS.md
     # In mock mode, auto-install without prompting
@@ -387,28 +429,31 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
 
     should_install = True
     if not mock_mode:
-        console.print(f"\n[bold]Install DAF_AGENTS.md now?[/bold]")
-        console.print(f"[dim]This will copy the bundled DAF_AGENTS.md to: {cs_agents_repo}[/dim]")
-        should_install = Confirm.ask("Install DAF_AGENTS.md to repository?", default=True)
+        console.print(f"\n[bold]Install DAF_AGENTS.md to DEVAIFLOW_HOME?[/bold]")
+        console.print(f"[dim]This will copy the bundled DAF_AGENTS.md to: {daf_agents_home}[/dim]")
+        console.print(f"[dim]Recommended: Centralized location for all projects[/dim]")
+        should_install = Confirm.ask("Install DAF_AGENTS.md to DEVAIFLOW_HOME?", default=True)
     else:
-        console.print(f"[dim]Mock mode: Auto-installing DAF_AGENTS.md to {cs_agents_repo}[/dim]")
+        console.print(f"[dim]Mock mode: Auto-installing DAF_AGENTS.md to {daf_agents_home}[/dim]")
 
     if not should_install:
         console.print(f"\n[yellow]Cannot continue without DAF_AGENTS.md[/yellow]")
         console.print(f"\n[bold]Manual installation options:[/bold]")
-        console.print(f"\n  Option 1: Copy to repository (project-specific)")
+        console.print(f"\n  Option 1: Copy to DEVAIFLOW_HOME (recommended, centralized)")
+        console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {cs_home}/")
+        console.print(f"\n  Option 2: Copy to repository (project-specific)")
         console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {repo_path}/")
-        console.print(f"\n  Option 2: Copy to workspace (shared across all projects)")
+        console.print(f"\n  Option 3: Copy to workspace (shared across all projects)")
         if config and config.repos and config.repos.get_default_workspace_path():
             console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {workspace_path}/")
         console.print(f"\nSee: https://github.com/itdove/devaiflow/blob/main/docs/02-installation.md")
         return False
 
-    # Install bundled DAF_AGENTS.md to repository
-    success, diagnostics = _install_bundled_cs_agents(cs_agents_repo)
+    # Install bundled DAF_AGENTS.md to DEVAIFLOW_HOME
+    success, diagnostics = _install_bundled_cs_agents(daf_agents_home)
     if success:
-        console.print(f"[green]✓ Installed DAF_AGENTS.md to repository[/green]")
-        console.print(f"[dim]  Location: {cs_agents_repo}[/dim]")
+        console.print(f"[green]✓ Installed DAF_AGENTS.md to DEVAIFLOW_HOME[/green]")
+        console.print(f"[dim]  Location: {daf_agents_home}[/dim]")
         console.print(f"\n[dim]You can customize DAF_AGENTS.md for your organization's needs.[/dim]")
         console.print(f"[dim]See: docs/02-installation.md#customizing-for-your-organization[/dim]")
         return True
@@ -426,9 +471,11 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
         console.print(f"  • File permissions issue")
 
         console.print(f"\n[bold]Manual installation options:[/bold]")
-        console.print(f"\n  Option 1: Copy to repository (project-specific)")
+        console.print(f"\n  Option 1: Copy to DEVAIFLOW_HOME (recommended, centralized)")
+        console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {cs_home}/")
+        console.print(f"\n  Option 2: Copy to repository (project-specific)")
         console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {repo_path}/")
-        console.print(f"\n  Option 2: Copy to workspace (shared across all projects)")
+        console.print(f"\n  Option 3: Copy to workspace (shared across all projects)")
         if config and config.repos and config.repos.get_default_workspace_path():
             console.print(f"    cp /path/to/devaiflow/DAF_AGENTS.md {workspace_path}/")
         console.print(f"\nSee: https://github.com/itdove/devaiflow/blob/main/docs/02-installation.md")

--- a/tests/test_context_files.py
+++ b/tests/test_context_files.py
@@ -1,0 +1,100 @@
+"""Tests for hierarchical context files loading."""
+
+import pytest
+from pathlib import Path
+from devflow.utils.context_files import load_hierarchical_context_files
+from devflow.utils.paths import get_cs_home
+
+
+def test_load_hierarchical_context_files_empty(temp_daf_home):
+    """Test loading context files when none exist."""
+    # With temp_daf_home fixture, DEVAIFLOW_HOME is empty
+    context_files = load_hierarchical_context_files()
+
+    # Should return empty list when no files exist
+    assert context_files == []
+
+
+def test_load_hierarchical_context_files_with_daf_agents(temp_daf_home):
+    """Test that DAF_AGENTS.md is loaded when it exists in DEVAIFLOW_HOME."""
+    cs_home = get_cs_home()
+
+    # Create DAF_AGENTS.md
+    daf_agents_path = cs_home / "DAF_AGENTS.md"
+    daf_agents_path.write_text("# DAF Tool Usage Guide")
+
+    # Load context files
+    context_files = load_hierarchical_context_files()
+
+    # Should find DAF_AGENTS.md
+    assert len(context_files) == 1
+    path, description = context_files[0]
+    assert path == str(daf_agents_path)
+    assert description == "daf tool usage guide"
+
+
+def test_load_hierarchical_context_files_all_files(temp_daf_home):
+    """Test loading all hierarchical context files."""
+    cs_home = get_cs_home()
+
+    # Create all context files
+    (cs_home / "backends").mkdir(parents=True, exist_ok=True)
+    (cs_home / "backends" / "JIRA.md").write_text("# JIRA Backend")
+    (cs_home / "ENTERPRISE.md").write_text("# Enterprise")
+    (cs_home / "ORGANIZATION.md").write_text("# Organization")
+    (cs_home / "TEAM.md").write_text("# Team")
+    (cs_home / "USER.md").write_text("# User")
+    (cs_home / "DAF_AGENTS.md").write_text("# DAF Agents")
+
+    # Load context files
+    context_files = load_hierarchical_context_files()
+
+    # Should find all 6 files
+    assert len(context_files) == 6
+
+    # Verify all expected descriptions are present
+    descriptions = [desc for _, desc in context_files]
+    assert "JIRA backend integration rules" in descriptions
+    assert "enterprise-wide policies and standards" in descriptions
+    assert "organization coding standards" in descriptions
+    assert "team conventions and workflows" in descriptions
+    assert "personal notes and preferences" in descriptions
+    assert "daf tool usage guide" in descriptions
+
+
+def test_load_hierarchical_context_files_order(temp_daf_home):
+    """Test that context files are loaded in the expected order."""
+    cs_home = get_cs_home()
+
+    # Create files in random order
+    (cs_home / "USER.md").write_text("# User")
+    (cs_home / "DAF_AGENTS.md").write_text("# DAF Agents")
+    (cs_home / "ENTERPRISE.md").write_text("# Enterprise")
+
+    # Load context files
+    context_files = load_hierarchical_context_files()
+
+    # Should be in hierarchical order: backends, enterprise, organization, team, user, daf_agents
+    descriptions = [desc for _, desc in context_files]
+
+    # Verify order (only the ones that exist)
+    assert descriptions[0] == "enterprise-wide policies and standards"  # ENTERPRISE.md
+    assert descriptions[1] == "personal notes and preferences"  # USER.md
+    assert descriptions[2] == "daf tool usage guide"  # DAF_AGENTS.md
+
+
+def test_load_hierarchical_context_files_skip_directories(temp_daf_home):
+    """Test that directories are skipped (only files are loaded)."""
+    cs_home = get_cs_home()
+
+    # Create a directory with the same name as a context file
+    (cs_home / "DAF_AGENTS.md").mkdir()
+    (cs_home / "ENTERPRISE.md").write_text("# Enterprise")
+
+    # Load context files
+    context_files = load_hierarchical_context_files()
+
+    # Should only find ENTERPRISE.md (DAF_AGENTS.md is a directory, not a file)
+    assert len(context_files) == 1
+    _, description = context_files[0]
+    assert description == "enterprise-wide policies and standards"

--- a/tests/test_daf_agents_validation.py
+++ b/tests/test_daf_agents_validation.py
@@ -130,6 +130,7 @@ def test_validate_daf_agents_auto_install_success(tmp_path, temp_daf_home, monke
     """Test successful auto-installation of bundled DAF_AGENTS.md."""
     from devflow.config.loader import ConfigLoader
     from unittest.mock import MagicMock
+    from devflow.utils.paths import get_cs_home
 
     # Mock Confirm.ask to return True (user accepts installation)
     mock_confirm = MagicMock(return_value=True)
@@ -165,13 +166,14 @@ def test_validate_daf_agents_auto_install_success(tmp_path, temp_daf_home, monke
     # Should auto-install DAF_AGENTS.md and succeed
     session = _create_mock_session(str(repo_dir))
 
-    
+
 
     result = validate_daf_agents_md(session, config_loader)
     assert result is True
 
-    # Verify DAF_AGENTS.md was created
-    assert (repo_dir / "DAF_AGENTS.md").exists()
+    # Verify DAF_AGENTS.md was created in DEVAIFLOW_HOME (new behavior)
+    cs_home = get_cs_home()
+    assert (cs_home / "DAF_AGENTS.md").exists()
 
     # Verify Confirm was called
     assert mock_confirm.called
@@ -629,6 +631,7 @@ def test_validate_daf_agents_multi_project_session_not_found(tmp_path, temp_daf_
     from devflow.config.models import Conversation, ProjectInfo
     from devflow.config.models import Session
     from unittest.mock import MagicMock
+    from devflow.utils.paths import get_cs_home
     import uuid
 
     # Mock Confirm.ask to return True (user accepts installation)
@@ -682,12 +685,13 @@ def test_validate_daf_agents_multi_project_session_not_found(tmp_path, temp_daf_
 
     config_loader = ConfigLoader()
 
-    # Should offer to install DAF_AGENTS.md to workspace
+    # Should offer to install DAF_AGENTS.md to DEVAIFLOW_HOME (new behavior)
     result = validate_daf_agents_md(session, config_loader)
     assert result is True
 
-    # Verify DAF_AGENTS.md was created in workspace
-    assert (workspace / "DAF_AGENTS.md").exists()
+    # Verify DAF_AGENTS.md was created in DEVAIFLOW_HOME (new behavior)
+    cs_home = get_cs_home()
+    assert (cs_home / "DAF_AGENTS.md").exists()
 
     # Verify Confirm was called
     assert mock_confirm.called
@@ -759,4 +763,126 @@ def test_validate_daf_agents_multi_project_session_user_declines(tmp_path, temp_
     assert not (workspace / "DAF_AGENTS.md").exists()
 
     # Verify Confirm was called
+    assert mock_confirm.called
+
+
+def test_validate_daf_agents_devaiflow_home_priority_over_repo(tmp_path, temp_daf_home):
+    """Test that DEVAIFLOW_HOME is checked before repository."""
+    from devflow.config.loader import ConfigLoader
+    from devflow.utils.paths import get_cs_home
+
+    # Create DEVAIFLOW_HOME with up-to-date DAF_AGENTS.md
+    cs_home = get_cs_home()
+    bundled_content, _ = _get_bundled_daf_agents_content()
+    (cs_home / "DAF_AGENTS.md").write_text(bundled_content)
+
+    # Create repo with DIFFERENT (older) DAF_AGENTS.md
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repo_dir = workspace / "test-repo"
+    repo_dir.mkdir()
+    (repo_dir / "DAF_AGENTS.md").write_text("# Old Repository Version")
+
+    # Create config
+    config_loader = ConfigLoader()
+    config = config_loader.create_default_config()
+    from devflow.config.models import WorkspaceDefinition
+    config.repos.workspaces = [
+        WorkspaceDefinition(name="default", path=str(workspace))
+    ]
+    config.repos.last_used_workspace = "default"
+    config_loader.save_config(config)
+
+    session = _create_mock_session(str(repo_dir))
+
+    # Should find DEVAIFLOW_HOME version (not repository version)
+    result = validate_daf_agents_md(session, config_loader)
+    assert result is True
+
+    # Repository file should still have old content (wasn't used)
+    assert (repo_dir / "DAF_AGENTS.md").read_text() == "# Old Repository Version"
+
+
+def test_validate_daf_agents_devaiflow_home_priority_over_workspace(tmp_path, temp_daf_home):
+    """Test that DEVAIFLOW_HOME is checked before workspace."""
+    from devflow.config.loader import ConfigLoader
+    from devflow.utils.paths import get_cs_home
+
+    # Create DEVAIFLOW_HOME with up-to-date DAF_AGENTS.md
+    cs_home = get_cs_home()
+    bundled_content, _ = _get_bundled_daf_agents_content()
+    (cs_home / "DAF_AGENTS.md").write_text(bundled_content)
+
+    # Create workspace with DIFFERENT (older) DAF_AGENTS.md
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "DAF_AGENTS.md").write_text("# Old Workspace Version")
+
+    # Create repo WITHOUT DAF_AGENTS.md
+    repo_dir = workspace / "test-repo"
+    repo_dir.mkdir()
+
+    # Create config
+    config_loader = ConfigLoader()
+    config = config_loader.create_default_config()
+    from devflow.config.models import WorkspaceDefinition
+    config.repos.workspaces = [
+        WorkspaceDefinition(name="default", path=str(workspace))
+    ]
+    config.repos.last_used_workspace = "default"
+    config_loader.save_config(config)
+
+    session = _create_mock_session(str(repo_dir))
+
+    # Should find DEVAIFLOW_HOME version (not workspace version)
+    result = validate_daf_agents_md(session, config_loader)
+    assert result is True
+
+    # Workspace file should still have old content (wasn't used)
+    assert (workspace / "DAF_AGENTS.md").read_text() == "# Old Workspace Version"
+
+
+def test_validate_daf_agents_upgrade_devaiflow_home(tmp_path, temp_daf_home, monkeypatch):
+    """Test that upgrade detection works for DEVAIFLOW_HOME location."""
+    from devflow.config.loader import ConfigLoader
+    from devflow.utils.paths import get_cs_home
+    from unittest.mock import MagicMock
+
+    # Mock Confirm.ask to return True (user accepts upgrade)
+    mock_confirm = MagicMock(return_value=True)
+    monkeypatch.setattr("rich.prompt.Confirm.ask", mock_confirm)
+
+    # Create DEVAIFLOW_HOME with outdated DAF_AGENTS.md
+    cs_home = get_cs_home()
+    (cs_home / "DAF_AGENTS.md").write_text("# Old DEVAIFLOW_HOME Version")
+
+    # Create workspace and repo
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repo_dir = workspace / "test-repo"
+    repo_dir.mkdir()
+
+    # Create config
+    config_loader = ConfigLoader()
+    config = config_loader.create_default_config()
+    from devflow.config.models import WorkspaceDefinition
+    config.repos.workspaces = [
+        WorkspaceDefinition(name="default", path=str(workspace))
+    ]
+    config.repos.last_used_workspace = "default"
+    config_loader.save_config(config)
+
+    session = _create_mock_session(str(repo_dir))
+
+    # Should find, check, and upgrade DEVAIFLOW_HOME version
+    result = validate_daf_agents_md(session, config_loader)
+    assert result is True
+
+    # Verify upgrade was performed on DEVAIFLOW_HOME file
+    bundled_content, _ = _get_bundled_daf_agents_content()
+    new_content = (cs_home / "DAF_AGENTS.md").read_text()
+    assert new_content == bundled_content
+    assert "Old DEVAIFLOW_HOME Version" not in new_content
+
+    # Verify Confirm was called for upgrade
     assert mock_confirm.called


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://redhat.atlassian.net/browse/itdove/devaiflow#171>
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR refactors the DAF_AGENTS.md file lookup logic to prioritize the `DEVAIFLOW_HOME` directory for multi-project sessions. Previously, the agent configuration file lookup may not have consistently checked `DEVAIFLOW_HOME` first, which could cause issues in multi-project workflows where centralized configuration is needed.

The changes update both the core lookup logic in `devflow/utils/context_files.py` and the validation logic in `devflow/utils/daf_agents_validation.py` to ensure `DEVAIFLOW_HOME` is the primary location checked for `DAF_AGENTS.md`. Corresponding test coverage has been added/updated to verify the new lookup priority.

This enables better support for multi-project sessions where a single DAF_AGENTS.md configuration should be shared across multiple project repositories.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Set the `DEVAIFLOW_HOME` environment variable to a test directory (e.g., `export DEVAIFLOW_HOME=/tmp/test-devaiflow`)
3. Create a `DAF_AGENTS.md` file in the `DEVAIFLOW_HOME` directory
4. Initialize a multi-project DevAIFlow session
5. Verify that the application reads the `DAF_AGENTS.md` from `DEVAIFLOW_HOME` (check logs or behavior)
6. Test fallback behavior: remove `DAF_AGENTS.md` from `DEVAIFLOW_HOME` and verify the application handles the missing file appropriately
7. Run the updated test suite: `pytest tests/test_context_files.py tests/test_daf_agents_validation.py`

### Scenarios tested
- DAF_AGENTS.md present in DEVAIFLOW_HOME directory is correctly discovered and loaded
- Multi-project session correctly uses centralized DAF_AGENTS.md from DEVAIFLOW_HOME
- Validation logic correctly identifies DAF_AGENTS.md location priority
- All unit tests pass with the refactored lookup logic

## Deployment considerations
- [ ] This code change is ready for deployment on its own
- [x] This code change requires the following considerations before being deployed:
  - Ensure `DEVAIFLOW_HOME` environment variable is configured in deployment environments where multi-project sessions are used
  - If migrating from existing deployments, consider moving existing `DAF_AGENTS.md` files to the `DEVAIFLOW_HOME` directory
  - Document the new lookup priority for users: `DEVAIFLOW_HOME` is now the primary location for `DAF_AGENTS.md`