### PR TITLE
itdove/devaiflow#229: daf sync fails to detect repositories with enterprise/self-hosted GitLab/GitHub remotes

### DIFF
--- a/devflow/utils/git_remote.py
+++ b/devflow/utils/git_remote.py
@@ -134,15 +134,27 @@ class GitRemoteDetector:
     def _host_to_platform(self, host: str) -> Optional[str]:
         """Map hostname to platform name.
 
+        Supports both public instances (github.com, gitlab.com) and
+        enterprise/self-hosted instances (github.enterprise.com, gitlab.cee.redhat.com, etc.).
+
         Args:
-            host: Hostname (e.g., 'github.com')
+            host: Hostname (e.g., 'github.com', 'gitlab.cee.redhat.com')
 
         Returns:
             Platform name ('github', 'gitlab') or None if unsupported
+
+        Examples:
+            >>> detector._host_to_platform('github.com')
+            'github'
+            >>> detector._host_to_platform('github.enterprise.com')
+            'github'
+            >>> detector._host_to_platform('gitlab.cee.redhat.com')
+            'gitlab'
         """
-        if host in self.GITHUB_HOSTS:
+        host_lower = host.lower()
+        if 'github' in host_lower:
             return 'github'
-        elif host in self.GITLAB_HOSTS:
+        elif 'gitlab' in host_lower:
             return 'gitlab'
         return None
 

--- a/tests/test_git_remote.py
+++ b/tests/test_git_remote.py
@@ -172,6 +172,48 @@ class TestGitRemoteDetector:
 
         assert result is None
 
+    def test_parse_repository_info_github_enterprise_https(self):
+        """Test parsing GitHub Enterprise HTTPS URL."""
+        detector = GitRemoteDetector()
+        result = detector.parse_repository_info('https://github.enterprise.com/owner/repo.git')
+
+        assert result == ('github', 'owner', 'repo')
+
+    def test_parse_repository_info_github_enterprise_ssh(self):
+        """Test parsing GitHub Enterprise SSH URL."""
+        detector = GitRemoteDetector()
+        result = detector.parse_repository_info('git@github.enterprise.com:owner/repo.git')
+
+        assert result == ('github', 'owner', 'repo')
+
+    def test_parse_repository_info_gitlab_enterprise_https(self):
+        """Test parsing GitLab Enterprise HTTPS URL."""
+        detector = GitRemoteDetector()
+        result = detector.parse_repository_info('https://gitlab.cee.redhat.com/group/project.git')
+
+        assert result == ('gitlab', 'group', 'project')
+
+    def test_parse_repository_info_gitlab_enterprise_ssh(self):
+        """Test parsing GitLab Enterprise SSH URL."""
+        detector = GitRemoteDetector()
+        result = detector.parse_repository_info('git@gitlab.cee.redhat.com:group/project.git')
+
+        assert result == ('gitlab', 'group', 'project')
+
+    def test_parse_repository_info_github_self_hosted(self):
+        """Test parsing self-hosted GitHub instance URL."""
+        detector = GitRemoteDetector()
+        result = detector.parse_repository_info('https://github.company.internal/owner/repo.git')
+
+        assert result == ('github', 'owner', 'repo')
+
+    def test_parse_repository_info_gitlab_self_hosted(self):
+        """Test parsing self-hosted GitLab instance URL."""
+        detector = GitRemoteDetector()
+        result = detector.parse_repository_info('https://gitlab.company.internal/group/project.git')
+
+        assert result == ('gitlab', 'group', 'project')
+
     def test_parse_repository_info_invalid_url(self):
         """Test parsing invalid URL."""
         detector = GitRemoteDetector()
@@ -290,6 +332,32 @@ upstream\thttps://github.com/main/repo.git (push)
         """Test mapping unsupported host."""
         detector = GitRemoteDetector()
         assert detector._host_to_platform('bitbucket.org') is None
+
+    def test_host_to_platform_github_enterprise(self):
+        """Test mapping GitHub Enterprise host."""
+        detector = GitRemoteDetector()
+        assert detector._host_to_platform('github.enterprise.com') == 'github'
+
+    def test_host_to_platform_gitlab_enterprise(self):
+        """Test mapping GitLab Enterprise host."""
+        detector = GitRemoteDetector()
+        assert detector._host_to_platform('gitlab.cee.redhat.com') == 'gitlab'
+
+    def test_host_to_platform_github_self_hosted(self):
+        """Test mapping self-hosted GitHub instance."""
+        detector = GitRemoteDetector()
+        assert detector._host_to_platform('github.company.internal') == 'github'
+
+    def test_host_to_platform_gitlab_self_hosted(self):
+        """Test mapping self-hosted GitLab instance."""
+        detector = GitRemoteDetector()
+        assert detector._host_to_platform('gitlab.company.internal') == 'gitlab'
+
+    def test_host_to_platform_case_insensitive(self):
+        """Test that platform detection is case-insensitive."""
+        detector = GitRemoteDetector()
+        assert detector._host_to_platform('GitHub.Enterprise.COM') == 'github'
+        assert detector._host_to_platform('GitLab.CEE.RedHat.COM') == 'gitlab'
 
 
 class TestConvenienceFunctions:


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://github.com/itdove/devaiflow/issues/229>

## Description
This PR fixes an issue where `daf sync` fails to detect repositories with enterprise/self-hosted GitLab/GitHub remotes. The detection logic has been enhanced to support custom domain Git instances beyond the standard github.com and gitlab.com domains.

**Changes:**
- Updated `devflow/utils/git_remote.py` to properly identify and parse Git remote URLs from enterprise and self-hosted instances
- Added comprehensive test coverage in `tests/test_git_remote.py` for various enterprise/self-hosted URL patterns

This resolves the issue where users with enterprise GitHub or self-hosted GitLab instances were unable to use daf sync functionality.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Configure a repository with an enterprise GitHub remote (e.g., `git@github.enterprise.com:org/repo.git`)
3. Run `daf sync` and verify the repository is correctly detected
4. Configure a repository with a self-hosted GitLab remote (e.g., `git@gitlab.company.com:org/repo.git`)
5. Run `daf sync` and verify the repository is correctly detected
6. Run the test suite with `pytest tests/test_git_remote.py` to verify all test cases pass

### Scenarios tested
- Standard GitHub.com and GitLab.com URLs (regression testing)
- Enterprise GitHub URLs with custom domains
- Self-hosted GitLab URLs with custom domains
- Various Git URL formats (SSH, HTTPS, git protocol)

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: