### PR TITLE
itdove/devaiflow#221: Add template-based model provider configuration to TUI

### DIFF
--- a/devflow/config/templates/__init__.py
+++ b/devflow/config/templates/__init__.py
@@ -1,0 +1,19 @@
+"""Model provider templates for DevAIFlow."""
+
+from .model_providers import (
+    ProviderTemplate,
+    AnthropicTemplate,
+    VertexAITemplate,
+    OpenRouterTemplate,
+    CustomServerTemplate,
+    get_template_registry,
+)
+
+__all__ = [
+    "ProviderTemplate",
+    "AnthropicTemplate",
+    "VertexAITemplate",
+    "OpenRouterTemplate",
+    "CustomServerTemplate",
+    "get_template_registry",
+]

--- a/devflow/config/templates/model_providers.py
+++ b/devflow/config/templates/model_providers.py
@@ -1,0 +1,423 @@
+"""Model provider templates for TUI configuration.
+
+This module provides template-based configuration for different AI model providers,
+making it easier for users to configure providers with provider-specific forms.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass
+class FormField:
+    """Represents a form field in a provider template."""
+
+    field_id: str
+    label: str
+    field_type: str  # "input", "select", "checkbox"
+    placeholder: str = ""
+    required: bool = False
+    default_value: Any = None
+    options: Optional[List[Tuple[str, str]]] = None  # For select fields
+    help_text: str = ""
+
+
+class ProviderTemplate(ABC):
+    """Base class for model provider templates."""
+
+    @abstractmethod
+    def get_name(self) -> str:
+        """Get template display name."""
+        pass
+
+    @abstractmethod
+    def get_description(self) -> str:
+        """Get description for template selection screen."""
+        pass
+
+    @abstractmethod
+    def get_template_id(self) -> str:
+        """Get unique template identifier."""
+        pass
+
+    @abstractmethod
+    def get_fields(self) -> List[FormField]:
+        """Get form fields for this provider."""
+        pass
+
+    @abstractmethod
+    def generate_config(self, form_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate profile configuration from form data.
+
+        Args:
+            form_data: Dictionary of field_id -> value from the form
+
+        Returns:
+            Profile configuration dictionary
+        """
+        pass
+
+    def validate(self, form_data: Dict[str, Any]) -> List[str]:
+        """Validate form data.
+
+        Args:
+            form_data: Dictionary of field_id -> value from the form
+
+        Returns:
+            List of validation error messages (empty if valid)
+        """
+        errors = []
+        for field in self.get_fields():
+            if field.required:
+                value = form_data.get(field.field_id, "")
+                if not value or (isinstance(value, str) and not value.strip()):
+                    errors.append(f"{field.label} is required")
+        return errors
+
+
+class AnthropicTemplate(ProviderTemplate):
+    """Template for Anthropic API configuration."""
+
+    def get_name(self) -> str:
+        return "Anthropic API (native)"
+
+    def get_description(self) -> str:
+        return "Use official Anthropic Claude API (requires API key)"
+
+    def get_template_id(self) -> str:
+        return "anthropic"
+
+    def get_fields(self) -> List[FormField]:
+        """Anthropic needs minimal configuration - most use env vars."""
+        return [
+            FormField(
+                field_id="profile_name",
+                label="Profile Name",
+                field_type="input",
+                placeholder="e.g., anthropic, claude-api",
+                required=True,
+                help_text="Unique name for this profile",
+            ),
+            FormField(
+                field_id="api_key",
+                label="API Key (optional)",
+                field_type="input",
+                placeholder="Leave empty to use ANTHROPIC_API_KEY env var",
+                required=False,
+                help_text="Anthropic API key - defaults to environment variable",
+            ),
+            FormField(
+                field_id="model_name",
+                label="Model Name (optional)",
+                field_type="input",
+                placeholder="e.g., claude-sonnet-4-5",
+                required=False,
+                help_text="Specific model to use - leave empty for default",
+            ),
+        ]
+
+    def generate_config(self, form_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate Anthropic profile configuration."""
+        config = {
+            "name": form_data["profile_name"],
+        }
+
+        # Only add optional fields if provided
+        if form_data.get("api_key"):
+            config["api_key"] = form_data["api_key"]
+        if form_data.get("model_name"):
+            config["model_name"] = form_data["model_name"]
+
+        return config
+
+
+class VertexAITemplate(ProviderTemplate):
+    """Template for Google Vertex AI configuration."""
+
+    def get_name(self) -> str:
+        return "Google Vertex AI"
+
+    def get_description(self) -> str:
+        return "Use Claude via Google Cloud Vertex AI (requires GCP project)"
+
+    def get_template_id(self) -> str:
+        return "vertex"
+
+    def get_fields(self) -> List[FormField]:
+        """Vertex AI needs GCP project and region."""
+        return [
+            FormField(
+                field_id="profile_name",
+                label="Profile Name",
+                field_type="input",
+                placeholder="e.g., vertex-prod, gcp-claude",
+                required=True,
+                help_text="Unique name for this profile",
+            ),
+            FormField(
+                field_id="vertex_project_id",
+                label="GCP Project ID",
+                field_type="input",
+                placeholder="your-gcp-project-id",
+                required=True,
+                help_text="Google Cloud Platform project ID",
+            ),
+            FormField(
+                field_id="vertex_region",
+                label="GCP Region",
+                field_type="select",
+                required=True,
+                default_value="us-east5",
+                options=self._get_vertex_regions(),
+                help_text="Region where Vertex AI Claude is available",
+            ),
+            FormField(
+                field_id="model_name",
+                label="Model Name (optional)",
+                field_type="input",
+                placeholder="e.g., claude-sonnet-4-5@20250929",
+                required=False,
+                help_text="Specific Claude model version",
+            ),
+        ]
+
+    def _get_vertex_regions(self) -> List[Tuple[str, str]]:
+        """Get list of Vertex AI regions supporting Claude."""
+        return [
+            ("US East (Virginia)", "us-east5"),
+            ("Europe West (Belgium)", "europe-west1"),
+            ("Europe West (London)", "europe-west2"),
+            ("Asia Southeast (Singapore)", "asia-southeast1"),
+        ]
+
+    def generate_config(self, form_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate Vertex AI profile configuration."""
+        config = {
+            "name": form_data["profile_name"],
+            "use_vertex": True,
+            "vertex_project_id": form_data["vertex_project_id"],
+            "vertex_region": form_data["vertex_region"],
+        }
+
+        if form_data.get("model_name"):
+            config["model_name"] = form_data["model_name"]
+
+        return config
+
+
+class OpenRouterTemplate(ProviderTemplate):
+    """Template for OpenRouter configuration."""
+
+    def get_name(self) -> str:
+        return "OpenRouter"
+
+    def get_description(self) -> str:
+        return "Access multiple models via OpenRouter (pay-per-use, very affordable)"
+
+    def get_template_id(self) -> str:
+        return "openrouter"
+
+    def get_fields(self) -> List[FormField]:
+        """OpenRouter needs API key and model selection."""
+        return [
+            FormField(
+                field_id="profile_name",
+                label="Profile Name",
+                field_type="input",
+                placeholder="e.g., openrouter-deepseek, openrouter-free",
+                required=True,
+                help_text="Unique name for this profile",
+            ),
+            FormField(
+                field_id="auth_token",
+                label="API Key",
+                field_type="input",
+                placeholder="Your OpenRouter API key",
+                required=True,
+                help_text="Get from openrouter.ai/keys",
+            ),
+            FormField(
+                field_id="model_name",
+                label="Model",
+                field_type="select",
+                required=True,
+                default_value="deepseek/deepseek-v3.2",
+                options=self._get_popular_models(),
+                help_text="Select model or choose Custom to enter manually",
+            ),
+            FormField(
+                field_id="custom_model",
+                label="Custom Model Name",
+                field_type="input",
+                placeholder="model/name",
+                required=False,
+                help_text="Only if you selected 'Custom' above",
+            ),
+            FormField(
+                field_id="base_url",
+                label="Base URL (optional)",
+                field_type="input",
+                placeholder="https://openrouter.ai/api",
+                required=False,
+                default_value="https://openrouter.ai/api",
+                help_text="Default is correct for most users",
+            ),
+        ]
+
+    def _get_popular_models(self) -> List[Tuple[str, str]]:
+        """Get list of popular OpenRouter models."""
+        return [
+            ("DeepSeek V3.2 ($0.28/M - cheapest)", "deepseek/deepseek-v3.2"),
+            ("Claude 3.5 Sonnet (high quality)", "anthropic/claude-3.5-sonnet"),
+            ("GPT-OSS 120B (free tier)", "openai/gpt-oss-120b:free"),
+            ("Custom (enter manually below)", "custom"),
+        ]
+
+    def generate_config(self, form_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate OpenRouter profile configuration."""
+        # Use custom model if "custom" was selected
+        model_name = form_data["model_name"]
+        if model_name == "custom":
+            model_name = form_data.get("custom_model", "")
+            if not model_name:
+                raise ValueError("Custom model name is required when 'Custom' is selected")
+
+        config = {
+            "name": form_data["profile_name"],
+            "base_url": form_data.get("base_url") or "https://openrouter.ai/api",
+            "auth_token": form_data["auth_token"],
+            "api_key": "",  # Empty string to disable ANTHROPIC_API_KEY
+            "model_name": model_name,
+        }
+
+        return config
+
+    def validate(self, form_data: Dict[str, Any]) -> List[str]:
+        """Validate OpenRouter configuration."""
+        errors = super().validate(form_data)
+
+        # Check if custom model is provided when needed
+        if form_data.get("model_name") == "custom":
+            if not form_data.get("custom_model", "").strip():
+                errors.append("Custom model name is required when 'Custom' is selected")
+
+        return errors
+
+
+class CustomServerTemplate(ProviderTemplate):
+    """Template for custom server configuration (llama.cpp, LM Studio, etc.)."""
+
+    def get_name(self) -> str:
+        return "llama.cpp / Custom Server"
+
+    def get_description(self) -> str:
+        return "Connect to local llama.cpp server or other custom API endpoint"
+
+    def get_template_id(self) -> str:
+        return "custom"
+
+    def get_fields(self) -> List[FormField]:
+        """Custom server needs URL and auth details."""
+        return [
+            FormField(
+                field_id="profile_name",
+                label="Profile Name",
+                field_type="input",
+                placeholder="e.g., llama-cpp, lmstudio, local-model",
+                required=True,
+                help_text="Unique name for this profile",
+            ),
+            FormField(
+                field_id="base_url",
+                label="Base URL",
+                field_type="input",
+                placeholder="http://localhost:8000",
+                required=True,
+                help_text="URL where your server is running",
+            ),
+            FormField(
+                field_id="auth_token",
+                label="Auth Token (optional)",
+                field_type="input",
+                placeholder="llama-cpp",
+                required=False,
+                help_text="Authentication token - use 'llama-cpp' for llama.cpp server",
+            ),
+            FormField(
+                field_id="api_key",
+                label="API Key (optional)",
+                field_type="input",
+                placeholder="Leave empty for local servers",
+                required=False,
+                help_text="Leave empty to disable ANTHROPIC_API_KEY env var",
+            ),
+            FormField(
+                field_id="model_name",
+                label="Model Name",
+                field_type="input",
+                placeholder="e.g., Qwen3-Coder",
+                required=True,
+                help_text="Model alias as configured in your server (--alias flag for llama.cpp)",
+            ),
+        ]
+
+    def generate_config(self, form_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate custom server profile configuration."""
+        config = {
+            "name": form_data["profile_name"],
+            "base_url": form_data["base_url"],
+            "model_name": form_data["model_name"],
+        }
+
+        # Add optional fields
+        if form_data.get("auth_token"):
+            config["auth_token"] = form_data["auth_token"]
+        if form_data.get("api_key"):
+            config["api_key"] = form_data["api_key"]
+
+        return config
+
+
+# Template Registry
+_TEMPLATE_REGISTRY: Dict[str, ProviderTemplate] = {
+    "anthropic": AnthropicTemplate(),
+    "vertex": VertexAITemplate(),
+    "openrouter": OpenRouterTemplate(),
+    "custom": CustomServerTemplate(),
+}
+
+
+def get_template_registry() -> Dict[str, ProviderTemplate]:
+    """Get the template registry.
+
+    Returns:
+        Dictionary mapping template_id -> ProviderTemplate instance
+    """
+    return _TEMPLATE_REGISTRY
+
+
+def detect_template_from_profile(profile_data: Dict[str, Any]) -> str:
+    """Detect which template a profile was created with.
+
+    Args:
+        profile_data: Profile configuration dictionary
+
+    Returns:
+        Template ID (one of: anthropic, vertex, openrouter, custom)
+    """
+    # Check for Vertex AI
+    if profile_data.get("use_vertex"):
+        return "vertex"
+
+    # Check for OpenRouter (has base_url pointing to openrouter.ai)
+    base_url = profile_data.get("base_url", "")
+    if "openrouter.ai" in base_url:
+        return "openrouter"
+
+    # Check for custom server (has base_url but not OpenRouter)
+    if base_url:
+        return "custom"
+
+    # Default to Anthropic
+    return "anthropic"

--- a/devflow/ui/config_tui.py
+++ b/devflow/ui/config_tui.py
@@ -44,6 +44,11 @@ from rich.text import Text
 
 from devflow.config.loader import ConfigLoader
 from devflow.config.models import Config, JiraTransitionConfig, ContextFile, WorkspaceDefinition
+from devflow.config.templates.model_providers import (
+    get_template_registry,
+    detect_template_from_profile,
+    FormField,
+)
 from devflow.jira.client import JiraClient
 from devflow.jira.utils import get_field_with_alias
 
@@ -1032,8 +1037,88 @@ class ModelProviderProfileEntry(Container):
             self.post_message(self.SetAsDefaultPressed(self.profile_name))
 
 
+class TemplateSelectionScreen(ModalScreen):
+    """Modal screen for selecting a provider template."""
+
+    DEFAULT_CSS = """
+    TemplateSelectionScreen {
+        align: center middle;
+    }
+
+    TemplateSelectionScreen > Container {
+        width: 80;
+        height: auto;
+        max-height: 80%;
+        background: $surface;
+        border: thick $primary;
+        padding: 1 2;
+    }
+
+    TemplateSelectionScreen .template-option {
+        height: auto;
+        margin: 1 0;
+        padding: 1;
+        border: solid $primary;
+    }
+
+    TemplateSelectionScreen .template-option:hover {
+        background: $primary 20%;
+    }
+
+    TemplateSelectionScreen .template-option Static {
+        width: 100%;
+    }
+
+    TemplateSelectionScreen Button {
+        margin: 0 1;
+    }
+
+    TemplateSelectionScreen .button-row {
+        width: 100%;
+        margin: 1 0 0 0;
+        align: center middle;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Cancel"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        """Compose template selection screen."""
+        with VerticalScroll():
+            with Container():
+                yield Static("[bold cyan]Select Provider Type[/bold cyan]\n")
+                yield Static(
+                    "Choose the type of model provider you want to configure.\n"
+                    "Each template provides a customized form for that provider.\n",
+                    classes="section-help"
+                )
+
+                # Get templates from registry
+                templates = get_template_registry()
+
+                # Display template options
+                for template_id, template in templates.items():
+                    with Container(classes="template-option", id=f"template_{template_id}"):
+                        yield Static(f"[bold]{template.get_name()}[/bold]")
+                        yield Static(f"[dim]{template.get_description()}[/dim]")
+                        yield Button("Select", variant="primary", id=f"select_{template_id}")
+
+                with Horizontal(classes="button-row"):
+                    yield Button("Cancel", variant="default", id="cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button press."""
+        if event.button.id == "cancel":
+            self.dismiss(None)
+        elif event.button.id.startswith("select_"):
+            template_id = event.button.id.replace("select_", "")
+            self.dismiss(template_id)
+
+
 class AddEditProfileScreen(ModalScreen):
-    """Modal screen for adding/editing a model provider profile."""
+    """Modal screen for adding/editing a model provider profile using templates."""
 
     DEFAULT_CSS = """
     AddEditProfileScreen {
@@ -1079,10 +1164,16 @@ class AddEditProfileScreen(ModalScreen):
         Binding("escape", "dismiss", "Cancel"),
     ]
 
-    def __init__(self, existing_name: Optional[str] = None, existing_profile: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        template_id: Optional[str] = None,
+        existing_name: Optional[str] = None,
+        existing_profile: Optional[Dict[str, Any]] = None
+    ):
         """Initialize add/edit profile screen.
 
         Args:
+            template_id: Template to use for new profiles
             existing_name: If provided, edit mode (profile name)
             existing_profile: Profile data being edited
         """
@@ -1091,178 +1182,121 @@ class AddEditProfileScreen(ModalScreen):
         self.existing_profile = existing_profile or {}
         self.is_edit_mode = existing_name is not None
 
+        # Detect template from existing profile or use provided template
+        if self.is_edit_mode:
+            self.template_id = detect_template_from_profile(self.existing_profile)
+        else:
+            self.template_id = template_id or "anthropic"
+
+        # Get the template instance
+        templates = get_template_registry()
+        self.template = templates.get(self.template_id)
+
     def compose(self) -> ComposeResult:
-        """Compose add/edit profile screen."""
+        """Compose add/edit profile screen using template fields."""
         with VerticalScroll():
             with Container():
-                title = f"Edit Profile: {self.existing_name}" if self.is_edit_mode else "Add Model Provider Profile"
+                # Title
+                if self.is_edit_mode:
+                    title = f"Edit Profile: {self.existing_name}"
+                else:
+                    title = f"Add {self.template.get_name()} Profile"
                 yield Static(f"[bold cyan]{title}[/bold cyan]\n")
 
-                # Profile Name (disabled in edit mode)
-                yield Label("Profile Name *")
-                yield Input(
-                    value=self.existing_name if self.existing_name else "",
-                    placeholder="e.g., llama-cpp, vertex-prod, openrouter",
-                    id="profile_name",
-                    disabled=self.is_edit_mode,
-                )
+                # Show provider type info
+                yield Static(f"[dim]Provider: {self.template.get_name()}[/dim]")
+                yield Static(f"[dim]{self.template.get_description()}[/dim]\n")
 
-                yield Static("[dim]Choose provider type:[/dim]", classes="section")
+                # Dynamically render fields from template
+                for field in self.template.get_fields():
+                    # Get existing value if in edit mode
+                    existing_value = ""
+                    if self.is_edit_mode:
+                        # Map field_id to existing profile data
+                        if field.field_id == "profile_name":
+                            existing_value = self.existing_name or ""
+                        else:
+                            existing_value = self.existing_profile.get(field.field_id, field.default_value or "")
 
-                # Provider Type Selection
-                provider_type = "anthropic"
-                if self.existing_profile.get("use_vertex"):
-                    provider_type = "vertex"
-                elif self.existing_profile.get("base_url"):
-                    provider_type = "custom"
+                    # Render label with required indicator
+                    label_text = field.label
+                    if field.required:
+                        label_text += " *"
+                    yield Label(label_text)
 
-                yield Label("Provider Type *")
-                yield Select(
-                    options=[
-                        ("Anthropic API (default)", "anthropic"),
-                        ("Google Vertex AI", "vertex"),
-                        ("Custom (llama.cpp, OpenRouter, etc.)", "custom"),
-                    ],
-                    value=provider_type,
-                    allow_blank=False,
-                    id="provider_type",
-                )
+                    # Render field based on type
+                    if field.field_type == "input":
+                        # Special handling for profile_name - disable in edit mode
+                        disabled = self.is_edit_mode and field.field_id == "profile_name"
+                        yield Input(
+                            value=str(existing_value) if existing_value else "",
+                            placeholder=field.placeholder,
+                            id=field.field_id,
+                            disabled=disabled,
+                        )
+                    elif field.field_type == "select":
+                        # Select field
+                        value = existing_value if existing_value else field.default_value
+                        yield Select(
+                            options=field.options or [],
+                            value=value,
+                            allow_blank=not field.required,
+                            id=field.field_id,
+                        )
+                    elif field.field_type == "checkbox":
+                        # Checkbox field
+                        yield Checkbox(
+                            field.label,
+                            value=bool(existing_value),
+                            id=field.field_id,
+                        )
 
-                # Vertex AI specific fields
-                with Vertical(id="vertex_fields", classes="section"):
-                    yield Static("[bold]Vertex AI Settings:[/bold]")
-                    yield Label("GCP Project ID *")
-                    yield Input(
-                        value=self.existing_profile.get("vertex_project_id") or "",
-                        placeholder="your-gcp-project-id",
-                        id="vertex_project_id",
-                    )
-                    yield Label("GCP Region *")
-                    # Get default from regions list (use first option)
-                    regions = _get_vertex_ai_regions()
-                    default_region = regions[0][1] if regions else "global"  # First region in list
-                    yield Select(
-                        options=regions,
-                        value=self.existing_profile.get("vertex_region") or default_region,
-                        allow_blank=False,
-                        id="vertex_region",
-                    )
+                    # Add help text if provided
+                    if field.help_text:
+                        yield Static(f"[dim italic]{field.help_text}[/dim italic]")
 
-                # Custom provider fields
-                with Vertical(id="custom_fields", classes="section"):
-                    yield Static("[bold]Custom Provider Settings:[/bold]")
-                    yield Label("Base URL *")
-                    yield Input(
-                        value=self.existing_profile.get("base_url") or "",
-                        placeholder="http://localhost:11434 or https://openrouter.ai/api",
-                        id="base_url",
-                    )
-                    yield Label("Auth Token")
-                    yield Input(
-                        value=self.existing_profile.get("auth_token") or "",
-                        placeholder="llama-cpp or your-api-key",
-                        id="auth_token",
-                    )
-                    yield Label("API Key")
-                    yield Input(
-                        value=self.existing_profile.get("api_key") or "",
-                        placeholder="Leave empty to disable (for local models)",
-                        id="api_key",
-                    )
-                    yield Label("Model Name")
-                    yield Input(
-                        value=self.existing_profile.get("model_name") or "",
-                        placeholder="devstral-small-2, gpt-oss-120b:free, etc.",
-                        id="model_name",
-                    )
-
+                # Buttons
                 with Horizontal(classes="button-row"):
                     save_label = "Update" if self.is_edit_mode else "Add"
                     yield Button(save_label, variant="success", id="save")
                     yield Button("Cancel", variant="default", id="cancel")
 
-    def on_mount(self) -> None:
-        """Called when screen is mounted - set initial field visibility."""
-        self._update_field_visibility()
-
-    def on_select_changed(self, event: Select.Changed) -> None:
-        """Handle provider type selection change."""
-        if event.select.id == "provider_type":
-            self._update_field_visibility()
-
-    def _update_field_visibility(self) -> None:
-        """Update field visibility based on provider type."""
-        try:
-            provider_select = self.query_one("#provider_type", Select)
-            provider_type = provider_select.value
-
-            vertex_fields = self.query_one("#vertex_fields", Vertical)
-            custom_fields = self.query_one("#custom_fields", Vertical)
-
-            if provider_type == "vertex":
-                vertex_fields.display = True
-                custom_fields.display = False
-            elif provider_type == "custom":
-                vertex_fields.display = False
-                custom_fields.display = True
-            else:  # anthropic
-                vertex_fields.display = False
-                custom_fields.display = False
-        except NoMatches:
-            pass  # Fields not yet mounted
-
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        """Handle button press."""
+        """Handle button press using template-based validation and config generation."""
         if event.button.id == "save":
-            name_input = self.query_one("#profile_name", Input)
-            provider_select = self.query_one("#provider_type", Select)
+            # Collect form data from all template fields
+            form_data = {}
+            for field in self.template.get_fields():
+                try:
+                    if field.field_type == "input":
+                        input_widget = self.query_one(f"#{field.field_id}", Input)
+                        form_data[field.field_id] = input_widget.value.strip()
+                    elif field.field_type == "select":
+                        select_widget = self.query_one(f"#{field.field_id}", Select)
+                        form_data[field.field_id] = select_widget.value
+                    elif field.field_type == "checkbox":
+                        checkbox_widget = self.query_one(f"#{field.field_id}", Checkbox)
+                        form_data[field.field_id] = checkbox_widget.value
+                except NoMatches:
+                    # Field not found - use default if available
+                    if field.default_value is not None:
+                        form_data[field.field_id] = field.default_value
 
-            name = name_input.value.strip()
-            provider_type = provider_select.value
-
-            # Validation
-            if not name:
-                self.app.notify("Profile name is required", severity="error")
+            # Validate form data using template
+            validation_errors = self.template.validate(form_data)
+            if validation_errors:
+                error_msg = "Validation errors:\n" + "\n".join(f"  • {err}" for err in validation_errors)
+                self.app.notify(error_msg, severity="error", timeout=10)
                 return
 
-            # Build profile data based on provider type
-            profile_data = {"name": name}
-
-            if provider_type == "vertex":
-                project_id = self.query_one("#vertex_project_id", Input).value.strip()
-                region = self.query_one("#vertex_region", Select).value
-
-                if not project_id:
-                    self.app.notify("GCP Project ID is required for Vertex AI", severity="error")
-                    return
-
-                profile_data.update({
-                    "use_vertex": True,
-                    "vertex_project_id": project_id,
-                    "vertex_region": region,
-                })
-
-            elif provider_type == "custom":
-                base_url = self.query_one("#base_url", Input).value.strip()
-                auth_token = self.query_one("#auth_token", Input).value.strip()
-                api_key = self.query_one("#api_key", Input).value.strip()
-                model_name = self.query_one("#model_name", Input).value.strip()
-
-                if not base_url:
-                    self.app.notify("Base URL is required for custom provider", severity="error")
-                    return
-
-                profile_data["base_url"] = base_url
-                if auth_token:
-                    profile_data["auth_token"] = auth_token
-                if api_key:
-                    profile_data["api_key"] = api_key
-                if model_name:
-                    profile_data["model_name"] = model_name
-
-            # For anthropic, just the name is enough (minimal profile)
-
-            self.dismiss((name, profile_data))
+            # Generate profile configuration from template
+            try:
+                profile_data = self.template.generate_config(form_data)
+                profile_name = form_data.get("profile_name", "")
+                self.dismiss((profile_name, profile_data))
+            except Exception as e:
+                self.app.notify(f"Error generating profile: {str(e)}", severity="error")
+                return
         else:
             self.dismiss(None)
 
@@ -2705,36 +2739,43 @@ class ConfigTUI(App):
             self.push_screen(AddEditWorkspaceScreen(), handle_add_workspace_result)
 
         elif event.button.id == "add_profile":
-            def handle_add_profile_result(result):
-                """Handle the result from the add profile screen."""
-                if result:
-                    profile_name, profile_data = result
+            def handle_template_selection(template_id):
+                """Handle template selection - show profile form with selected template."""
+                if template_id:
+                    def handle_add_profile_result(result):
+                        """Handle the result from the add profile screen."""
+                        if result:
+                            profile_name, profile_data = result
 
-                    # Initialize model_provider if it doesn't exist
-                    if not self.config.model_provider:
-                        from devflow.config.models import ModelProviderConfig
-                        self.config.model_provider = ModelProviderConfig(
-                            default_profile="anthropic",
-                            profiles={}
-                        )
+                            # Initialize model_provider if it doesn't exist
+                            if not self.config.model_provider:
+                                from devflow.config.models import ModelProviderConfig
+                                self.config.model_provider = ModelProviderConfig(
+                                    default_profile="anthropic",
+                                    profiles={}
+                                )
 
-                    # Check if profile name already exists
-                    if profile_name in self.config.model_provider.profiles:
-                        self.notify(f"Profile '{profile_name}' already exists", severity="error")
-                        return
+                            # Check if profile name already exists
+                            if profile_name in self.config.model_provider.profiles:
+                                self.notify(f"Profile '{profile_name}' already exists", severity="error")
+                                return
 
-                    # Convert dict to ModelProviderProfile object
-                    from devflow.config.models import ModelProviderProfile
-                    profile_obj = ModelProviderProfile(**profile_data)
+                            # Convert dict to ModelProviderProfile object
+                            from devflow.config.models import ModelProviderProfile
+                            profile_obj = ModelProviderProfile(**profile_data)
 
-                    # Add the new profile
-                    self.config.model_provider.profiles[profile_name] = profile_obj
+                            # Add the new profile
+                            self.config.model_provider.profiles[profile_name] = profile_obj
 
-                    self._refresh_profiles_list()
-                    self.notify(f"Added profile: {profile_name}", severity="information")
-                    self.modified = True
+                            self._refresh_profiles_list()
+                            self.notify(f"Added profile: {profile_name}", severity="information")
+                            self.modified = True
 
-            self.push_screen(AddEditProfileScreen(), handle_add_profile_result)
+                    # Show profile form with selected template
+                    self.push_screen(AddEditProfileScreen(template_id=template_id), handle_add_profile_result)
+
+            # First show template selection screen
+            self.push_screen(TemplateSelectionScreen(), handle_template_selection)
 
         elif event.button.id == "upgrade_commands":
             self._handle_upgrade_commands()

--- a/tests/test_model_provider_templates.py
+++ b/tests/test_model_provider_templates.py
@@ -1,0 +1,288 @@
+"""Tests for model provider templates."""
+
+import pytest
+from devflow.config.templates.model_providers import (
+    AnthropicTemplate,
+    VertexAITemplate,
+    OpenRouterTemplate,
+    CustomServerTemplate,
+    get_template_registry,
+    detect_template_from_profile,
+)
+
+
+class TestAnthropicTemplate:
+    """Tests for Anthropic template."""
+
+    def test_template_metadata(self):
+        """Test template metadata."""
+        template = AnthropicTemplate()
+        assert template.get_name() == "Anthropic API (native)"
+        assert template.get_template_id() == "anthropic"
+        assert "Anthropic" in template.get_description()
+
+    def test_get_fields(self):
+        """Test getting template fields."""
+        template = AnthropicTemplate()
+        fields = template.get_fields()
+
+        assert len(fields) == 3
+        field_ids = [f.field_id for f in fields]
+        assert "profile_name" in field_ids
+        assert "api_key" in field_ids
+        assert "model_name" in field_ids
+
+    def test_generate_config_minimal(self):
+        """Test generating minimal Anthropic config."""
+        template = AnthropicTemplate()
+        form_data = {
+            "profile_name": "my-anthropic",
+        }
+
+        config = template.generate_config(form_data)
+        assert config["name"] == "my-anthropic"
+        assert "api_key" not in config
+        assert "model_name" not in config
+
+    def test_generate_config_with_optional_fields(self):
+        """Test generating config with optional fields."""
+        template = AnthropicTemplate()
+        form_data = {
+            "profile_name": "my-anthropic",
+            "api_key": "sk-test-123",
+            "model_name": "claude-sonnet-4-5",
+        }
+
+        config = template.generate_config(form_data)
+        assert config["name"] == "my-anthropic"
+        assert config["api_key"] == "sk-test-123"
+        assert config["model_name"] == "claude-sonnet-4-5"
+
+    def test_validate_missing_required_field(self):
+        """Test validation with missing required field."""
+        template = AnthropicTemplate()
+        form_data = {}
+
+        errors = template.validate(form_data)
+        assert len(errors) > 0
+        assert any("Profile Name" in err for err in errors)
+
+    def test_validate_success(self):
+        """Test validation with all required fields."""
+        template = AnthropicTemplate()
+        form_data = {
+            "profile_name": "my-anthropic",
+        }
+
+        errors = template.validate(form_data)
+        assert len(errors) == 0
+
+
+class TestVertexAITemplate:
+    """Tests for Vertex AI template."""
+
+    def test_template_metadata(self):
+        """Test template metadata."""
+        template = VertexAITemplate()
+        assert template.get_name() == "Google Vertex AI"
+        assert template.get_template_id() == "vertex"
+        assert "Vertex AI" in template.get_description()
+
+    def test_get_fields(self):
+        """Test getting template fields."""
+        template = VertexAITemplate()
+        fields = template.get_fields()
+
+        field_ids = [f.field_id for f in fields]
+        assert "profile_name" in field_ids
+        assert "vertex_project_id" in field_ids
+        assert "vertex_region" in field_ids
+        assert "model_name" in field_ids
+
+    def test_generate_config(self):
+        """Test generating Vertex AI config."""
+        template = VertexAITemplate()
+        form_data = {
+            "profile_name": "vertex-prod",
+            "vertex_project_id": "my-gcp-project",
+            "vertex_region": "us-east5",
+        }
+
+        config = template.generate_config(form_data)
+        assert config["name"] == "vertex-prod"
+        assert config["use_vertex"] is True
+        assert config["vertex_project_id"] == "my-gcp-project"
+        assert config["vertex_region"] == "us-east5"
+
+    def test_generate_config_with_model(self):
+        """Test generating config with specific model."""
+        template = VertexAITemplate()
+        form_data = {
+            "profile_name": "vertex-prod",
+            "vertex_project_id": "my-gcp-project",
+            "vertex_region": "us-east5",
+            "model_name": "claude-sonnet-4-5@20250929",
+        }
+
+        config = template.generate_config(form_data)
+        assert config["model_name"] == "claude-sonnet-4-5@20250929"
+
+    def test_validate_missing_required_fields(self):
+        """Test validation with missing required fields."""
+        template = VertexAITemplate()
+        form_data = {
+            "profile_name": "vertex-prod",
+        }
+
+        errors = template.validate(form_data)
+        assert len(errors) > 0
+        assert any("GCP Project ID" in err for err in errors)
+
+
+class TestOpenRouterTemplate:
+    """Tests for OpenRouter template."""
+
+    def test_template_metadata(self):
+        """Test template metadata."""
+        template = OpenRouterTemplate()
+        assert template.get_name() == "OpenRouter"
+        assert template.get_template_id() == "openrouter"
+        assert "OpenRouter" in template.get_description()
+
+    def test_generate_config(self):
+        """Test generating OpenRouter config."""
+        template = OpenRouterTemplate()
+        form_data = {
+            "profile_name": "openrouter-deepseek",
+            "auth_token": "sk-or-123",
+            "model_name": "deepseek/deepseek-v3.2",
+        }
+
+        config = template.generate_config(form_data)
+        assert config["name"] == "openrouter-deepseek"
+        assert config["base_url"] == "https://openrouter.ai/api"
+        assert config["auth_token"] == "sk-or-123"
+        assert config["api_key"] == ""
+        assert config["model_name"] == "deepseek/deepseek-v3.2"
+
+    def test_generate_config_custom_model(self):
+        """Test generating config with custom model."""
+        template = OpenRouterTemplate()
+        form_data = {
+            "profile_name": "openrouter-custom",
+            "auth_token": "sk-or-123",
+            "model_name": "custom",
+            "custom_model": "custom/my-model",
+        }
+
+        config = template.generate_config(form_data)
+        assert config["model_name"] == "custom/my-model"
+
+    def test_validate_custom_model_missing(self):
+        """Test validation when custom model is selected but not provided."""
+        template = OpenRouterTemplate()
+        form_data = {
+            "profile_name": "openrouter-custom",
+            "auth_token": "sk-or-123",
+            "model_name": "custom",
+        }
+
+        errors = template.validate(form_data)
+        assert len(errors) > 0
+        assert any("Custom model" in err for err in errors)
+
+
+class TestCustomServerTemplate:
+    """Tests for custom server template."""
+
+    def test_template_metadata(self):
+        """Test template metadata."""
+        template = CustomServerTemplate()
+        assert template.get_name() == "llama.cpp / Custom Server"
+        assert template.get_template_id() == "custom"
+        assert "llama.cpp" in template.get_description()
+
+    def test_generate_config_minimal(self):
+        """Test generating minimal custom server config."""
+        template = CustomServerTemplate()
+        form_data = {
+            "profile_name": "llama-cpp",
+            "base_url": "http://localhost:8000",
+            "model_name": "Qwen3-Coder",
+        }
+
+        config = template.generate_config(form_data)
+        assert config["name"] == "llama-cpp"
+        assert config["base_url"] == "http://localhost:8000"
+        assert config["model_name"] == "Qwen3-Coder"
+        assert "auth_token" not in config
+        assert "api_key" not in config
+
+    def test_generate_config_with_auth(self):
+        """Test generating config with auth fields."""
+        template = CustomServerTemplate()
+        form_data = {
+            "profile_name": "llama-cpp",
+            "base_url": "http://localhost:8000",
+            "model_name": "Qwen3-Coder",
+            "auth_token": "llama-cpp",
+        }
+
+        config = template.generate_config(form_data)
+        assert config["auth_token"] == "llama-cpp"
+        # api_key should not be present if not provided
+        assert "api_key" not in config
+
+
+class TestTemplateRegistry:
+    """Tests for template registry."""
+
+    def test_get_template_registry(self):
+        """Test getting template registry."""
+        registry = get_template_registry()
+
+        assert "anthropic" in registry
+        assert "vertex" in registry
+        assert "openrouter" in registry
+        assert "custom" in registry
+
+        assert isinstance(registry["anthropic"], AnthropicTemplate)
+        assert isinstance(registry["vertex"], VertexAITemplate)
+        assert isinstance(registry["openrouter"], OpenRouterTemplate)
+        assert isinstance(registry["custom"], CustomServerTemplate)
+
+
+class TestDetectTemplate:
+    """Tests for template detection."""
+
+    def test_detect_anthropic(self):
+        """Test detecting Anthropic template."""
+        profile = {"name": "anthropic"}
+        assert detect_template_from_profile(profile) == "anthropic"
+
+    def test_detect_vertex(self):
+        """Test detecting Vertex AI template."""
+        profile = {
+            "name": "vertex",
+            "use_vertex": True,
+            "vertex_project_id": "my-project",
+        }
+        assert detect_template_from_profile(profile) == "vertex"
+
+    def test_detect_openrouter(self):
+        """Test detecting OpenRouter template."""
+        profile = {
+            "name": "openrouter",
+            "base_url": "https://openrouter.ai/api",
+            "auth_token": "sk-or-123",
+        }
+        assert detect_template_from_profile(profile) == "openrouter"
+
+    def test_detect_custom(self):
+        """Test detecting custom server template."""
+        profile = {
+            "name": "llama-cpp",
+            "base_url": "http://localhost:8000",
+            "model_name": "Qwen3-Coder",
+        }
+        assert detect_template_from_profile(profile) == "custom"


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://github.com/itdove/devaiflow/issues/221>
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR adds template-based model provider configuration to the TUI (Text User Interface), enhancing the configurability of AI model providers through a structured template system.

### Changes
- Added new template system for model provider configuration (`devflow/config/templates/model_providers.py`)
- Integrated template-based configuration into the config TUI (`devflow/ui/config_tui.py`)
- Created comprehensive tests for model provider templates (`tests/test_model_provider_templates.py`)
- Updated template module initialization (`devflow/config/templates/__init__.py`)

This enhancement allows users to configure model providers through a more maintainable and extensible template-based approach within the TUI interface.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Launch the DevAIFlow TUI with `python -m devflow.ui.config_tui` (or appropriate command)
3. Navigate to the model provider configuration section
4. Verify that template-based configuration options are available
5. Test adding/modifying a model provider using the template system
6. Confirm that configuration changes are properly saved
7. Run the test suite: `pytest tests/test_model_provider_templates.py`
8. Verify all tests pass

### Scenarios tested
- Model provider template instantiation and validation
- TUI integration with template-based configuration
- Configuration persistence and retrieval
- Edge cases and error handling in template system

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: