### PR TITLE
itdove/devaiflow#198: daf note command treats message as session identifier instead of note content

### DIFF
--- a/devflow/cli/commands/note_command.py
+++ b/devflow/cli/commands/note_command.py
@@ -26,6 +26,25 @@ def add_note(identifier: Optional[str] = None, note: Optional[str] = None, sync_
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)
 
+    # Import get_active_conversation for auto-detection
+    from devflow.cli.utils import get_active_conversation
+    import os
+
+    # Auto-detect active session if in Claude Code session
+    # When identifier is provided but note is None, check if we're in an active session
+    # If yes, treat identifier as note content (fix for issue #198)
+    if identifier and not note and not latest:
+        # Check if we're in an active Claude Code session
+        active_result = get_active_conversation(session_manager)
+        if active_result:
+            # We're in an active session - treat identifier as note content
+            session, conversation, working_dir = active_result
+            note = identifier
+            identifier = session.name
+            issue_display = f" ({session.issue_key})" if session.issue_key else ""
+            console.print(f"[dim]Using active session: {identifier}{issue_display}[/dim]")
+        # else: not in active session, keep identifier as session name (old behavior)
+
     # If no identifier or --latest flag, use most recent active session
     if not identifier or latest:
         all_sessions = session_manager.list_sessions()
@@ -40,8 +59,18 @@ def add_note(identifier: Optional[str] = None, note: Optional[str] = None, sync_
         console.print(f"[dim]Using session: {identifier}{issue_display}[/dim]")
 
     # Get session using common utility (handles multi-session selection)
-    session = get_session_with_prompt(session_manager, identifier)
+    session = get_session_with_prompt(session_manager, identifier, error_if_not_found=False)
     if not session:
+        console.print(f"[red]No session found for '{identifier}'[/red]")
+        # Provide helpful guidance based on context
+        if os.environ.get("AI_AGENT_SESSION_ID"):
+            console.print("[dim]Tip: When in a Claude Code session, use:[/dim]")
+            console.print("[dim]  daf note \"your note text\"[/dim]")
+        else:
+            console.print("[dim]Usage:[/dim]")
+            console.print("[dim]  daf note SESSION_ID \"note text\"          # Add note to specific session[/dim]")
+            console.print("[dim]  daf note \"note text\"                      # Add note to active session (when in Claude Code)[/dim]")
+            console.print("[dim]  daf note --latest \"note text\"            # Add note to most recent session[/dim]")
         import sys
         sys.exit(1)
 
@@ -113,7 +142,8 @@ def view_notes(identifier: Optional[str] = None, latest: bool = False) -> None:
     # Check if notes file exists
     if not notes_file.exists():
         console.print(f"[yellow]No notes found for session '{session.name}'[/yellow]")
-        console.print(f"[dim]Add notes using: daf note '{session.name}' 'Your note text'[/dim]")
+        console.print(f"[dim]Add notes using: daf note 'Your note text' (when in active session)[/dim]")
+        console.print(f"[dim]                 or daf note '{session.name}' 'Your note text'[/dim]")
         return
 
     # Read and display notes

--- a/devflow/cli_skills/daf-cli/SKILL.md
+++ b/devflow/cli_skills/daf-cli/SKILL.md
@@ -316,20 +316,25 @@ daf jira add-comment PROJ-12345 "Comment text" --json
 
 ### Using `daf note` (Local Notes)
 
-✅ **Now works inside Claude Code sessions!**
+✅ **Now works inside Claude Code sessions with auto-detection!**
 
 ```bash
-# Add a note to current session (works inside Claude sessions)
+# Add a note to current session (auto-detects when in Claude Code session)
+daf note "Completed API implementation"
+daf note "Refactored authentication module"
+
+# Add note to specific session
 daf note PROJ-12345 "Completed API implementation"
 daf note --latest "Refactored authentication module"
 
 # View existing session notes
+daf notes                     # Auto-detects current session
 daf notes PROJ-12345
 daf notes --latest
 daf notes PROJ-12345 --json
 
 # Add structured progress notes
-daf note PROJ-12345 "$(cat <<'EOF'
+daf note "$(cat <<'EOF'
 Progress Update:
 * Completed API endpoint implementation
 * Added unit tests for edge cases
@@ -337,6 +342,11 @@ Progress Update:
 EOF
 )"
 ```
+
+**How `daf note` auto-detection works:**
+- **Inside Claude Code session**: `daf note "message"` auto-detects the active session
+- **Outside Claude Code**: Use `daf note SESSION_ID "message"` or `daf note --latest "message"`
+- **Explicit session**: Always specify with `daf note SESSION_ID "message"`
 
 **What `daf note` does:**
 - Appends to local `sessions/<name>/notes.md` file

--- a/devflow/cli_skills/daf-notes/SKILL.md
+++ b/devflow/cli_skills/daf-notes/SKILL.md
@@ -57,7 +57,8 @@ Total: 3 notes
 
 **Related commands:**
 ```bash
-daf note PROJ-12345 "Add progress note"  # Add a note
-daf summary PROJ-12345     # View session summary with notes
-daf info PROJ-12345        # View session details
+daf note "Add progress note"              # Add note to active session (auto-detects)
+daf note PROJ-12345 "Add progress note"   # Add note to specific session
+daf summary PROJ-12345                    # View session summary with notes
+daf info PROJ-12345                       # View session details
 ```

--- a/tests/test_note_command.py
+++ b/tests/test_note_command.py
@@ -455,3 +455,92 @@ def test_add_note_multiple_notes_same_session(temp_daf_home):
     second_pos = content.index("Second note")
     third_pos = content.index("Third note")
     assert first_pos < second_pos < third_pos
+
+
+def test_add_note_auto_detects_active_session_with_message_only(temp_daf_home, monkeypatch):
+    """Test that 'daf note MESSAGE' auto-detects active session (fix for issue #198)."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session = session_manager.create_session(
+        name="active-session",
+        goal="Test auto-detection",
+        working_directory="test-dir",
+        project_path="/path/to/project",
+        ai_agent_session_id="uuid-active-123",
+    )
+
+    # Simulate being inside an AI agent session
+    monkeypatch.setenv("AI_AGENT_SESSION_ID", "uuid-active-123")
+
+    # Call with message only (no explicit session identifier)
+    # This should auto-detect the active session and treat the first arg as note content
+    add_note(identifier="My note message", note=None)
+
+    # Verify note was added to the active session
+    notes_file = config_loader.get_session_dir("active-session") / "notes.md"
+    assert notes_file.exists()
+    content = notes_file.read_text()
+    assert "My note message" in content
+
+
+def test_add_note_explicit_session_still_works(temp_daf_home, monkeypatch):
+    """Test that 'daf note SESSION MESSAGE' still works with explicit session."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session1 = session_manager.create_session(
+        name="session-1",
+        goal="First session",
+        working_directory="dir1",
+        project_path="/path1",
+        ai_agent_session_id="uuid-1",
+    )
+
+    session2 = session_manager.create_session(
+        name="session-2",
+        goal="Second session",
+        working_directory="dir2",
+        project_path="/path2",
+        ai_agent_session_id="uuid-2",
+    )
+
+    # Simulate being inside session-1
+    monkeypatch.setenv("AI_AGENT_SESSION_ID", "uuid-1")
+
+    # Explicitly add note to session-2 (not the active session)
+    add_note(identifier="session-2", note="Note for session 2")
+
+    # Verify note was added to session-2, not session-1
+    notes_file2 = config_loader.get_session_dir("session-2") / "notes.md"
+    assert notes_file2.exists()
+    content2 = notes_file2.read_text()
+    assert "Note for session 2" in content2
+
+    # Verify session-1 has no notes
+    notes_file1 = config_loader.get_session_dir("session-1") / "notes.md"
+    assert not notes_file1.exists()
+
+
+def test_add_note_message_only_outside_active_session_fails(temp_daf_home, monkeypatch):
+    """Test that 'daf note MESSAGE' fails with helpful error when not in active session."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session = session_manager.create_session(
+        name="test-session",
+        goal="Test session",
+        working_directory="test-dir",
+        project_path="/path/to/project",
+        ai_agent_session_id="uuid-test",
+    )
+
+    # Ensure we're NOT in an active session
+    monkeypatch.delenv("AI_AGENT_SESSION_ID", raising=False)
+
+    # Try to add note with message only (no active session)
+    # This should fail because "My note message" will be treated as session identifier
+    with pytest.raises(SystemExit) as exc_info:
+        add_note(identifier="My note message", note=None)
+    assert exc_info.value.code == 1
+    # Should show error that session "My note message" was not found


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://github.com/itdove/devaiflow/issues/198>
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR fixes a bug in the `daf note` command where the message parameter was being incorrectly treated as a session identifier instead of note content when executed within an active session context.

**Changes:**
- Added auto-detection logic to `daf note` command to automatically use the current active session when available
- Updated the command implementation to properly distinguish between message content and session identifiers
- Enhanced skill documentation (`daf-cli` and `daf-notes`) to reflect the improved behavior
- Added comprehensive test coverage for the auto-detection functionality

**Technical Details:**
When a user runs `daf note "message"` within an active session, the command now automatically associates the note with the current session without requiring explicit session ID specification. This eliminates the ambiguity that was causing messages to be misinterpreted as session identifiers.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Start a new daf session: `daf start <session-id>`
3. Run `daf note "This is a test note"` without specifying a session ID
4. Verify the note is created with the message "This is a test note" attached to the current session
5. Run `daf notes` to confirm the note appears in the active session's notes
6. Exit the session and attempt `daf note "message"` without an active session to verify proper error handling
7. Run the test suite: `pytest tests/test_note_command.py` to verify all test cases pass

### Scenarios tested
- Creating notes in an active session without explicit session ID specification
- Verifying note content is correctly stored as message text
- Confirming auto-detection works with the current session context
- Error handling when no active session exists

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: