### PR TITLE
itdove/devaiflow#286: Skills documentation: Clarify Markdown vs JIRA Wiki markup usage

### DIFF
--- a/devflow/cli_skills/daf-cli/SKILL.md
+++ b/devflow/cli_skills/daf-cli/SKILL.md
@@ -137,7 +137,6 @@ Running these commands inside Claude Code can cause:
 1. **Fields:** See **daf-jira-fields skill** for system vs custom field syntax
 2. **Discover:** Run `daf config show --fields` to see YOUR custom fields
 3. **Read JIRA:** Use Atlassian MCP for fast reads
-4. **JIRA markup:** Use JIRA Wiki markup (NOT Markdown)
 
 ## See Also
 

--- a/devflow/cli_skills/daf-jira/SKILL.md
+++ b/devflow/cli_skills/daf-jira/SKILL.md
@@ -68,3 +68,99 @@ daf jira create bug --summary "..."    # Create new JIRA bug
 daf jira create story --summary "..."  # Create new JIRA story
 daf jira update PROJ-12345 --priority Major  # Update ticket fields
 ```
+
+## JIRA Wiki Markup
+
+**CRITICAL:** JIRA uses **Wiki markup syntax**, NOT Markdown.
+
+When using `daf jira create`, `daf jira add-comment`, or `daf jira update` commands, all text fields (descriptions, comments, acceptance criteria) **MUST** use **JIRA Wiki markup** formatting.
+
+### Syntax Reference
+
+| Element | ✅ JIRA Wiki Markup (CORRECT) | ❌ Markdown (WRONG) |
+|---------|-------------------------------|---------------------|
+| Header 2 | `h2. Header` | `## Header` |
+| Header 3 | `h3. Header` | `### Header` |
+| Bold | `*bold*` | `**bold**` |
+| Italic | `_italic_` | `*italic*` |
+| Code block | `{code:bash}\ncode\n{code}` | ` ```bash\ncode\n``` ` |
+| Inline code | `{{code}}` | `` `code` `` |
+| Unordered list | `* item` | `- item` |
+| Ordered list | `# item` | `1. item` |
+| Link | `[text|url]` | `[text](url)` |
+| Checkbox | `- [] item` | `- [ ] item` |
+
+### Why This Matters
+
+- JIRA will NOT render Markdown correctly
+- Using `## Header` will display as plain text, not a header
+- Using ` ```bash ` code blocks will not format as code
+- Acceptance criteria must use `- []` format (not `- [ ]`)
+
+### Example: Creating JIRA Ticket with Wiki Markup
+
+```bash
+# Correct JIRA Wiki markup formatting
+daf jira create story --summary "Add caching layer" \
+  --description "h3. Overview
+
+Implement Redis caching to improve API performance.
+
+h3. Requirements
+
+* Cache should store subscription lookups
+* Configurable TTL (default: 5 minutes)
+* Handle cache misses gracefully
+
+h3. Implementation Notes
+
+Use {{redis-py}} client with the following configuration:
+
+{code:python}
+redis_client = Redis(
+    host='localhost',
+    port=6379,
+    decode_responses=True
+)
+{code}
+
+*Target:* 50ms response time" \
+  --field acceptance_criteria="- [] Unit tests pass
+- [] Integration tests pass
+- [] Performance benchmarks meet targets"
+```
+
+### Common Mistakes
+
+❌ **DON'T** use Markdown in JIRA tickets:
+```bash
+# WRONG - Markdown will not render in JIRA
+daf jira create bug --description "### Bug Description
+
+**Problem:** API times out
+
+\`\`\`python
+# broken code
+\`\`\`"
+```
+
+✅ **DO** use JIRA Wiki markup:
+```bash
+# CORRECT - JIRA Wiki markup
+daf jira create bug --description "h3. Bug Description
+
+*Problem:* API times out
+
+{code:python}
+# broken code
+{code}"
+```
+
+### When to Use JIRA Wiki Markup
+
+**✅ Use JIRA Wiki markup for all JIRA operations:**
+- `daf jira create` - Creating JIRA tickets
+- `daf jira add-comment` - Adding JIRA comments
+- `daf jira update` - Updating JIRA descriptions
+
+**Note:** For GitHub/GitLab operations (`daf git create`, `daf git add-comment`, `daf git update`), use Markdown syntax instead. See **daf-git skill** for complete Markdown syntax reference.


### PR DESCRIPTION
Jira Issue: <https://jira.example.com/browse/itdove/devaiflow#286>

## Description
This PR expands the JIRA Wiki markup documentation in the DevAIFlow skills to clarify when to use Markdown versus JIRA Wiki markup. The changes update documentation in the daf-cli and daf-jira skill files to provide clearer guidance on markup format usage when creating and updating JIRA issues through the daf command-line tool.

The documentation improvements help users understand:
- When JIRA Wiki markup is required vs when Markdown can be used
- How different JIRA fields handle markup formatting
- Best practices for formatting content in JIRA descriptions and comments

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Review the updated documentation in `devflow/cli_skills/daf-cli/SKILL.md`
3. Review the updated documentation in `devflow/cli_skills/daf-jira/SKILL.md`
4. Verify that the JIRA Wiki markup examples are correctly formatted
5. Verify that the guidance on Markdown vs JIRA Wiki markup usage is clear and accurate
6. Optionally: Test the documented commands to ensure the examples align with actual behavior

### Scenarios tested
- Reviewed documentation for clarity, accuracy, and proper markdown formatting
- Verified JIRA Wiki markup examples render correctly in documentation viewers

## Deployment considerations
- [x] This code change is ready for deployment on its own