### PR TITLE
fix(cli): update command references from github to git

### DIFF
--- a/devflow/cli/commands/git_create_command.py
+++ b/devflow/cli/commands/git_create_command.py
@@ -350,8 +350,8 @@ def git_create(
 
         # Show next steps
         console.print("\n[cyan]Next steps:[/cyan]")
-        console.print(f"  View: daf github view {issue_key}")
-        console.print(f"  Open session: daf github open {issue_key}")
+        console.print(f"  View: daf git view {issue_key}")
+        console.print(f"  Open session: daf git open {issue_key}")
 
     except IssueTrackerValidationError as e:
         console.print(f"[red]✗[/red] Validation error: {e}")

--- a/devflow/cli/commands/git_view_command.py
+++ b/devflow/cli/commands/git_view_command.py
@@ -134,7 +134,7 @@ def git_view(
         if not current_session_id:
             console.print("[red]✗[/red] Not in a DevAIFlow session")
             console.print("[dim]Run this command from within a Claude Code session opened via 'daf open'[/dim]")
-            console.print("[dim]Or provide an issue key: daf github view 123[/dim]")
+            console.print("[dim]Or provide an issue key: daf git view 123[/dim]")
             sys.exit(1)
 
         # Get session from ID
@@ -143,7 +143,7 @@ def git_view(
 
         if not session or not session.issue_key:
             console.print("[red]✗[/red] Current session has no GitHub issue associated")
-            console.print("[dim]Provide an issue key: daf github view 123[/dim]")
+            console.print("[dim]Provide an issue key: daf git view 123[/dim]")
             sys.exit(1)
 
         issue_key = session.issue_key


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR fixes inconsistent command references in the CLI where some locations referred to `daf github` instead of the correct `daf git` command. This was causing confusion and inconsistency in the command interface.

The changes update command references in the git create and git view commands to consistently use `daf git` throughout the codebase.

**Files modified:**
- `devflow/cli/commands/git_create_command.py` - Updated command references
- `devflow/cli/commands/git_view_command.py` - Updated command references

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run `daf git create` command and verify it executes correctly
3. Run `daf git view` command and verify it displays properly
4. Check help text for both commands to ensure references are correct
5. Search codebase for any remaining instances of `daf github` to confirm they've been updated
6. Verify error messages and output text use the correct command syntax

### Scenarios tested
- Executed `daf git create` command successfully
- Executed `daf git view` command successfully
- Verified command help text displays correct references
- Confirmed no remaining incorrect references in modified files

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: