### PR TITLE
itdove/devaiflow#290: Add project-level installation option for skills and commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,13 +387,18 @@ devflow/
 **❌ DO NOT EDIT DIRECTLY (Deployment Targets):**
 1. **`.claude/skills/daf-cli/SKILL.md`** (in this repository)
    - Development workspace copy
-   - Deployed by `daf upgrade` from `devflow/cli_skills/`
+   - Deployed by `daf upgrade --project-path .` from `devflow/cli_skills/`
    - Used for testing during development of DevAIFlow itself
 
 2. **`~/.claude/skills/daf-cli/SKILL.md`** (user home directory)
-   - User's local copy
+   - User's global copy
    - Deployed by `daf upgrade` from bundled version
-   - End users interact with this file
+   - Available in all projects by default
+
+3. **`<project>/.claude/skills/daf-cli/SKILL.md`** (project-specific)
+   - Project-level copy
+   - Deployed by `daf upgrade --project-path <project>` from bundled version
+   - Allows different skill versions per project
 
 **Why this matters:**
 - Skills must only document commands that work **inside Claude Code sessions**
@@ -414,9 +419,55 @@ devflow/
 
 **Update workflow:**
 1. Edit `devflow/cli_skills/daf-cli/SKILL.md` (bundled/primary version) ✅
-2. Run `daf upgrade` in development workspace to deploy to `.claude/skills/`
+2. Deploy to your development workspace:
+   - Global: `daf upgrade` → deploys to `~/.claude/skills/`
+   - Project: `daf upgrade --project-path .` → deploys to `.claude/skills/`
 3. Test the skill in a Claude Code session
-4. Users run `daf upgrade` to sync to their `~/.claude/skills/` directory
+4. Users install via:
+   - Global: `daf upgrade` → available in all projects
+   - Project-specific: `daf upgrade --project-path /path/to/project` → only in that project
+
+#### Project-Level Installation Examples
+
+**Use cases for project-level installation:**
+- Different skill versions for different projects
+- Project-specific skill customizations (not recommended for official skills)
+- Local development and testing of skill modifications
+- Team-specific skills that should not be installed globally
+
+**Installation commands:**
+
+```bash
+# Install to current project directory
+cd /path/to/your/project
+daf upgrade --project-path .
+
+# Install to specific project
+daf upgrade --project-path /path/to/project
+
+# Preview what would be installed
+daf upgrade --project-path . --dry-run
+
+# Install to global location (default)
+daf upgrade
+```
+
+**How skills are discovered:**
+
+Skills are loaded in this order (generic before organization-specific):
+1. User-level: `~/.claude/skills/` - Global, available everywhere
+2. Workspace-level: `<workspace>/.claude/skills/` - Workspace-specific
+3. Hierarchical: `$DEVAIFLOW_HOME/.claude/skills/` - Organization-specific
+4. Project-level: `<project>/.claude/skills/` - Project-specific
+
+If the same skill exists in multiple locations, all versions are loaded in order. Organization-specific skills (hierarchical) extend generic skills, so they must be loaded after generic ones.
+
+**Benefits of project-level installation:**
+- **Flexibility**: Choose installation location based on needs
+- **Project Isolation**: Different projects can have different skill versions
+- **Development Workflow**: Test skill changes locally before global deployment
+- **Team Collaboration**: Project-level skills can be committed to version control
+- **Backward Compatible**: Default behavior unchanged (installs globally)
 
 #### Claude Commands
 1. **Bundled commands (source of truth)**: `devflow/claude_commands/*.md`

--- a/devflow/cli/commands/upgrade_command.py
+++ b/devflow/cli/commands/upgrade_command.py
@@ -17,13 +17,14 @@ def upgrade_all(
     dry_run: bool = False,
     quiet: bool = False,
     upgrade_skills: bool = True,
-    upgrade_hierarchical_skills: bool = True
+    upgrade_hierarchical_skills: bool = True,
+    project_path: str = None
 ) -> None:
     """Upgrade bundled Claude Code skills.
 
     This command will:
-    - Install slash commands (daf-*) to ~/.claude/skills/ (global, available everywhere)
-    - Install reference skills (daf-cli, gh-cli, etc.) to ~/.claude/skills/ (global)
+    - Install slash commands (daf-*) to target directory
+    - Install reference skills (daf-cli, gh-cli, etc.) to target directory
     - Install organization-specific skills from hierarchical config files
     - Skip items that are already up-to-date
 
@@ -32,11 +33,12 @@ def upgrade_all(
         quiet: If True, suppress console output (errors still shown)
         upgrade_skills: If True, upgrade bundled skills (slash commands + reference skills)
         upgrade_hierarchical_skills: If True, install hierarchical skills from config files
+        project_path: Project directory path for project-level installation (default: None = global)
 
     Note:
-        All bundled skills are installed globally to ~/.claude/skills/ so they're
-        available in any project. Hierarchical skills are installed to
-        ~/.daf-sessions/.claude/skills/ for organization-specific context.
+        By default, skills are installed globally to ~/.claude/skills/.
+        With --project-path, skills are installed to <project>/.claude/skills/.
+        Hierarchical skills are always installed to ~/.daf-sessions/.claude/skills/.
     """
     config_loader = ConfigLoader()
     config = config_loader.load_config()
@@ -51,6 +53,23 @@ def upgrade_all(
         console.print("[dim]Add a workspace with: daf workspace add <name> <path>[/dim]")
         return
 
+    # Validate and determine target directory for skill installation
+    target_dir = None
+    if project_path:
+        project_path_obj = Path(project_path).expanduser().resolve()
+
+        # Validate that project path exists
+        if not project_path_obj.exists():
+            console.print(f"[red]✗[/red] Project path does not exist: {project_path_obj}")
+            return
+
+        if not project_path_obj.is_dir():
+            console.print(f"[red]✗[/red] Project path is not a directory: {project_path_obj}")
+            return
+
+        # Set target directory to <project>/.claude/skills/
+        target_dir = project_path_obj / ".claude" / "skills"
+
     if not quiet:
         if dry_run:
             console.print("[cyan]Checking for updates (dry run)...[/cyan]")
@@ -63,17 +82,21 @@ def upgrade_all(
     all_up_to_date = []
     all_failed = []
 
-    # Install slash commands globally
+    # Install slash commands
     if upgrade_skills:
         if not quiet:
             console.print("[bold]Slash Commands:[/bold]")
-            console.print(f"[dim]Installing to: ~/.claude/skills/[/dim]")
+            if target_dir:
+                console.print(f"[dim]Installing to: {target_dir}/[/dim]")
+            else:
+                console.print(f"[dim]Installing to: ~/.claude/skills/[/dim]")
             console.print()
 
         try:
             changed, up_to_date, failed = install_or_upgrade_slash_commands(
                 dry_run=dry_run,
-                quiet=quiet
+                quiet=quiet,
+                target_dir=target_dir
             )
             all_changed.extend([f"slash:{name}" for name in changed])
             all_up_to_date.extend([f"slash:{name}" for name in up_to_date])
@@ -90,17 +113,21 @@ def upgrade_all(
         if not quiet:
             console.print()
 
-    # Install reference skills globally
+    # Install reference skills
     if upgrade_skills:
         if not quiet:
             console.print("[bold]Reference Skills:[/bold]")
-            console.print(f"[dim]Installing to: ~/.claude/skills/[/dim]")
+            if target_dir:
+                console.print(f"[dim]Installing to: {target_dir}/[/dim]")
+            else:
+                console.print(f"[dim]Installing to: ~/.claude/skills/[/dim]")
             console.print()
 
         try:
             changed, up_to_date, failed = install_or_upgrade_reference_skills(
                 dry_run=dry_run,
-                quiet=quiet
+                quiet=quiet,
+                target_dir=target_dir
             )
             all_changed.extend([f"ref:{name}" for name in changed])
             all_up_to_date.extend([f"ref:{name}" for name in up_to_date])
@@ -170,7 +197,10 @@ def upgrade_all(
 
         # Show locations
         if upgrade_skills:
-            console.print(f"\n[dim]Bundled skills: ~/.claude/skills/[/dim]")
+            if target_dir:
+                console.print(f"\n[dim]Bundled skills: {target_dir}/[/dim]")
+            else:
+                console.print(f"\n[dim]Bundled skills: ~/.claude/skills/[/dim]")
 
         if upgrade_hierarchical_skills:
             from devflow.utils.paths import get_cs_home

--- a/devflow/cli/main.py
+++ b/devflow/cli/main.py
@@ -3754,22 +3754,31 @@ def purge_mock_data_cmd(ctx: click.Context, force: bool) -> None:
 @click.option("--dry-run", is_flag=True, help="Show what would be upgraded without actually upgrading")
 @click.option("--commands-only", is_flag=True, help="Upgrade only bundled slash commands")
 @click.option("--skills-only", is_flag=True, help="Upgrade only bundled skills")
+@click.option("--project-path", type=click.Path(), help="Install skills to project directory (e.g., '.', '/path/to/project')")
 @json_option
-def upgrade(ctx: click.Context, dry_run: bool, commands_only: bool, skills_only: bool) -> None:
+def upgrade(ctx: click.Context, dry_run: bool, commands_only: bool, skills_only: bool, project_path: str) -> None:
     """Upgrade bundled Claude Code skills.
 
-    This command installs all skills to ~/.claude/skills/ (global):
+    This command installs skills to ~/.claude/skills/ (global) by default.
+    Use --project-path to install to a specific project directory instead.
+
+    Installation locations:
+    - Default: ~/.claude/skills/ (available in all projects)
+    - With --project-path: <project>/.claude/skills/ (project-specific)
+    - Hierarchical skills: ~/.daf-sessions/.claude/skills/ (organization config)
+
+    Skills installed:
     - Slash commands: /daf-active, /daf-help, /daf-info, etc.
     - Reference skills: daf-cli, gh-cli, git-cli, glab-cli
-    - Hierarchical skills from organization config (to ~/.daf-sessions/)
+    - Hierarchical skills from organization config files
 
     Items that are already up-to-date will be skipped.
 
-    Note: All skills are installed globally so they work in any project.
-
     Examples:
-        daf upgrade           # Upgrade all skills
-        daf upgrade --dry-run # Preview what would be upgraded
+        daf upgrade                      # Install to ~/.claude/skills/ (global)
+        daf upgrade --project-path .     # Install to current directory
+        daf upgrade --project-path /path # Install to specific project
+        daf upgrade --dry-run            # Preview what would be upgraded
     """
     from devflow.cli.commands.upgrade_command import upgrade_all
 
@@ -3779,7 +3788,7 @@ def upgrade(ctx: click.Context, dry_run: bool, commands_only: bool, skills_only:
         console.print("[dim]All slash commands are now skills. Upgrading all skills...[/dim]")
         console.print()
 
-    upgrade_all(dry_run=dry_run, upgrade_skills=True)
+    upgrade_all(dry_run=dry_run, upgrade_skills=True, project_path=project_path)
 
 
 # Note: 'import' is a Python keyword, so we name the function import_cmd

--- a/devflow/utils/claude_commands.py
+++ b/devflow/utils/claude_commands.py
@@ -143,9 +143,10 @@ def list_reference_skills() -> List[Path]:
 
 def install_or_upgrade_slash_commands(
     dry_run: bool = False,
-    quiet: bool = False
+    quiet: bool = False,
+    target_dir: Optional[Path] = None
 ) -> Tuple[List[str], List[str], List[str]]:
-    """Install or upgrade bundled slash commands to user-level ~/.claude/skills directory.
+    """Install or upgrade bundled slash commands to specified directory.
 
     Slash commands are skills with a 'name:' field in their frontmatter that should be
     globally available across all projects.
@@ -153,6 +154,7 @@ def install_or_upgrade_slash_commands(
     Args:
         dry_run: If True, only report what would be changed without actually changing
         quiet: If True, suppress console output (errors still shown)
+        target_dir: Target directory for installation (default: ~/.claude/skills/)
 
     Returns:
         Tuple of (installed/upgraded, up_to_date, failed) skill names
@@ -161,9 +163,12 @@ def install_or_upgrade_slash_commands(
     if not slash_commands:
         return ([], [], [])
 
-    # Install to user-level ~/.claude/skills/ (or $CLAUDE_CONFIG_DIR/skills/)
-    claude_config = get_claude_config_dir()
-    skills_dir = claude_config / "skills"
+    # Install to specified directory or default to user-level ~/.claude/skills/
+    if target_dir is None:
+        claude_config = get_claude_config_dir()
+        skills_dir = claude_config / "skills"
+    else:
+        skills_dir = target_dir
 
     if not dry_run:
         skills_dir.mkdir(parents=True, exist_ok=True)
@@ -204,9 +209,10 @@ def install_or_upgrade_slash_commands(
 
 def install_or_upgrade_reference_skills(
     dry_run: bool = False,
-    quiet: bool = False
+    quiet: bool = False,
+    target_dir: Optional[Path] = None
 ) -> Tuple[List[str], List[str], List[str]]:
-    """Install or upgrade bundled reference skills to user-level ~/.claude/skills directory.
+    """Install or upgrade bundled reference skills to specified directory.
 
     Reference skills are skills WITHOUT a 'name:' field that provide context and
     documentation (like daf-cli, gh-cli, git-cli, glab-cli).
@@ -214,6 +220,7 @@ def install_or_upgrade_reference_skills(
     Args:
         dry_run: If True, only report what would be changed without actually changing
         quiet: If True, suppress console output (errors still shown)
+        target_dir: Target directory for installation (default: ~/.claude/skills/)
 
     Returns:
         Tuple of (installed/upgraded, up_to_date, failed) skill names
@@ -223,9 +230,12 @@ def install_or_upgrade_reference_skills(
     if not bundled_skills:
         return ([], [], [])
 
-    # Install to user-level ~/.claude/skills/ (or $CLAUDE_CONFIG_DIR/skills/)
-    claude_config = get_claude_config_dir()
-    skills_dir = claude_config / "skills"
+    # Install to specified directory or default to user-level ~/.claude/skills/
+    if target_dir is None:
+        claude_config = get_claude_config_dir()
+        skills_dir = claude_config / "skills"
+    else:
+        skills_dir = target_dir
 
     if not dry_run:
         skills_dir.mkdir(parents=True, exist_ok=True)

--- a/integration-tests/test_upgrade_project_path.sh
+++ b/integration-tests/test_upgrade_project_path.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+# Integration test for daf upgrade --project-path feature
+#
+# This test verifies:
+# 1. Skills install to project directory when --project-path is specified
+# 2. Skills install to ~/.claude/skills/ by default
+# 3. Project-level skills are discoverable
+# 4. --dry-run mode works with --project-path
+# 5. Error handling for invalid project paths
+
+set -e
+
+# Enable debug mode if --debug flag is passed
+if [[ "$1" == "--debug" ]]; then
+    set -x
+fi
+
+# Test configuration
+TEMP_DIR="/tmp/test-upgrade-project-path-$$"
+TEST_PROJECT="$TEMP_DIR/test-project"
+GLOBAL_SKILLS_DIR="$HOME/.claude/skills"
+BACKUP_SKILLS_DIR="$HOME/.claude/skills.backup-$$"
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "=== Testing daf upgrade --project-path feature ==="
+echo ""
+
+# Setup: Create test environment
+echo "Setting up test environment..."
+mkdir -p "$TEST_PROJECT"
+mkdir -p "$TEMP_DIR"
+
+# Backup existing global skills if they exist
+if [ -d "$GLOBAL_SKILLS_DIR" ]; then
+    echo "Backing up existing global skills to $BACKUP_SKILLS_DIR"
+    mv "$GLOBAL_SKILLS_DIR" "$BACKUP_SKILLS_DIR"
+fi
+
+# Cleanup function
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    rm -rf "$TEMP_DIR"
+
+    # Restore global skills backup
+    if [ -d "$BACKUP_SKILLS_DIR" ]; then
+        echo "Restoring global skills from backup"
+        rm -rf "$GLOBAL_SKILLS_DIR"
+        mv "$BACKUP_SKILLS_DIR" "$GLOBAL_SKILLS_DIR"
+    fi
+}
+
+trap cleanup EXIT
+
+# Test 1: Install to project directory
+echo "=== Test 1: Install skills to project directory ==="
+daf upgrade --project-path "$TEST_PROJECT"
+echo ""
+
+if [ -d "$TEST_PROJECT/.claude/skills" ]; then
+    skill_count=$(ls -1 "$TEST_PROJECT/.claude/skills" | wc -l | tr -d ' ')
+    echo -e "${GREEN}✓${NC} Skills directory created at $TEST_PROJECT/.claude/skills/"
+    echo "  Found $skill_count skill directories"
+
+    # Verify at least some skills were installed
+    if [ "$skill_count" -gt 5 ]; then
+        echo -e "${GREEN}✓${NC} Multiple skills installed successfully"
+    else
+        echo -e "${RED}✗${NC} Expected more than 5 skills, found $skill_count"
+        exit 1
+    fi
+else
+    echo -e "${RED}✗${NC} Skills directory NOT created at project path"
+    ls -la "$TEST_PROJECT/" || true
+    exit 1
+fi
+
+# Verify specific skills exist
+expected_skills=("daf-cli" "gh-cli" "git-cli" "glab-cli")
+for skill in "${expected_skills[@]}"; do
+    if [ -d "$TEST_PROJECT/.claude/skills/$skill" ]; then
+        echo -e "${GREEN}✓${NC} $skill installed"
+    else
+        echo -e "${RED}✗${NC} $skill NOT installed"
+        exit 1
+    fi
+done
+
+echo ""
+
+# Test 2: Install to current directory using '.'
+echo "=== Test 2: Install to current directory using '.' ==="
+TEST_PROJECT_CURRENT="$TEMP_DIR/test-current"
+mkdir -p "$TEST_PROJECT_CURRENT"
+cd "$TEST_PROJECT_CURRENT"
+daf upgrade --project-path .
+cd - > /dev/null
+echo ""
+
+if [ -d "$TEST_PROJECT_CURRENT/.claude/skills" ]; then
+    echo -e "${GREEN}✓${NC} Skills installed to current directory"
+else
+    echo -e "${RED}✗${NC} Skills NOT installed to current directory"
+    exit 1
+fi
+
+echo ""
+
+# Test 3: Default installation (global)
+echo "=== Test 3: Default installation to ~/.claude/skills/ ==="
+# Remove global skills if they exist
+rm -rf "$GLOBAL_SKILLS_DIR"
+
+daf upgrade
+echo ""
+
+if [ -d "$GLOBAL_SKILLS_DIR" ]; then
+    skill_count=$(ls -1 "$GLOBAL_SKILLS_DIR" | wc -l | tr -d ' ')
+    echo -e "${GREEN}✓${NC} Skills installed to global directory: $GLOBAL_SKILLS_DIR"
+    echo "  Found $skill_count skill directories"
+else
+    echo -e "${RED}✗${NC} Global skills directory NOT created"
+    exit 1
+fi
+
+echo ""
+
+# Test 4: Dry run with project path
+echo "=== Test 4: Dry run mode with --project-path ==="
+TEST_PROJECT_DRYRUN="$TEMP_DIR/test-dryrun"
+mkdir -p "$TEST_PROJECT_DRYRUN"
+
+daf upgrade --project-path "$TEST_PROJECT_DRYRUN" --dry-run
+echo ""
+
+# In dry run mode, skills should NOT be installed
+if [ ! -d "$TEST_PROJECT_DRYRUN/.claude/skills" ]; then
+    echo -e "${GREEN}✓${NC} Dry run mode: skills NOT installed (as expected)"
+else
+    # Check if any skills were installed
+    if [ -n "$(ls -A "$TEST_PROJECT_DRYRUN/.claude/skills" 2>/dev/null)" ]; then
+        echo -e "${RED}✗${NC} Dry run mode: skills were installed (unexpected)"
+        exit 1
+    else
+        echo -e "${GREEN}✓${NC} Dry run mode: skills directory created but empty (acceptable)"
+    fi
+fi
+
+echo ""
+
+# Test 5: Error handling - nonexistent path
+echo "=== Test 5: Error handling for nonexistent path ==="
+NONEXISTENT_PATH="$TEMP_DIR/nonexistent-path"
+
+output=$(daf upgrade --project-path "$NONEXISTENT_PATH" 2>&1 || true)
+if echo "$output" | grep -q "does not exist"; then
+    echo -e "${GREEN}✓${NC} Correct error message for nonexistent path"
+else
+    echo -e "${RED}✗${NC} Expected error message not found"
+    echo "Output: $output"
+    exit 1
+fi
+
+echo ""
+
+# Test 6: Error handling - path is a file
+echo "=== Test 6: Error handling for file path ==="
+FILE_PATH="$TEMP_DIR/test-file.txt"
+touch "$FILE_PATH"
+
+output=$(daf upgrade --project-path "$FILE_PATH" 2>&1 || true)
+if echo "$output" | grep -q "not a directory"; then
+    echo -e "${GREEN}✓${NC} Correct error message for file path"
+else
+    echo -e "${RED}✗${NC} Expected error message not found"
+    echo "Output: $output"
+    exit 1
+fi
+
+echo ""
+
+# Test 7: Skills are discoverable (verify SKILL.md files exist)
+echo "=== Test 7: Verify skills have SKILL.md files ==="
+skills_valid=true
+for skill_dir in "$TEST_PROJECT/.claude/skills"/*; do
+    if [ -d "$skill_dir" ]; then
+        skill_name=$(basename "$skill_dir")
+        if [ -f "$skill_dir/SKILL.md" ]; then
+            echo -e "${GREEN}✓${NC} $skill_name has SKILL.md"
+        else
+            echo -e "${RED}✗${NC} $skill_name missing SKILL.md"
+            skills_valid=false
+        fi
+    fi
+done
+
+if [ "$skills_valid" = false ]; then
+    exit 1
+fi
+
+echo ""
+
+# Test 8: Verify skill content matches bundled version
+echo "=== Test 8: Verify installed skills match bundled version ==="
+# Compare daf-cli skill as a sample
+if [ -f "$TEST_PROJECT/.claude/skills/daf-cli/SKILL.md" ]; then
+    # Just verify the file has content
+    if [ -s "$TEST_PROJECT/.claude/skills/daf-cli/SKILL.md" ]; then
+        echo -e "${GREEN}✓${NC} Installed skill has content"
+    else
+        echo -e "${RED}✗${NC} Installed skill file is empty"
+        exit 1
+    fi
+else
+    echo -e "${YELLOW}⚠${NC} daf-cli/SKILL.md not found for verification"
+fi
+
+echo ""
+echo -e "${GREEN}=== All tests passed! ===${NC}"

--- a/tests/test_upgrade_command.py
+++ b/tests/test_upgrade_command.py
@@ -477,3 +477,190 @@ class TestUpgradeAllComprehensive:
 
                                     # Both location messages should be printed
                                     assert mock_console.print.called
+
+
+class TestProjectPathInstallation:
+    """Tests for --project-path installation option."""
+
+    def test_upgrade_with_valid_project_path(self, mock_config, mock_config_loader, tmp_path):
+        """Test upgrade with valid project path."""
+        # Create project directory
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        with patch('devflow.cli.commands.upgrade_command.ConfigLoader', return_value=mock_config_loader):
+            with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_slash_commands') as mock_slash:
+                with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_reference_skills') as mock_ref:
+                    with patch('devflow.cli.commands.upgrade_command.console'):
+                        mock_slash.return_value = (["daf-list"], [], [])
+                        mock_ref.return_value = (["gh-cli"], [], [])
+
+                        upgrade_all(
+                            upgrade_skills=True,
+                            upgrade_hierarchical_skills=False,
+                            project_path=str(project_dir)
+                        )
+
+                        # Verify target_dir was passed to install functions
+                        expected_target = project_dir / ".claude" / "skills"
+                        assert mock_slash.call_args[1]['target_dir'] == expected_target
+                        assert mock_ref.call_args[1]['target_dir'] == expected_target
+
+    def test_upgrade_with_current_directory(self, mock_config, mock_config_loader, tmp_path, monkeypatch):
+        """Test upgrade with current directory (.)."""
+        # Create project directory and change to it
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+        monkeypatch.chdir(project_dir)
+
+        with patch('devflow.cli.commands.upgrade_command.ConfigLoader', return_value=mock_config_loader):
+            with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_slash_commands') as mock_slash:
+                with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_reference_skills') as mock_ref:
+                    with patch('devflow.cli.commands.upgrade_command.console'):
+                        mock_slash.return_value = ([], [], [])
+                        mock_ref.return_value = ([], [], [])
+
+                        upgrade_all(
+                            upgrade_skills=True,
+                            upgrade_hierarchical_skills=False,
+                            project_path="."
+                        )
+
+                        # Verify target_dir resolves to absolute path
+                        call_args = mock_slash.call_args[1]
+                        assert call_args['target_dir'] is not None
+                        assert call_args['target_dir'].is_absolute()
+
+    def test_upgrade_with_nonexistent_project_path(self, mock_config, mock_config_loader, tmp_path):
+        """Test upgrade with nonexistent project path."""
+        nonexistent_path = tmp_path / "nonexistent"
+
+        with patch('devflow.cli.commands.upgrade_command.ConfigLoader', return_value=mock_config_loader):
+            with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_slash_commands') as mock_slash:
+                with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_reference_skills') as mock_ref:
+                    with patch('devflow.cli.commands.upgrade_command.console') as mock_console:
+                        upgrade_all(
+                            upgrade_skills=True,
+                            upgrade_hierarchical_skills=False,
+                            project_path=str(nonexistent_path)
+                        )
+
+                        # Should print error and return early
+                        assert mock_console.print.called
+                        # Should not call install functions
+                        mock_slash.assert_not_called()
+                        mock_ref.assert_not_called()
+
+    def test_upgrade_with_project_path_as_file(self, mock_config, mock_config_loader, tmp_path):
+        """Test upgrade with project path pointing to a file."""
+        # Create a file instead of directory
+        file_path = tmp_path / "test-file.txt"
+        file_path.write_text("test")
+
+        with patch('devflow.cli.commands.upgrade_command.ConfigLoader', return_value=mock_config_loader):
+            with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_slash_commands') as mock_slash:
+                with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_reference_skills') as mock_ref:
+                    with patch('devflow.cli.commands.upgrade_command.console') as mock_console:
+                        upgrade_all(
+                            upgrade_skills=True,
+                            upgrade_hierarchical_skills=False,
+                            project_path=str(file_path)
+                        )
+
+                        # Should print error and return early
+                        assert mock_console.print.called
+                        # Should not call install functions
+                        mock_slash.assert_not_called()
+                        mock_ref.assert_not_called()
+
+    def test_upgrade_without_project_path_uses_global(self, mock_config, mock_config_loader):
+        """Test upgrade without project path defaults to global installation."""
+        with patch('devflow.cli.commands.upgrade_command.ConfigLoader', return_value=mock_config_loader):
+            with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_slash_commands') as mock_slash:
+                with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_reference_skills') as mock_ref:
+                    with patch('devflow.cli.commands.upgrade_command.console'):
+                        mock_slash.return_value = ([], [], [])
+                        mock_ref.return_value = ([], [], [])
+
+                        upgrade_all(
+                            upgrade_skills=True,
+                            upgrade_hierarchical_skills=False,
+                            project_path=None
+                        )
+
+                        # Verify target_dir is None (defaults to global)
+                        assert mock_slash.call_args[1]['target_dir'] is None
+                        assert mock_ref.call_args[1]['target_dir'] is None
+
+    def test_upgrade_project_path_dry_run(self, mock_config, mock_config_loader, tmp_path):
+        """Test dry run with project path."""
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        with patch('devflow.cli.commands.upgrade_command.ConfigLoader', return_value=mock_config_loader):
+            with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_slash_commands') as mock_slash:
+                with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_reference_skills') as mock_ref:
+                    with patch('devflow.cli.commands.upgrade_command.console'):
+                        mock_slash.return_value = (["daf-list"], [], [])
+                        mock_ref.return_value = (["gh-cli"], [], [])
+
+                        upgrade_all(
+                            dry_run=True,
+                            upgrade_skills=True,
+                            upgrade_hierarchical_skills=False,
+                            project_path=str(project_dir)
+                        )
+
+                        # Verify both dry_run and target_dir are passed
+                        assert mock_slash.call_args[1]['dry_run'] is True
+                        assert mock_ref.call_args[1]['dry_run'] is True
+                        expected_target = project_dir / ".claude" / "skills"
+                        assert mock_slash.call_args[1]['target_dir'] == expected_target
+                        assert mock_ref.call_args[1]['target_dir'] == expected_target
+
+    def test_upgrade_project_path_output_message(self, mock_config, mock_config_loader, tmp_path):
+        """Test that output message shows correct installation path."""
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        with patch('devflow.cli.commands.upgrade_command.ConfigLoader', return_value=mock_config_loader):
+            with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_slash_commands') as mock_slash:
+                with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_reference_skills') as mock_ref:
+                    with patch('devflow.cli.commands.upgrade_command.console') as mock_console:
+                        mock_slash.return_value = (["daf-list"], [], [])
+                        mock_ref.return_value = ([], [], [])
+
+                        upgrade_all(
+                            upgrade_skills=True,
+                            upgrade_hierarchical_skills=False,
+                            project_path=str(project_dir),
+                            quiet=False
+                        )
+
+                        # Verify console.print was called with project path
+                        assert mock_console.print.called
+                        # Check if any call contains the project path
+                        calls = [str(call) for call in mock_console.print.call_args_list]
+                        assert any(str(project_dir) in call for call in calls)
+
+    def test_upgrade_project_path_with_tilde(self, mock_config, mock_config_loader, tmp_path):
+        """Test upgrade with project path containing tilde (~)."""
+        # Note: We can't actually test with real home directory, so we mock expanduser
+        with patch('devflow.cli.commands.upgrade_command.ConfigLoader', return_value=mock_config_loader):
+            with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_slash_commands') as mock_slash:
+                with patch('devflow.cli.commands.upgrade_command.install_or_upgrade_reference_skills') as mock_ref:
+                    with patch('devflow.cli.commands.upgrade_command.console'):
+                        with patch('pathlib.Path.expanduser') as mock_expanduser:
+                            with patch('pathlib.Path.exists', return_value=True):
+                                with patch('pathlib.Path.is_dir', return_value=True):
+                                    mock_slash.return_value = ([], [], [])
+                                    mock_ref.return_value = ([], [], [])
+
+                                    upgrade_all(
+                                        upgrade_skills=True,
+                                        upgrade_hierarchical_skills=False,
+                                        project_path="~/projects/test"
+                                    )
+
+                                    # Should have called expanduser
+                                    assert mock_expanduser.called


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->
Related Issue: itdove/devaiflow#290

## Description
This PR adds support for project-level installation of skills and commands in DevAIFlow. Previously, skills could only be installed globally. This enhancement allows users to install skills at the project level, enabling better isolation and project-specific customization.

**Key changes:**
- Enhanced the `upgrade` command to support a `--project-path` option for installing skills at the project level
- Updated CLI command structure in `upgrade_command.py` to handle project-level installations
- Modified `claude_commands.py` utility to support project-scoped skill management
- Added comprehensive integration tests (`test_upgrade_project_path.sh`) and unit tests
- Updated documentation in `AGENTS.md` to reflect the new installation options

**Technical decisions:**
- Maintained backward compatibility with existing global installation behavior
- Added project-path parameter to provide explicit control over installation scope
- Implemented proper validation and error handling for project-level installations

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Navigate to a test project directory
3. Run the upgrade command with `--project-path` option: `devflow upgrade --project-path .`
4. Verify that skills are installed in the project-local directory
5. Run the upgrade command without `--project-path` to verify global installation still works
6. Execute the new integration test: `./integration-tests/test_upgrade_project_path.sh`
7. Run unit tests: `pytest tests/test_upgrade_command.py`

### Scenarios tested
- Project-level skill installation with valid project path
- Global skill installation (existing behavior)
- Error handling for invalid project paths
- Integration tests covering both installation scopes
- Unit tests verifying command parameter handling

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: