### PR TITLE
itdove/devaiflow#232: Misleading 'JIRA not configured' message when using 'daf sync -w workspace'

### DIFF
--- a/devflow/cli/commands/sync_command.py
+++ b/devflow/cli/commands/sync_command.py
@@ -785,12 +785,18 @@ def sync_multi_backend(
         else:
             console_print("[dim]No JIRA sync filters configured, skipping JIRA sync[/dim]")
     else:
-        if config.jira and not config.jira.url:
-            console_print("[dim]JIRA URL not configured, skipping JIRA sync[/dim]")
-        elif config.jira and not config.jira.project:
-            console_print("[dim]JIRA project not configured, skipping JIRA sync[/dim]")
-        else:
-            console_print("[dim]JIRA not configured, skipping JIRA sync[/dim]")
+        # Only show JIRA messages when no workspace filters are used
+        # If workspace filters present, user explicitly requested workspace-only mode (silent)
+        has_workspace_filters = workspace_filter or repository_filter
+
+        if not has_workspace_filters:
+            # No workspace filters - user intended to sync JIRA, so show why we're not
+            if config.jira and not config.jira.url:
+                console_print("[dim]JIRA URL not configured, skipping JIRA sync[/dim]")
+            elif config.jira and not config.jira.project:
+                console_print("[dim]JIRA project not configured, skipping JIRA sync[/dim]")
+            else:
+                console_print("[dim]JIRA not configured, skipping JIRA sync[/dim]")
 
     # Phase 2: Scan workspaces for git repositories (if sync_workspaces=True)
     all_repositories = []

--- a/tests/test_smart_sync.py
+++ b/tests/test_smart_sync.py
@@ -47,3 +47,76 @@ def test_sync_with_repository_filter_skips_jira(temp_daf_home):
             mock_jira.assert_not_called()
 
 
+def test_sync_workspace_filter_shows_no_jira_message_when_jira_configured(temp_daf_home):
+    """Test: daf sync -w workspace with JIRA configured shows no JIRA skip message (silent)."""
+    runner = CliRunner()
+
+    # Initialize config with JIRA configured
+    with patch("rich.prompt.Confirm.ask", side_effect=[False, False]):
+        result = runner.invoke(cli, ["init", "--skip-jira-discovery"])
+
+    # Configure JIRA (add jira_project to organization.json)
+    import json
+    from pathlib import Path
+    org_config_path = Path(temp_daf_home) / "organization.json"
+    with open(org_config_path, "r") as f:
+        org_config = json.load(f)
+    org_config["jira_project"] = "PROJ"
+    with open(org_config_path, "w") as f:
+        json.dump(org_config, f, indent=2)
+
+    # Set JIRA_URL environment variable to simulate JIRA being configured
+    with patch.dict("os.environ", {"JIRA_URL": "https://jira.example.com"}):
+        with patch("devflow.cli.commands.sync_command.scan_workspace_for_repositories", return_value=[]):
+            result = runner.invoke(cli, ["sync", "-w", "primary"])
+
+            # Verify no JIRA sync skip messages (silent when using workspace filter)
+            assert "skipping jira sync" not in result.output.lower()
+            assert "jira not configured" not in result.output.lower()
+
+
+def test_sync_repository_filter_shows_no_jira_message_when_jira_configured(temp_daf_home):
+    """Test: daf sync --repository with JIRA configured shows no JIRA skip message (silent)."""
+    runner = CliRunner()
+
+    # Initialize config with JIRA configured
+    with patch("rich.prompt.Confirm.ask", side_effect=[False, False]):
+        result = runner.invoke(cli, ["init", "--skip-jira-discovery"])
+
+    # Configure JIRA
+    import json
+    from pathlib import Path
+    org_config_path = Path(temp_daf_home) / "organization.json"
+    with open(org_config_path, "r") as f:
+        org_config = json.load(f)
+    org_config["jira_project"] = "PROJ"
+    with open(org_config_path, "w") as f:
+        json.dump(org_config, f, indent=2)
+
+    # Set JIRA_URL environment variable
+    with patch.dict("os.environ", {"JIRA_URL": "https://jira.example.com"}):
+        with patch("devflow.cli.commands.sync_command.sync_github_repository", return_value={'created_count': 0, 'updated_count': 0}):
+            result = runner.invoke(cli, ["sync", "--repository", "owner/repo"])
+
+            # Verify no JIRA sync skip messages (silent when using repository filter)
+            assert "skipping jira sync" not in result.output.lower()
+            assert "jira not configured" not in result.output.lower()
+
+
+def test_sync_without_jira_configured_shows_jira_not_configured_message(temp_daf_home):
+    """Test: daf sync without JIRA configured shows 'JIRA not configured' message."""
+    runner = CliRunner()
+
+    # Initialize config without JIRA
+    with patch("rich.prompt.Confirm.ask", side_effect=[False, False]):
+        result = runner.invoke(cli, ["init", "--skip-jira-discovery"])
+
+    # Run sync without workspace filter (should check JIRA)
+    with patch("devflow.cli.commands.sync_command.scan_workspace_for_repositories", return_value=[]):
+        result = runner.invoke(cli, ["sync"])
+
+        # Verify message indicates JIRA not configured (either "JIRA not configured" or "JIRA project not configured")
+        assert ("jira not configured" in result.output.lower() or "jira project not configured" in result.output.lower())
+        assert "workspace-only mode" not in result.output.lower()
+
+


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://redhat.atlassian.net/browse/itdove/devaiflow#232>

## Description
This PR addresses a misleading UX issue where JIRA-related configuration messages were displayed when using the `daf sync` command with workspace filters (`-w`/`--workspace`), even though JIRA integration is not required for workspace-based syncing.

The changes suppress JIRA configuration messages when workspace filters are active, improving the user experience by only showing relevant messaging for the operation being performed.

**Technical changes:**
- Modified `devflow/cli/commands/sync_command.py` to conditionally suppress JIRA-related messages when workspace filters are in use
- Added test coverage in `tests/test_smart_sync.py` to verify the suppression behavior

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run `daf sync -w <workspace-name>` with a workspace filter
3. Verify that JIRA configuration messages are NOT displayed during the sync operation
4. Run `daf sync` without workspace filters in a scenario where JIRA is not configured
5. Verify that appropriate JIRA messages are still shown in contexts where they are relevant
6. Run the test suite: `pytest tests/test_smart_sync.py` to verify new test coverage

### Scenarios tested
- `daf sync` with workspace filter when JIRA is not configured - JIRA messages suppressed
- `daf sync` without workspace filter - JIRA messages displayed as appropriate
- Unit tests pass for the new suppression logic

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: