### PR TITLE
feat: support multiple remotes in target branch selection

### DIFF
--- a/devflow/cli/commands/complete_command.py
+++ b/devflow/cli/commands/complete_command.py
@@ -1377,26 +1377,51 @@ def _select_target_branch(working_dir: Path, config, upstream_info: Optional[dic
                 console.print(f"[dim]Automatically using default branch: {default_branch} (configured in prompts)[/dim]")
                 return default_branch
 
-    # Determine which remote to query (upstream if fork, otherwise origin)
-    remote_name = "origin"
+    # Determine which remotes to query
     if upstream_info:
-        # Check if upstream remote exists
+        # Fork scenario: fetch from both upstream and origin
         upstream_url = upstream_info.get('upstream_url')
+        upstream_remote = None
         if upstream_url:
-            existing_remote = GitUtils.get_remote_name_for_url(working_dir, upstream_url)
-            if existing_remote:
-                remote_name = existing_remote
+            upstream_remote = GitUtils.get_remote_name_for_url(working_dir, upstream_url)
 
-    # Fetch remote branches
-    branches = GitUtils.list_remote_branches(working_dir, remote_name)
+        # Fetch branches from both remotes
+        remote_branches = {}
+        if upstream_remote:
+            upstream_branches = GitUtils.list_remote_branches(working_dir, upstream_remote)
+            if upstream_branches:
+                remote_branches[upstream_remote] = upstream_branches
 
-    # Filter out current branch (cannot create PR to same branch as source)
-    if current_branch and current_branch in branches:
-        branches = [b for b in branches if b != current_branch]
+        origin_branches = GitUtils.list_remote_branches(working_dir, "origin")
+        if origin_branches:
+            remote_branches["origin"] = origin_branches
+    else:
+        # Non-fork scenario: only fetch from origin
+        origin_branches = GitUtils.list_remote_branches(working_dir, "origin")
+        remote_branches = {"origin": origin_branches} if origin_branches else {}
+
+    # Build combined branch list with remote prefixes
+    branches = []
+    branch_to_remote = {}  # Map branch display name to (remote, actual_branch)
+    for remote, remote_branch_list in remote_branches.items():
+        for branch in remote_branch_list:
+            # Filter out current branch
+            if current_branch and branch == current_branch:
+                continue
+
+            # Use format "remote/branch" for display when multiple remotes
+            if len(remote_branches) > 1:
+                display_name = f"{remote}/{branch}"
+            else:
+                display_name = branch
+
+            branches.append(display_name)
+            branch_to_remote[display_name] = (remote, branch)
 
     # Handle empty branch list
     if not branches:
-        console.print(f"[yellow]⚠[/yellow] No branches found on remote '{remote_name}'")
+        remotes_str = ", ".join(remote_branches.keys()) if remote_branches else "configured remotes"
+        console.print(f"[yellow]⚠[/yellow] No branches found on {remotes_str}")
         console.print("[dim]Continuing without target branch selection[/dim]")
         return None
 
@@ -1404,15 +1429,21 @@ def _select_target_branch(working_dir: Path, config, upstream_info: Optional[dic
     default_branch = GitUtils.get_default_branch(working_dir)
 
     # Show branch selection prompt
-    console.print(f"\n[cyan]Select target branch for PR/MR (remote: {remote_name}):[/cyan]")
+    if len(remote_branches) > 1:
+        remotes_str = " and ".join(remote_branches.keys())
+        console.print(f"\n[cyan]Select target branch for PR/MR (remotes: {remotes_str}):[/cyan]")
+    else:
+        remote_name = list(remote_branches.keys())[0]
+        console.print(f"\n[cyan]Select target branch for PR/MR (remote: {remote_name}):[/cyan]")
 
     # Display branch options as numbered list
     console.print("\n[bold]Available branches:[/bold]")
-    for i, branch in enumerate(branches, 1):
-        if branch == default_branch:
-            console.print(f"{i}. {branch} [green](default)[/green]")
+    for i, branch_display in enumerate(branches, 1):
+        remote, actual_branch = branch_to_remote[branch_display]
+        if actual_branch == default_branch:
+            console.print(f"{i}. {branch_display} [green](default)[/green]")
         else:
-            console.print(f"{i}. {branch}")
+            console.print(f"{i}. {branch_display}")
 
     # Add "Skip" option
     skip_option_number = len(branches) + 1
@@ -1423,10 +1454,14 @@ def _select_target_branch(working_dir: Path, config, upstream_info: Optional[dic
     numeric_choices = [str(i) for i in range(1, skip_option_number + 1)]
 
     # Find default choice number (default branch if available, otherwise first branch)
-    if default_branch and default_branch in branches:
-        default_choice = str(branches.index(default_branch) + 1)
-    else:
-        default_choice = "1"
+    default_choice = "1"
+    if default_branch:
+        # Find the display name that corresponds to the default branch
+        for i, branch_display in enumerate(branches, 1):
+            remote, actual_branch = branch_to_remote[branch_display]
+            if actual_branch == default_branch:
+                default_choice = str(i)
+                break
 
     # Prompt for selection
     choice = Prompt.ask("Select option", choices=numeric_choices, default=default_choice)

--- a/tests/test_pr_target_branch.py
+++ b/tests/test_pr_target_branch.py
@@ -526,10 +526,14 @@ def test_select_target_branch_empty_after_filtering(monkeypatch, tmp_path):
 
 
 def test_select_target_branch_fork_filters_current(monkeypatch, tmp_path):
-    """Test fork scenario - current local branch filtered from upstream branches."""
+    """Test fork scenario - current local branch filtered from both upstream and origin branches."""
     def mock_list_remote_branches(path, remote):
-        # Upstream branches including a branch with same name as local
-        return ["main", "develop", "feature-x", "release/2.5"]
+        # Return different branches for different remotes
+        if remote == "upstream":
+            return ["main", "develop", "feature-x", "release/2.5"]
+        elif remote == "origin":
+            return ["main", "develop", "release/2.5"]
+        return []
 
     def mock_get_default_branch(path):
         return "main"
@@ -543,8 +547,8 @@ def test_select_target_branch_fork_filters_current(monkeypatch, tmp_path):
 
     # Mock Prompt.ask to simulate user selecting first option
     def mock_prompt_ask(prompt_text, choices, default):
-        # Should have 3 branches (feature-x filtered out) + skip = 4 options
-        assert choices == ["1", "2", "3", "4"]
+        # upstream: 3 branches (feature-x filtered out) + origin: 3 branches = 6 branches + skip = 7 options
+        assert choices == ["1", "2", "3", "4", "5", "6", "7"]
         return "1"
 
     monkeypatch.setattr("rich.prompt.Prompt.ask", mock_prompt_ask)
@@ -564,8 +568,8 @@ def test_select_target_branch_fork_filters_current(monkeypatch, tmp_path):
     # Call with current_branch="feature-x"
     result = _select_target_branch(tmp_path, config, upstream_info=upstream_info, current_branch="feature-x")
 
-    # Should return main (first available after filtering)
-    assert result == "main"
+    # Should return upstream/main (first available after filtering, with remote prefix)
+    assert result == "upstream/main"
 
 
 def test_create_github_pr_strips_remote_prefix_from_target_branch(monkeypatch, tmp_path):
@@ -672,3 +676,101 @@ def test_create_gitlab_mr_strips_remote_prefix_from_target_branch(monkeypatch, t
     # Remote prefix should be stripped
     assert "develop" in glab_cmd
     assert "upstream/develop" not in glab_cmd
+
+
+def test_select_target_branch_shows_both_upstream_and_origin(monkeypatch, tmp_path):
+    """Test that branch selection shows branches from both upstream and origin when upstream exists."""
+
+    # Mock git utilities
+    def mock_list_remote_branches(path, remote):
+        # Return different branches for different remotes
+        if remote == "upstream":
+            return ["main", "develop", "release/2.5"]
+        elif remote == "origin":
+            return ["main", "develop", "feature-a", "feature-b"]
+        return []
+
+    def mock_get_default_branch(path):
+        return "main"
+
+    def mock_get_remote_name_for_url(path, url):
+        # Return "upstream" for upstream URL
+        if "upstream" in url:
+            return "upstream"
+        return None
+
+    monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.list_remote_branches", mock_list_remote_branches)
+    monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.get_default_branch", mock_get_default_branch)
+    monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.get_remote_name_for_url", mock_get_remote_name_for_url)
+
+    # Mock Prompt.ask to verify the options presented
+    selected_branch = None
+    def mock_prompt_ask(prompt_text, choices, default):
+        nonlocal selected_branch
+        # Verify we have branches from both remotes
+        # upstream: main, develop, release/2.5 (3 branches, but main is current so filtered = 2)
+        # origin: main, develop, feature-a, feature-b (4 branches, but main is current so filtered = 3)
+        # Total: 2 (upstream) + 3 (origin) = 5 branches + 1 skip = 6 options
+        assert choices == ["1", "2", "3", "4", "5", "6"], f"Expected 6 choices, got {choices}"
+        # Select the first option (upstream/develop)
+        selected_branch = "1"
+        return "1"
+
+    monkeypatch.setattr("rich.prompt.Prompt.ask", mock_prompt_ask)
+
+    # Create config
+    config = _create_minimal_config_mock(
+        prompts_config=PromptsConfig(auto_select_target_branch=None)
+    )
+
+    # Mock upstream info (fork scenario)
+    upstream_info = {
+        'upstream_url': 'https://github.com/upstream/repo.git',
+        'upstream_owner': 'upstream',
+        'upstream_repo': 'repo',
+    }
+
+    # Call with current_branch="main" (to filter it out)
+    result = _select_target_branch(tmp_path, config, upstream_info=upstream_info, current_branch="main")
+
+    # Should return a branch with remote prefix format (e.g., "upstream/develop")
+    assert result is not None
+    assert "/" in result  # Should have remote prefix when multiple remotes
+
+
+def test_select_target_branch_origin_only_no_prefix(monkeypatch, tmp_path):
+    """Test that branch selection shows branches without prefix when only origin exists (no upstream)."""
+
+    # Mock git utilities
+    def mock_list_remote_branches(path, remote):
+        # Only origin exists
+        if remote == "origin":
+            return ["main", "develop", "feature-a"]
+        return []
+
+    def mock_get_default_branch(path):
+        return "main"
+
+    monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.list_remote_branches", mock_list_remote_branches)
+    monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.get_default_branch", mock_get_default_branch)
+
+    # Mock Prompt.ask
+    def mock_prompt_ask(prompt_text, choices, default):
+        # 3 branches total (main filtered out leaves 2) + skip = 3 options
+        assert choices == ["1", "2", "3"]
+        return "1"
+
+    monkeypatch.setattr("rich.prompt.Prompt.ask", mock_prompt_ask)
+
+    # Create config
+    config = _create_minimal_config_mock(
+        prompts_config=PromptsConfig(auto_select_target_branch=None)
+    )
+
+    # No upstream info (not a fork)
+    result = _select_target_branch(tmp_path, config, upstream_info=None, current_branch="main")
+
+    # Should return a branch WITHOUT remote prefix when only one remote
+    assert result is not None
+    # When only origin exists, branches should not have "origin/" prefix
+    assert result in ["develop", "feature-a"]


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR adds support for selecting target branches from multiple remotes when creating a pull request. Previously, when choosing a target branch, users could only select from one remote. Now, when both `origin` and `upstream` remotes are configured, users can select target branches from either remote.

The implementation updates the target branch selection logic in the complete command to detect and present branches from all available remotes, improving flexibility for contributors working with forked repositories.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Set up a git repository with both `origin` and `upstream` remotes configured
3. Create test branches on both remotes
4. Run the PR creation command and invoke target branch selection
5. Verify that branches from both `origin` and `upstream` remotes are available for selection
6. Select a target branch from each remote in separate test runs to confirm functionality

### Scenarios tested
- Target branch selection with only `origin` remote configured
- Target branch selection with both `origin` and `upstream` remotes configured
- Selecting a target branch from the `origin` remote
- Selecting a target branch from the `upstream` remote
- Automated test coverage in `tests/test_pr_target_branch.py`

## Deployment considerations
- [x] This code change is ready for deployment on its own