### PR TITLE
itdove/devaiflow#256: Parent field linking fails silently when parent_field_mapping is not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Parent field linking now works without `parent_field_mapping` configuration (#256)
+  - `daf jira create --parent` now defaults to standard JIRA `parent` field
+  - Previously failed silently when `parent_field_mapping` was not configured
+  - Eliminates need to configure `parent_field_mapping` for modern JIRA instances
+  - Maintains backward compatibility with legacy configurations using `epic_link`
+  - Configuration is now truly optional (only needed for legacy custom fields)
+
 ## [2.0.0] - 2026-03-19
 
 ### Added

--- a/devflow/jira/client.py
+++ b/devflow/jira/client.py
@@ -1515,22 +1515,24 @@ class JiraClient(IssueTrackerClient):
 
         Returns:
             Field ID string (e.g., "customfield_12311140", or "parent" for sub-task)
-            Returns None if parent_field_mapping not configured or field not found
+            Returns "parent" (standard field) if parent_field_mapping not configured or field not found
         """
         try:
             from devflow.config.loader import ConfigLoader
             config_loader = ConfigLoader()
             config = config_loader.load_config()
 
+            # If no parent_field_mapping configured, use standard parent field
             if not config or not config.jira or not config.jira.parent_field_mapping:
-                return None
+                return "parent"
 
             # Get logical field name from parent_field_mapping (e.g., "epic_link" or "parent")
             issue_type_lower = issue_type.lower()
             logical_field_name = config.jira.parent_field_mapping.get(issue_type_lower)
 
+            # Fall back to standard field if issue type not mapped
             if not logical_field_name:
-                return None
+                return "parent"
 
             # If logical field is "parent" (standard field for sub-tasks), return it directly
             if logical_field_name == "parent":
@@ -1540,7 +1542,8 @@ class JiraClient(IssueTrackerClient):
             return field_mapper.get_field_id(logical_field_name)
 
         except Exception:
-            return None
+            # Fall back to standard field on any error
+            return "parent"
 
     def create_issue(
         self,

--- a/docs/config-templates/README.md
+++ b/docs/config-templates/README.md
@@ -44,9 +44,15 @@ Example manual field mapping:
 }
 ```
 
-### Parent Field Mapping
+### Parent Field Mapping (Optional)
 
-Maps issue types to their parent link field names. Configure in `organization.json`:
+**This configuration is OPTIONAL.** By default, DevAIFlow uses the standard JIRA `parent` field for parent-child relationships, which works on modern JIRA instances.
+
+**Only configure this if:**
+- Your JIRA instance uses legacy custom fields (e.g., `epic_link`) for parent relationships
+- You need to override the default behavior for specific issue types
+
+Example configuration in `organization.json`:
 ```json
 {
   "parent_field_mapping": {
@@ -59,7 +65,14 @@ Maps issue types to their parent link field names. Configure in `organization.js
 }
 ```
 
-This is organization-specific hierarchy policy. Leave null for auto-discovery.
+**Default behavior (no configuration):**
+- All issue types use the standard `parent` field
+- Works on JIRA Cloud and modern JIRA Server/Data Center instances
+- No configuration required
+
+**Legacy behavior (with configuration):**
+- Maps specific issue types to custom field names
+- Required for older JIRA instances using `epic_link` custom fields
 
 ### Sync Filters
 

--- a/tests/test_parent_field_fallback.py
+++ b/tests/test_parent_field_fallback.py
@@ -1,0 +1,229 @@
+"""Tests for _get_parent_field_id method and parent field fallback behavior."""
+
+import json
+import pytest
+from unittest.mock import Mock
+from pathlib import Path
+
+from devflow.jira.client import JiraClient
+from devflow.jira.field_mapper import JiraFieldMapper
+
+
+@pytest.fixture
+def mock_field_mapper():
+    """Create a mock field mapper with epic_link mapping."""
+    mapper = Mock(spec=JiraFieldMapper)
+    # Simulate looking up epic_link custom field ID
+    mapper.get_field_id.return_value = "customfield_12311140"
+    # Mock field_mappings as empty dict to avoid iteration errors
+    mapper.field_mappings = {}
+    return mapper
+
+
+@pytest.fixture
+def config_with_parent_mapping(temp_daf_home):
+    """Create config with parent_field_mapping configured."""
+    from devflow.config.loader import ConfigLoader
+
+    loader = ConfigLoader()
+    backends_dir = loader.config_dir / "backends"
+    backends_dir.mkdir(exist_ok=True)
+
+    # Backend config
+    backend_data = {
+        "url": "https://test-jira.example.com",
+        "field_mappings": None,
+    }
+    with open(backends_dir / "jira.json", "w") as f:
+        json.dump(backend_data, f, indent=2)
+
+    # Organization config with parent_field_mapping
+    org_data = {
+        "jira_project": "TEST",
+        "parent_field_mapping": {
+            "story": "epic_link",
+            "task": "epic_link",
+            "bug": "epic_link",
+            "sub-task": "parent",
+            "epic": "parent"
+        }
+    }
+    with open(loader.config_dir / "organization.json", "w") as f:
+        json.dump(org_data, f, indent=2)
+
+    # User config (minimal)
+    user_data = {"repos": {"workspaces": []}}
+    with open(loader.config_dir / "config.json", "w") as f:
+        json.dump(user_data, f, indent=2)
+
+    return loader
+
+
+@pytest.fixture
+def config_without_parent_mapping(temp_daf_home):
+    """Create config WITHOUT parent_field_mapping configured."""
+    from devflow.config.loader import ConfigLoader
+
+    loader = ConfigLoader()
+    backends_dir = loader.config_dir / "backends"
+    backends_dir.mkdir(exist_ok=True)
+
+    # Backend config (no parent_field_mapping)
+    backend_data = {
+        "url": "https://test-jira.example.com",
+        "field_mappings": None,
+    }
+    with open(backends_dir / "jira.json", "w") as f:
+        json.dump(backend_data, f, indent=2)
+
+    # Organization config WITHOUT parent_field_mapping
+    org_data = {
+        "jira_project": "TEST",
+    }
+    with open(loader.config_dir / "organization.json", "w") as f:
+        json.dump(org_data, f, indent=2)
+
+    # User config (minimal)
+    user_data = {"repos": {"workspaces": []}}
+    with open(loader.config_dir / "config.json", "w") as f:
+        json.dump(user_data, f, indent=2)
+
+    return loader
+
+
+def test_get_parent_field_id_without_config_returns_parent(config_without_parent_mapping, mock_field_mapper):
+    """Test that _get_parent_field_id returns 'parent' when parent_field_mapping is not configured."""
+    client = JiraClient()
+
+    # Test all common issue types
+    assert client._get_parent_field_id("story", mock_field_mapper) == "parent"
+    assert client._get_parent_field_id("task", mock_field_mapper) == "parent"
+    assert client._get_parent_field_id("bug", mock_field_mapper) == "parent"
+    assert client._get_parent_field_id("epic", mock_field_mapper) == "parent"
+    assert client._get_parent_field_id("sub-task", mock_field_mapper) == "parent"
+
+
+def test_get_parent_field_id_with_config_uses_epic_link(config_with_parent_mapping, mock_field_mapper):
+    """Test that _get_parent_field_id returns custom field ID when parent_field_mapping is configured with epic_link."""
+    client = JiraClient()
+
+    # Test issue types mapped to epic_link (should return custom field ID)
+    assert client._get_parent_field_id("story", mock_field_mapper) == "customfield_12311140"
+    assert client._get_parent_field_id("task", mock_field_mapper) == "customfield_12311140"
+    assert client._get_parent_field_id("bug", mock_field_mapper) == "customfield_12311140"
+
+    # Verify field_mapper.get_field_id was called with "epic_link"
+    mock_field_mapper.get_field_id.assert_called_with("epic_link")
+
+
+def test_get_parent_field_id_with_config_uses_parent_for_subtask(config_with_parent_mapping, mock_field_mapper):
+    """Test that _get_parent_field_id returns 'parent' for sub-tasks when explicitly mapped."""
+    client = JiraClient()
+
+    # Sub-tasks should use standard parent field
+    assert client._get_parent_field_id("sub-task", mock_field_mapper) == "parent"
+    assert client._get_parent_field_id("epic", mock_field_mapper) == "parent"
+
+    # Field mapper should NOT be called for "parent" logical field
+    # Reset the mock to check subsequent calls don't happen for "parent"
+    mock_field_mapper.get_field_id.reset_mock()
+    client._get_parent_field_id("sub-task", mock_field_mapper)
+    mock_field_mapper.get_field_id.assert_not_called()
+
+
+def test_get_parent_field_id_issue_type_not_in_mapping_returns_parent(config_with_parent_mapping, mock_field_mapper):
+    """Test that _get_parent_field_id returns 'parent' for unmapped issue types."""
+    client = JiraClient()
+
+    # Test issue types not in the mapping
+    assert client._get_parent_field_id("spike", mock_field_mapper) == "parent"
+    assert client._get_parent_field_id("custom-type", mock_field_mapper) == "parent"
+    assert client._get_parent_field_id("unknown", mock_field_mapper) == "parent"
+
+
+def test_get_parent_field_id_exception_returns_parent(config_with_parent_mapping, mock_field_mapper):
+    """Test that _get_parent_field_id returns 'parent' on any exception."""
+    client = JiraClient()
+
+    # Make field_mapper.get_field_id raise an exception
+    mock_field_mapper.get_field_id.side_effect = Exception("Field mapper error")
+
+    # Should fall back to "parent" instead of propagating exception
+    assert client._get_parent_field_id("story", mock_field_mapper) == "parent"
+
+
+def test_create_issue_with_parent_without_config(config_without_parent_mapping, mock_field_mapper, monkeypatch):
+    """Test that create_issue adds parent link using 'parent' field when config is not set."""
+    client = JiraClient()
+
+    def mock_api_request(method, endpoint, **kwargs):
+        response = Mock()
+        if method == "POST" and "/rest/api/2/issue" in endpoint:
+            # Verify parent link is in payload using standard "parent" field
+            payload = kwargs.get("json", {})
+            assert "parent" in payload["fields"], "Parent field should be in payload"
+            assert payload["fields"]["parent"] == "PROJ-10000"
+
+            response.status_code = 201
+            response.json.return_value = {"key": "PROJ-12345"}
+        return response
+
+    monkeypatch.setattr(client, "_api_request", mock_api_request)
+
+    issue_key = client.create_issue(
+        issue_type="Story",
+        summary="Test story with parent",
+        description="Story description",
+        priority="Medium",
+        project_key="PROJ",
+        field_mapper=mock_field_mapper,
+        parent="PROJ-10000",
+    )
+
+    assert issue_key == "PROJ-12345"
+
+
+def test_create_issue_with_parent_with_epic_link_config(config_with_parent_mapping, mock_field_mapper, monkeypatch):
+    """Test that create_issue adds parent link using epic_link custom field when configured."""
+    client = JiraClient()
+
+    def mock_api_request(method, endpoint, **kwargs):
+        response = Mock()
+        if method == "POST" and "/rest/api/2/issue" in endpoint:
+            # Verify parent link uses custom field ID from epic_link mapping
+            payload = kwargs.get("json", {})
+            assert "customfield_12311140" in payload["fields"], "Epic link custom field should be in payload"
+            assert payload["fields"]["customfield_12311140"] == "PROJ-10000"
+
+            response.status_code = 201
+            response.json.return_value = {"key": "PROJ-12346"}
+        return response
+
+    monkeypatch.setattr(client, "_api_request", mock_api_request)
+
+    issue_key = client.create_issue(
+        issue_type="Story",
+        summary="Test story with parent (epic_link)",
+        description="Story description",
+        priority="Medium",
+        project_key="PROJ",
+        field_mapper=mock_field_mapper,
+        parent="PROJ-10000",
+    )
+
+    assert issue_key == "PROJ-12346"
+
+
+def test_backward_compatibility_existing_configs_still_work(config_with_parent_mapping, mock_field_mapper):
+    """Test that existing configurations with parent_field_mapping continue to work correctly."""
+    client = JiraClient()
+
+    # Organizations with parent_field_mapping should continue using their configured mappings
+    assert client._get_parent_field_id("story", mock_field_mapper) == "customfield_12311140"
+    assert client._get_parent_field_id("task", mock_field_mapper) == "customfield_12311140"
+    assert client._get_parent_field_id("bug", mock_field_mapper) == "customfield_12311140"
+    assert client._get_parent_field_id("sub-task", mock_field_mapper) == "parent"
+    assert client._get_parent_field_id("epic", mock_field_mapper) == "parent"
+
+    # Verify the custom field lookup was called correctly
+    assert mock_field_mapper.get_field_id.call_count >= 3  # At least for story, task, bug


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR fixes an issue where parent field linking was failing silently when `parent_field_mapping` is not configured in the devaiflow configuration. 

Previously, if a user did not explicitly configure the parent field mapping, the JIRA client would fail to properly link issues to their parent items without providing any error or feedback. This fix introduces a fallback mechanism that defaults to using the standard JIRA parent field when no custom mapping is configured.

**Changes made:**
- Updated `devflow/jira/client.py` to implement fallback logic for parent field handling
- Added comprehensive test coverage in `tests/test_parent_field_fallback.py` to verify the fallback behavior
- Updated documentation in `docs/config-templates/README.md` to clarify parent field configuration requirements
- Added changelog entry documenting the fix

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Set up a test environment with JIRA integration enabled
3. Create a configuration file **without** `parent_field_mapping` specified
4. Attempt to create a child issue that should link to a parent issue
5. Verify that the parent field is properly set using the standard JIRA parent field
6. Run the test suite: `pytest tests/test_parent_field_fallback.py`
7. Verify all tests pass
8. (Optional) Test with an explicit `parent_field_mapping` configuration to ensure backward compatibility

### Scenarios tested
- Parent field linking without `parent_field_mapping` configured (fallback to default)
- Parent field linking with custom `parent_field_mapping` configured (existing behavior)
- Error handling when parent issue does not exist
- Automated test coverage for fallback mechanism

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: