### PR TITLE
itdove/devaiflow#285: daf init/upgrade: Respect CLAUDE_CONFIG_DIR environment variable for skill installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,35 @@ DevAIFlow automatically checks GitHub authentication before operations and provi
 
 See [Troubleshooting Guide](docs/guides/troubleshooting.md#githubd-authentication---fine-grained-token-required) for common authentication issues.
 
+## Environment Variables
+
+DevAIFlow supports the following environment variables for customization:
+
+### DEVAIFLOW_HOME
+- **Purpose**: Customize where DevAIFlow stores session data and configuration
+- **Default**: `~/.daf-sessions`
+- **Example**:
+  ```bash
+  export DEVAIFLOW_HOME="~/custom/devaiflow-data"
+  daf init
+  ```
+
+### CLAUDE_CONFIG_DIR
+- **Purpose**: Customize where Claude Code stores its configuration and data files (official Claude Code variable)
+- **Default**: `~/.claude`
+- **Use Case**: Useful for testing with multiple Claude Code configurations or custom storage locations
+- **Example**:
+  ```bash
+  export CLAUDE_CONFIG_DIR="~/.config/claude"
+  daf upgrade  # Skills will be installed to $CLAUDE_CONFIG_DIR/skills/
+  ```
+- **Documentation**: https://code.claude.com/docs/en/env-vars
+
+### JIRA_AUTH_TYPE, JIRA_API_TOKEN, JIRA_URL
+- **Purpose**: Authenticate with JIRA instance
+- **Required for**: JIRA integration
+- **See**: Quick Start section above for examples
+
 ## For Other Organizations
 
 **DevAIFlow is fully generic and works with GitHub, GitLab, or JIRA.** Configuration is file-based and can be customized for your organization.

--- a/devflow/agent/claude_agent.py
+++ b/devflow/agent/claude_agent.py
@@ -12,6 +12,7 @@ from typing import Optional, Set, Dict, List, Any
 
 from devflow.agent.interface import AgentInterface
 from devflow.utils.dependencies import require_tool
+from devflow.utils.paths import get_claude_config_dir
 
 
 class ClaudeAgent(AgentInterface):
@@ -28,10 +29,10 @@ class ClaudeAgent(AgentInterface):
         """Initialize Claude agent.
 
         Args:
-            claude_dir: Claude Code directory. Defaults to ~/.claude
+            claude_dir: Claude Code directory. Defaults to ~/.claude or $CLAUDE_CONFIG_DIR
         """
         if claude_dir is None:
-            claude_dir = Path.home() / ".claude"
+            claude_dir = get_claude_config_dir()
         self.claude_dir = claude_dir
         self.projects_dir = claude_dir / "projects"
 
@@ -430,8 +431,9 @@ class ClaudeAgent(AgentInterface):
         """
         skills_dirs = []
 
-        # 1. User-level skills: ~/.claude/skills/
-        user_skills = Path.home() / ".claude" / "skills"
+        # 1. User-level skills: ~/.claude/skills/ (or $CLAUDE_CONFIG_DIR/skills/)
+        claude_config = get_claude_config_dir()
+        user_skills = claude_config / "skills"
         if user_skills.exists():
             skills_dirs.append(str(user_skills))
 

--- a/devflow/agent/ollama_claude_agent.py
+++ b/devflow/agent/ollama_claude_agent.py
@@ -23,6 +23,7 @@ from typing import Optional, Set, List, Dict, Any
 
 from devflow.agent.interface import AgentInterface
 from devflow.utils.dependencies import require_tool
+from devflow.utils.paths import get_claude_config_dir
 
 
 class OllamaClaudeAgent(AgentInterface):
@@ -54,7 +55,7 @@ class OllamaClaudeAgent(AgentInterface):
         self.ollama_dir = ollama_dir
 
         # Claude Code sessions are stored in the same location regardless of launcher
-        self.claude_dir = Path.home() / ".claude"
+        self.claude_dir = get_claude_config_dir()
         self.projects_dir = self.claude_dir / "projects"
 
     def launch_session(

--- a/devflow/archive/base.py
+++ b/devflow/archive/base.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from devflow.config.loader import ConfigLoader
+from devflow.utils.paths import get_claude_config_dir
 
 
 class ArchiveManagerBase:
@@ -33,7 +34,7 @@ class ArchiveManagerBase:
         Returns:
             Path to .jsonl file if found, None otherwise
         """
-        claude_dir = Path.home() / ".claude" / "projects"
+        claude_dir = get_claude_config_dir() / "projects"
         if not claude_dir.exists():
             return None
 

--- a/devflow/backup/manager.py
+++ b/devflow/backup/manager.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional
 from devflow.archive.base import ArchiveManagerBase
 from devflow.config.loader import ConfigLoader
 from devflow.config.models import Session
-from devflow.utils.paths import get_cs_home
+from devflow.utils.paths import get_cs_home, get_claude_config_dir
 
 
 class BackupManager(ArchiveManagerBase):
@@ -175,7 +175,7 @@ class BackupManager(ArchiveManagerBase):
             conversations_dir = temp_dir / "conversations"
             if conversations_dir.exists():
                 # Find Claude's projects directory
-                claude_dir = Path.home() / ".claude" / "projects"
+                claude_dir = get_claude_config_dir() / "projects"
                 if not claude_dir.exists():
                     claude_dir.mkdir(parents=True)
 

--- a/devflow/cli/commands/cleanup_command.py
+++ b/devflow/cli/commands/cleanup_command.py
@@ -13,7 +13,7 @@ from rich.prompt import Confirm
 from devflow.cli.utils import require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
-from devflow.utils.paths import get_cs_home
+from devflow.utils.paths import get_cs_home, get_claude_config_dir
 from devflow.utils.time_parser import parse_duration
 
 console = Console()
@@ -287,7 +287,7 @@ def _find_conversation_file(ai_agent_session_id: str) -> Optional[Path]:
     Returns:
         Path to conversation file if found, None otherwise
     """
-    claude_projects = Path.home() / ".claude" / "projects"
+    claude_projects = get_claude_config_dir() / "projects"
     if not claude_projects.exists():
         return None
 

--- a/devflow/cli/commands/info_command.py
+++ b/devflow/cli/commands/info_command.py
@@ -13,6 +13,7 @@ from devflow.cli.utils import get_status_display, output_json as json_output, se
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
 from devflow.config.models import Session, ConversationContext
+from devflow.utils.paths import get_claude_config_dir
 
 console = Console()
 
@@ -417,8 +418,8 @@ def _get_conversation_file_path(project_path: str, ai_agent_session_id: str) -> 
     if encoded_path.startswith("-"):
         encoded_path = encoded_path[1:]
 
-    # Claude Code stores sessions in ~/.claude/projects/{encoded-path}/
-    claude_dir = Path.home() / ".claude" / "projects" / encoded_path
+    # Claude Code stores sessions in ~/.claude/projects/{encoded-path}/ (or $CLAUDE_CONFIG_DIR/projects/{encoded-path}/)
+    claude_dir = get_claude_config_dir() / "projects" / encoded_path
     conv_file = claude_dir / f"{ai_agent_session_id}.jsonl"
 
     # Check if file exists

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -29,6 +29,7 @@ from devflow.session.summary import generate_session_summary
 from devflow.cli.signal_handler import setup_signal_handlers, is_cleanup_done
 from devflow.utils.context_files import load_hierarchical_context_files
 from devflow.utils.model_provider import get_active_profile, build_env_from_profile, get_profile_display_name
+from devflow.utils.paths import get_claude_config_dir
 from devflow.utils.daf_agents_validation import (
     validate_daf_agents_md as _validate_context_files,
     _install_bundled_cs_agents,
@@ -926,8 +927,8 @@ def open_session(
                 # Skills can be in 3 locations: user-level, workspace-level, project-level
                 skills_dirs = []
 
-                # 1. User-level skills: ~/.claude/skills/
-                user_skills = Path.home() / ".claude" / "skills"
+                # 1. User-level skills: ~/.claude/skills/ (or $CLAUDE_CONFIG_DIR/skills/)
+                user_skills = get_claude_config_dir() / "skills"
                 if user_skills.exists():
                     skills_dirs.append(str(user_skills))
 

--- a/devflow/cli/skills_discovery.py
+++ b/devflow/cli/skills_discovery.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from typing import Optional
 
+from devflow.utils.paths import get_claude_config_dir
+
 
 def discover_skills(project_path: Optional[str] = None, workspace: Optional[str] = None) -> list[tuple[str, str]]:
     """Discover all skills from user-level, workspace-level, hierarchical (DEVAIFLOW_HOME), and project-level locations.
@@ -47,8 +49,8 @@ def discover_skills(project_path: Optional[str] = None, workspace: Optional[str]
 
         return (str(skill_file.resolve()), description)
 
-    # 1. User-level skills: ~/.claude/skills/ (generic skills like daf-cli, git-cli)
-    user_skills_dir = Path.home() / ".claude" / "skills"
+    # 1. User-level skills: ~/.claude/skills/ (or $CLAUDE_CONFIG_DIR/skills/) - generic skills like daf-cli, git-cli
+    user_skills_dir = get_claude_config_dir() / "skills"
     if user_skills_dir.exists():
         for skill_dir in sorted(user_skills_dir.iterdir()):
             if skill_dir.is_dir():

--- a/devflow/export/manager.py
+++ b/devflow/export/manager.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional
 from devflow.archive.base import ArchiveManagerBase
 from devflow.config.loader import ConfigLoader
 from devflow.config.models import Session
-from devflow.utils.paths import get_cs_home
+from devflow.utils.paths import get_cs_home, get_claude_config_dir
 
 
 class ExportManager(ArchiveManagerBase):
@@ -336,7 +336,7 @@ class ExportManager(ArchiveManagerBase):
             # Import conversation history files if present
             conversations_dir = temp_dir / "conversations"
             if conversations_dir.exists():
-                claude_dir = Path.home() / ".claude" / "projects"
+                claude_dir = get_claude_config_dir() / "projects"
                 if not claude_dir.exists():
                     claude_dir.mkdir(parents=True)
 

--- a/devflow/mocks/claude_mock.py
+++ b/devflow/mocks/claude_mock.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from devflow.mocks.persistence import MockDataStore
+from devflow.utils.paths import get_claude_config_dir
 
 
 class MockClaudeCode:
@@ -196,7 +197,7 @@ class MockClaudeCode:
 
         # Determine Claude home directory
         if claude_home is None:
-            claude_home = Path.home() / ".claude"
+            claude_home = get_claude_config_dir()
 
         # Create projects directory (encoding project path)
         project_path = session.get("project_path", "")

--- a/devflow/session/discovery.py
+++ b/devflow/session/discovery.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
+from devflow.utils.paths import get_claude_config_dir
+
 
 @dataclass
 class DiscoveredSession:
@@ -27,9 +29,9 @@ class SessionDiscovery:
         """Initialize session discovery.
 
         Args:
-            claude_dir: Path to .claude directory. Defaults to ~/.claude
+            claude_dir: Path to .claude directory. Defaults to ~/.claude or $CLAUDE_CONFIG_DIR
         """
-        self.claude_dir = claude_dir or Path.home() / ".claude"
+        self.claude_dir = claude_dir or get_claude_config_dir()
         self.projects_dir = self.claude_dir / "projects"
 
     def discover_sessions(self) -> List[DiscoveredSession]:

--- a/devflow/session/repair.py
+++ b/devflow/session/repair.py
@@ -9,6 +9,8 @@ from typing import Dict, List, Optional, Tuple
 
 from rich.console import Console
 
+from devflow.utils.paths import get_claude_config_dir
+
 console = Console()
 
 
@@ -26,7 +28,7 @@ def get_conversation_file_path(ai_agent_session_id: str) -> Optional[Path]:
     Returns:
         Path to conversation file if found, None otherwise
     """
-    claude_home = Path.home() / ".claude"
+    claude_home = get_claude_config_dir()
     projects_dir = claude_home / "projects"
 
     if not projects_dir.exists():
@@ -339,7 +341,7 @@ def scan_all_conversations() -> List[Tuple[str, Path, Dict[str, any]]]:
     Returns:
         List of tuples: (ai_agent_session_id, file_path, corruption_info)
     """
-    claude_home = Path.home() / ".claude"
+    claude_home = get_claude_config_dir()
     projects_dir = claude_home / "projects"
 
     if not projects_dir.exists():

--- a/devflow/session/summary.py
+++ b/devflow/session/summary.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple
 from pydantic import BaseModel
 
 from devflow.config.models import Session
+from devflow.utils.paths import get_claude_config_dir
 
 
 class CommandExecution(BaseModel):
@@ -380,7 +381,7 @@ def find_conversation_file(session: Session) -> Optional[Path]:
     # Note: Claude Code KEEPS the leading dash in directory names
     # Do NOT remove it
 
-    claude_dir = Path.home() / ".claude" / "projects" / encoded_path
+    claude_dir = get_claude_config_dir() / "projects" / encoded_path
     conversation_file = claude_dir / f"{active_conv.ai_agent_session_id}.jsonl"
 
     if conversation_file.exists():

--- a/devflow/utils/claude_commands.py
+++ b/devflow/utils/claude_commands.py
@@ -15,6 +15,8 @@ from typing import List, Tuple, Optional
 import shutil
 from rich.console import Console
 
+from devflow.utils.paths import get_claude_config_dir
+
 console = Console()
 
 
@@ -159,9 +161,9 @@ def install_or_upgrade_slash_commands(
     if not slash_commands:
         return ([], [], [])
 
-    # Install to user-level ~/.claude/skills/
-    user_home = Path.home()
-    skills_dir = user_home / ".claude" / "skills"
+    # Install to user-level ~/.claude/skills/ (or $CLAUDE_CONFIG_DIR/skills/)
+    claude_config = get_claude_config_dir()
+    skills_dir = claude_config / "skills"
 
     if not dry_run:
         skills_dir.mkdir(parents=True, exist_ok=True)
@@ -221,9 +223,9 @@ def install_or_upgrade_reference_skills(
     if not bundled_skills:
         return ([], [], [])
 
-    # Install to user-level ~/.claude/skills/
-    user_home = Path.home()
-    skills_dir = user_home / ".claude" / "skills"
+    # Install to user-level ~/.claude/skills/ (or $CLAUDE_CONFIG_DIR/skills/)
+    claude_config = get_claude_config_dir()
+    skills_dir = claude_config / "skills"
 
     if not dry_run:
         skills_dir.mkdir(parents=True, exist_ok=True)
@@ -445,8 +447,9 @@ def build_claude_command(
     # Collect all skills directories
     skills_dirs = []
 
-    # 1. User-level skills: ~/.claude/skills/
-    user_skills = Path.home() / ".claude" / "skills"
+    # 1. User-level skills: ~/.claude/skills/ (or $CLAUDE_CONFIG_DIR/skills/)
+    claude_config = get_claude_config_dir()
+    user_skills = claude_config / "skills"
     if user_skills.exists():
         skills_dirs.append(str(user_skills))
 

--- a/devflow/utils/paths.py
+++ b/devflow/utils/paths.py
@@ -37,6 +37,34 @@ def get_cs_home() -> Path:
     return Path.home() / ".daf-sessions"
 
 
+def get_claude_config_dir() -> Path:
+    """Get Claude Code config directory, respecting CLAUDE_CONFIG_DIR.
+
+    This function respects the official Claude Code environment variable
+    CLAUDE_CONFIG_DIR, which allows users to customize where Claude Code
+    stores its configuration and data files.
+
+    Returns:
+        Path to Claude config directory:
+        - $CLAUDE_CONFIG_DIR if set (official Claude Code variable)
+        - ~/.claude otherwise (backward compatible)
+
+    Examples:
+        >>> # With CLAUDE_CONFIG_DIR not set
+        >>> get_claude_config_dir()
+        PosixPath('/home/user/.claude')
+
+        >>> # With CLAUDE_CONFIG_DIR set to custom path
+        >>> os.environ['CLAUDE_CONFIG_DIR'] = '~/.config/claude'
+        >>> get_claude_config_dir()
+        PosixPath('/home/user/.config/claude')
+    """
+    claude_config_dir = os.getenv("CLAUDE_CONFIG_DIR")
+    if claude_config_dir:
+        return Path(claude_config_dir).expanduser().resolve()
+    return Path.home() / ".claude"
+
+
 def is_mock_mode() -> bool:
     """Check if mock mode is enabled.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -95,6 +95,44 @@ daf config show
 daf config show --json
 ```
 
+## Environment Variables
+
+DevAIFlow respects the following environment variables for customization:
+
+### DEVAIFLOW_HOME
+- **Purpose**: Customize where DevAIFlow stores session data and configuration
+- **Default**: `~/.daf-sessions`
+- **Usage**:
+  ```bash
+  export DEVAIFLOW_HOME="~/custom/devaiflow-data"
+  daf init
+  ```
+
+### CLAUDE_CONFIG_DIR
+- **Purpose**: Customize where Claude Code stores its configuration and data files
+- **Default**: `~/.claude`
+- **Official Variable**: This is an official Claude Code environment variable
+- **Use Cases**:
+  - Testing with multiple Claude Code configurations
+  - Custom storage locations for skills and session data
+  - Enterprise deployments with specific directory requirements
+- **Impact**: When set, DevAIFlow will:
+  - Install skills to `$CLAUDE_CONFIG_DIR/skills/` instead of `~/.claude/skills/`
+  - Look for Claude Code sessions in `$CLAUDE_CONFIG_DIR/projects/`
+  - Use `$CLAUDE_CONFIG_DIR` for all Claude Code-related operations
+- **Example**:
+  ```bash
+  export CLAUDE_CONFIG_DIR="~/.config/claude"
+  daf upgrade  # Skills install to $CLAUDE_CONFIG_DIR/skills/
+  daf open PROJ-123  # Session files in $CLAUDE_CONFIG_DIR/projects/
+  ```
+- **Documentation**: https://code.claude.com/docs/en/env-vars
+
+### JIRA_AUTH_TYPE, JIRA_API_TOKEN, JIRA_URL
+- **Purpose**: Authenticate with JIRA instance
+- **Required for**: JIRA integration
+- **See**: JIRA configuration section below
+
 ## Configuration File
 
 Location: `$DEVAIFLOW_HOME/config.json`

--- a/tests/test_claude_config_dir_integration.py
+++ b/tests/test_claude_config_dir_integration.py
@@ -1,0 +1,103 @@
+"""Integration tests for CLAUDE_CONFIG_DIR environment variable support.
+
+These tests verify that DevAIFlow respects the official Claude Code
+environment variable CLAUDE_CONFIG_DIR for skill installation and session
+operations.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from devflow.agent.claude_agent import ClaudeAgent
+from devflow.utils.claude_commands import install_or_upgrade_reference_skills
+from devflow.utils.paths import get_claude_config_dir
+
+
+class TestClaudeConfigDirIntegration:
+    """Integration tests for CLAUDE_CONFIG_DIR support."""
+
+    def test_get_claude_config_dir_respects_env_var(self, tmp_path, monkeypatch):
+        """Test that get_claude_config_dir respects CLAUDE_CONFIG_DIR."""
+        custom_path = tmp_path / "custom-claude-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_path))
+
+        result = get_claude_config_dir()
+
+        assert result == custom_path
+
+    def test_skill_installation_respects_claude_config_dir(self, tmp_path, monkeypatch):
+        """Test that skill installation uses CLAUDE_CONFIG_DIR."""
+        custom_path = tmp_path / "custom-claude-config"
+        custom_path.mkdir(parents=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_path))
+
+        # Install skills
+        changed, up_to_date, failed = install_or_upgrade_reference_skills(dry_run=False, quiet=True)
+
+        # Verify skills were installed to custom directory
+        skills_dir = custom_path / "skills"
+        assert skills_dir.exists()
+
+        # Verify at least one skill was installed
+        assert len(list(skills_dir.iterdir())) > 0
+
+    def test_claude_agent_respects_claude_config_dir(self, tmp_path, monkeypatch):
+        """Test that ClaudeAgent uses CLAUDE_CONFIG_DIR."""
+        custom_path = tmp_path / "custom-claude-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_path))
+
+        agent = ClaudeAgent()
+
+        assert agent.claude_dir == custom_path
+        assert agent.projects_dir == custom_path / "projects"
+
+    def test_claude_agent_with_custom_dir_overrides_env(self, tmp_path, monkeypatch):
+        """Test that ClaudeAgent's custom dir parameter overrides env var."""
+        env_path = tmp_path / "env-claude-config"
+        custom_path = tmp_path / "custom-claude-config"
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(env_path))
+
+        # Pass custom_path to constructor - should override env var
+        agent = ClaudeAgent(claude_dir=custom_path)
+
+        assert agent.claude_dir == custom_path
+        assert agent.claude_dir != env_path
+
+    def test_skill_installation_in_custom_dir_creates_directory(self, tmp_path, monkeypatch):
+        """Test that skill installation creates CLAUDE_CONFIG_DIR if needed."""
+        custom_path = tmp_path / "non-existent" / "claude-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_path))
+
+        # Directory should not exist yet
+        assert not custom_path.exists()
+
+        # Install skills
+        changed, up_to_date, failed = install_or_upgrade_reference_skills(dry_run=False, quiet=True)
+
+        # Verify directory was created
+        assert custom_path.exists()
+        assert (custom_path / "skills").exists()
+
+    def test_default_behavior_without_env_var(self, tmp_path, monkeypatch):
+        """Test that default behavior is preserved when CLAUDE_CONFIG_DIR is not set."""
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        result = get_claude_config_dir()
+        expected = tmp_path / ".claude"
+
+        assert result == expected
+
+    def test_multiple_agents_share_same_claude_config_dir(self, tmp_path, monkeypatch):
+        """Test that multiple ClaudeAgent instances use the same CLAUDE_CONFIG_DIR."""
+        custom_path = tmp_path / "shared-claude-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_path))
+
+        agent1 = ClaudeAgent()
+        agent2 = ClaudeAgent()
+
+        assert agent1.claude_dir == agent2.claude_dir
+        assert agent1.claude_dir == custom_path

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from devflow.utils.paths import get_cs_home, is_mock_mode
+from devflow.utils.paths import get_cs_home, is_mock_mode, get_claude_config_dir
 
 
 def test_get_cs_home_default(monkeypatch, tmp_path):
@@ -134,3 +134,104 @@ def test_is_mock_mode_with_daf_set_to_zero(monkeypatch):
     monkeypatch.setenv("DAF_MOCK_MODE", "0")
 
     assert is_mock_mode() is False
+
+
+# Tests for get_claude_config_dir()
+
+
+def test_get_claude_config_dir_default(monkeypatch, tmp_path):
+    """Test get_claude_config_dir returns ~/.claude by default."""
+    # Ensure environment variable is not set
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+    # Mock Path.home() to use tmp_path to avoid side effects
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    result = get_claude_config_dir()
+    expected = tmp_path / ".claude"
+
+    assert result == expected
+    assert isinstance(result, Path)
+
+
+def test_get_claude_config_dir_with_env_var(monkeypatch, tmp_path):
+    """Test get_claude_config_dir returns CLAUDE_CONFIG_DIR value when set."""
+    custom_path = tmp_path / "custom-claude-config"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_path))
+
+    result = get_claude_config_dir()
+
+    assert result == custom_path
+    assert isinstance(result, Path)
+
+
+def test_get_claude_config_dir_with_tilde_expansion(monkeypatch):
+    """Test get_claude_config_dir expands tilde in CLAUDE_CONFIG_DIR."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "~/.config/claude")
+
+    result = get_claude_config_dir()
+    expected = Path.home() / ".config/claude"
+
+    assert result == expected
+    assert not str(result).startswith("~")
+
+
+def test_get_claude_config_dir_with_relative_path(monkeypatch):
+    """Test get_claude_config_dir resolves relative paths to absolute."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "relative/claude/path")
+
+    result = get_claude_config_dir()
+
+    assert result.is_absolute()
+    assert str(result).endswith("relative/claude/path")
+
+
+def test_get_claude_config_dir_with_absolute_path(monkeypatch, tmp_path):
+    """Test get_claude_config_dir handles absolute paths."""
+    custom_path = tmp_path / "absolute-claude-config"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_path))
+
+    result = get_claude_config_dir()
+
+    assert result == custom_path
+    assert result.is_absolute()
+
+
+def test_get_claude_config_dir_consistency(monkeypatch, tmp_path):
+    """Test get_claude_config_dir returns same value on multiple calls."""
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+    # Mock Path.home() to use tmp_path to avoid side effects
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    result1 = get_claude_config_dir()
+    result2 = get_claude_config_dir()
+
+    assert result1 == result2
+
+
+def test_get_claude_config_dir_with_complex_path(monkeypatch, tmp_path):
+    """Test get_claude_config_dir handles paths with spaces and special chars."""
+    complex_path = tmp_path / "my config" / "claude-data"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(complex_path))
+
+    result = get_claude_config_dir()
+
+    assert result == complex_path
+    assert isinstance(result, Path)
+
+
+def test_get_claude_config_dir_different_from_devaiflow_home(monkeypatch, tmp_path):
+    """Test get_claude_config_dir and get_cs_home can have different values."""
+    claude_path = tmp_path / "claude-config"
+    devaiflow_path = tmp_path / "devaiflow-sessions"
+
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_path))
+    monkeypatch.setenv("DEVAIFLOW_HOME", str(devaiflow_path))
+
+    claude_result = get_claude_config_dir()
+    devaiflow_result = get_cs_home()
+
+    assert claude_result != devaiflow_result
+    assert claude_result == claude_path
+    assert devaiflow_result == devaiflow_path


### PR DESCRIPTION
Jira Issue: <https://jira.example.com/browse/itdove/devaiflow#285>

## Description
This PR adds support for the `CLAUDE_CONFIG_DIR` environment variable throughout the DevAIFlow codebase to allow users to customize the location where Claude configuration files and skills are installed. This change enables users to specify an alternative configuration directory instead of using the default `~/.claude` location.

The implementation updates 19 files across the codebase to consistently respect the `CLAUDE_CONFIG_DIR` environment variable, including:
- Agent implementations (claude_agent.py, ollama_claude_agent.py, claude_mock.py)
- CLI commands (init, upgrade, cleanup, info, open)
- Core utilities (paths.py, claude_commands.py, skills_discovery.py)
- Session management (discovery.py, repair.py, summary.py)
- Archive and backup managers
- Export functionality

This change is particularly important for `daf init` and `daf upgrade` commands, which install skills to the Claude configuration directory. With this update, users can control where skills are installed by setting the `CLAUDE_CONFIG_DIR` environment variable.

Comprehensive integration tests have been added to verify the functionality works correctly across different scenarios.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Verify default behavior (without CLAUDE_CONFIG_DIR set):
   - Run `daf init` and verify skills are installed to `~/.claude/skills/`
   - Run `daf info` and verify it shows the default configuration directory
3. Test with custom CLAUDE_CONFIG_DIR:
   - Set `export CLAUDE_CONFIG_DIR=/tmp/custom-claude-config`
   - Run `daf init` and verify skills are installed to `/tmp/custom-claude-config/skills/`
   - Run `daf upgrade` and verify it uses the custom directory
   - Run `daf info` and verify it shows the custom configuration directory
4. Test other commands respect the environment variable:
   - Run `daf open` and verify session initialization uses the correct config directory
   - Run `daf cleanup` with the custom directory set
5. Run the test suite: `pytest tests/test_claude_config_dir_integration.py tests/test_paths.py`

### Scenarios tested
- Default behavior without CLAUDE_CONFIG_DIR environment variable set
- Custom configuration directory with CLAUDE_CONFIG_DIR set to an absolute path
- Skills installation and discovery with custom config directory
- Session management and repair operations with custom config directory
- Backward compatibility with existing installations

## Deployment considerations
- [x] This code change is ready for deployment on its own