### PR TITLE
itdove/devaiflow#211: AttributeError in 'daf session add-project': workspaces.get() called on list instead of dict

### DIFF
--- a/devflow/cli/commands/session_project_command.py
+++ b/devflow/cli/commands/session_project_command.py
@@ -48,10 +48,10 @@ def add_project_to_session(
         console.print("[red]✗[/red] No workspaces configured. Run [cyan]daf init[/cyan] first.")
         sys.exit(1)
 
-    workspace = config.repos.workspaces.get(workspace_name)
+    workspace = config.repos.get_workspace_by_name(workspace_name)
     if not workspace:
         console.print(f"[red]✗[/red] Workspace not found: {workspace_name}")
-        console.print(f"[dim]Available workspaces: {', '.join(config.repos.workspaces.keys())}[/dim]")
+        console.print(f"[dim]Available workspaces: {', '.join(w.name for w in config.repos.workspaces)}[/dim]")
         sys.exit(1)
 
     workspace_path = Path(workspace.path).expanduser().resolve()

--- a/tests/test_session_project_commands.py
+++ b/tests/test_session_project_commands.py
@@ -187,3 +187,201 @@ def test_remove_nonexistent_project_exits(temp_daf_home, tmp_path):
             project_name="nonexistent",
             force=True,
         )
+
+
+def test_add_project_workspace_lookup(temp_daf_home, tmp_path, monkeypatch):
+    """Test that add_project_to_session correctly looks up workspace by name.
+
+    This is a regression test for issue #211 where the code incorrectly
+    called .get() on config.repos.workspaces (a List) instead of using
+    config.repos.get_workspace_by_name().
+    """
+    from devflow.cli.commands.session_project_command import add_project_to_session
+    from devflow.config.models import (
+        WorkspaceDefinition,
+        ProjectInfo,
+        ConversationContext,
+        Conversation,
+        Config,
+        JiraConfig,
+        RepoConfig,
+    )
+
+    # Setup workspace directories
+    workspace_path = tmp_path / "test-workspace"
+    workspace_path.mkdir()
+    project1_path = workspace_path / "project1"
+    project1_path.mkdir()
+    project2_path = workspace_path / "project2"
+    project2_path.mkdir()
+
+    # Initialize git repos to avoid branch creation errors
+    (project1_path / ".git").mkdir()
+    (project2_path / ".git").mkdir()
+
+    # Create config with workspace (workspaces is a List, not dict)
+    config = Config(
+        jira=JiraConfig(url="https://jira.example.com", transitions={}),
+        repos=RepoConfig(
+            workspaces=[
+                WorkspaceDefinition(
+                    name="test-workspace",
+                    path=str(workspace_path),
+                )
+            ]
+        )
+    )
+
+    # Mock load_config on ConfigLoader class to return our test config
+    monkeypatch.setattr(ConfigLoader, 'load_config', lambda self: config)
+
+    # Create a multi-project session
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    # Create multi-project conversation context
+    conversation_context = ConversationContext(
+        ai_agent_session_id="uuid-test",
+        project_path=str(project1_path),
+        branch="main",
+        is_multi_project=True,
+        workspace_path=str(workspace_path),
+        projects={
+            "project1": ProjectInfo(
+                project_path=str(project1_path),
+                relative_path="project1",
+                branch="main",
+                base_branch="main",
+                repo_name="project1",
+            ),
+        }
+    )
+
+    # Create conversation container
+    conversation = Conversation(
+        active_session=conversation_context,
+        archived_sessions=[]
+    )
+
+    # Create session with multi-project conversation
+    session = session_manager.create_session(
+        name="test-workspace-lookup",
+        goal="Test workspace lookup",
+        working_directory="project1",
+        project_path=str(project1_path),
+        branch="main",
+        ai_agent_session_id="uuid-test",
+    )
+
+    # Replace the default conversation with our multi-project one
+    session.conversations["project1"] = conversation
+    session_manager.update_session(session)
+
+    # Mock branch creation to avoid interactive prompts
+    with patch('devflow.cli.commands.new_command._handle_branch_creation') as mock_branch:
+        mock_branch.return_value = ("main", "main")
+
+        # This should work without AttributeError
+        # Before fix: would fail with "AttributeError: 'list' object has no attribute 'get'"
+        add_project_to_session(
+            session_name="test-workspace-lookup",
+            project_names=["project2"],
+            workspace_name="test-workspace",
+            branch="main",
+        )
+
+    # Verify project was added
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+    session = session_manager.get_session("test-workspace-lookup")
+    assert len(session.active_conversation.projects) == 2
+    assert "project1" in session.active_conversation.projects
+    assert "project2" in session.active_conversation.projects
+
+
+def test_add_project_nonexistent_workspace(temp_daf_home, tmp_path, monkeypatch):
+    """Test that add_project_to_session fails gracefully with non-existent workspace.
+
+    This verifies that the error message correctly lists available workspaces
+    using the fixed syntax (not .keys() on a list).
+    """
+    from devflow.cli.commands.session_project_command import add_project_to_session
+    from devflow.config.models import (
+        WorkspaceDefinition,
+        ProjectInfo,
+        ConversationContext,
+        Conversation,
+        Config,
+        JiraConfig,
+        RepoConfig,
+    )
+
+    # Setup
+    workspace_path = tmp_path / "test-workspace"
+    workspace_path.mkdir()
+    project1_path = workspace_path / "project1"
+    project1_path.mkdir()
+
+    # Create config with workspace
+    config = Config(
+        jira=JiraConfig(url="https://jira.example.com", transitions={}),
+        repos=RepoConfig(
+            workspaces=[
+                WorkspaceDefinition(
+                    name="existing-workspace",
+                    path=str(workspace_path),
+                )
+            ]
+        )
+    )
+
+    # Mock load_config on ConfigLoader class to return our test config
+    monkeypatch.setattr(ConfigLoader, 'load_config', lambda self: config)
+
+    # Create a multi-project session
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    conversation_context = ConversationContext(
+        ai_agent_session_id="uuid-test",
+        project_path=str(project1_path),
+        branch="main",
+        is_multi_project=True,
+        workspace_path=str(workspace_path),
+        projects={
+            "project1": ProjectInfo(
+                project_path=str(project1_path),
+                relative_path="project1",
+                branch="main",
+                base_branch="main",
+                repo_name="project1",
+            ),
+        }
+    )
+
+    conversation = Conversation(
+        active_session=conversation_context,
+        archived_sessions=[]
+    )
+
+    session = session_manager.create_session(
+        name="test-bad-workspace",
+        goal="Test bad workspace",
+        working_directory="project1",
+        project_path=str(project1_path),
+        branch="main",
+        ai_agent_session_id="uuid-test",
+    )
+
+    session.conversations["project1"] = conversation
+    session_manager.update_session(session)
+
+    # Should exit when workspace doesn't exist
+    # Before fix: would fail with "AttributeError: 'list' object has no attribute 'keys'"
+    with pytest.raises(SystemExit):
+        add_project_to_session(
+            session_name="test-bad-workspace",
+            project_names=["project2"],
+            workspace_name="nonexistent-workspace",
+            branch="main",
+        )


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR fixes an `AttributeError` in the `daf session add-project` command where `workspaces.get()` was being called on a list object instead of a dictionary. 

The issue occurred because the code attempted to use the `.get()` method directly on the workspaces collection, which is a list. The fix refactors the workspace lookup to use the `get_workspace_by_name()` helper function, which properly iterates through the workspace list to find the matching workspace by name.

**Changes:**
- Updated `devflow/cli/commands/session_project_command.py` to use `get_workspace_by_name()` for workspace lookup
- Added test coverage in `tests/test_session_project_commands.py` to verify the fix

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Ensure you have a DevAIFlow session configuration with workspaces defined
3. Run `daf session add-project <project-name> --workspace <workspace-name>` with a valid workspace name
4. Verify the command completes successfully without an AttributeError
5. Run the test suite: `pytest tests/test_session_project_commands.py -v`
6. Verify all tests pass, including the new test cases for workspace lookup

### Scenarios tested
- Successfully adding a project to a session with a valid workspace name
- Proper workspace lookup using `get_workspace_by_name()` instead of direct `.get()` call on list
- Unit tests verify the refactored workspace lookup logic works correctly

## Deployment considerations
- [x] This code change is ready for deployment on its own