### PR TITLE
fix: resolve macOS symlinks and sum tokens across conversations

### DIFF
--- a/devflow/agent/claude_agent.py
+++ b/devflow/agent/claude_agent.py
@@ -321,15 +321,39 @@ class ClaudeAgent(AgentInterface):
         Claude Code replaces / with - in paths (keeps the leading -)
         and also replaces _ with -.
 
+        Resolves known symlinks (e.g., /var -> /private/var on macOS) to match
+        how Claude Code encodes paths when it launches.
+
         Args:
             project_path: Absolute path to project
 
         Returns:
             Encoded path string
         """
+        # Resolve known symlinks to match Claude Code's behavior
+        # On macOS, /var is a symlink to private/var
+        # We need to handle this even for non-existent paths (temp directories)
+        resolved_path = project_path
+
+        # Handle /var -> /private/var symlink on macOS
+        if project_path.startswith("/var/"):
+            # Check if /var is actually a symlink
+            var_path = Path("/var")
+            if var_path.is_symlink():
+                # Replace /var/ with the resolved target
+                target = var_path.resolve()
+                resolved_path = str(target / project_path[5:])  # Skip "/var/"
+
+        # Handle /tmp -> /private/tmp symlink on macOS
+        elif project_path.startswith("/tmp/"):
+            tmp_path = Path("/tmp")
+            if tmp_path.is_symlink():
+                target = tmp_path.resolve()
+                resolved_path = str(target / project_path[5:])  # Skip "/tmp/"
+
         # Claude Code replaces / with - in paths (keeps the leading -)
         # AND also replaces _ with -
-        encoded = project_path.replace("/", "-").replace("_", "-")
+        encoded = resolved_path.replace("/", "-").replace("_", "-")
         return encoded
 
     def get_agent_home_dir(self) -> Path:

--- a/devflow/cli/commands/list_command.py
+++ b/devflow/cli/commands/list_command.py
@@ -144,29 +144,33 @@ def _display_page(
                     minutes_ago = int((time_diff.total_seconds() % 3600) // 60)
                     last_session_display = f"{minutes_ago}m ago" if minutes_ago > 0 else "just now"
 
-        # Get token usage for active conversation
+        # Get token usage for all conversations (sum across all repos)
         token_display = "-"
-        if session.active_conversation:
-            conv = session.active_conversation
-            if conv.project_path and conv.ai_agent_session_id:
-                try:
-                    agent = create_agent_client(agent_backend)
-                    token_usage = agent.extract_token_usage(
-                        conv.ai_agent_session_id,
-                        conv.project_path
-                    )
-                    if token_usage:
-                        total_tokens = token_usage.get("total_tokens", 0)
-                        if total_tokens > 0:
-                            # Format tokens with K/M suffix for readability
-                            if total_tokens >= 1_000_000:
-                                token_display = f"{total_tokens / 1_000_000:.1f}M"
-                            elif total_tokens >= 1_000:
-                                token_display = f"{total_tokens / 1_000:.1f}K"
-                            else:
-                                token_display = str(total_tokens)
-                except Exception:
-                    pass  # Silently ignore errors
+        total_tokens = 0
+        if session.conversations:
+            agent = create_agent_client(agent_backend)
+            for working_dir, conversation in session.conversations.items():
+                # Handle both Conversation (new format) and ConversationContext (old format)
+                conv = conversation.active_session if hasattr(conversation, 'active_session') else conversation
+                if conv and conv.project_path and conv.ai_agent_session_id:
+                    try:
+                        token_usage = agent.extract_token_usage(
+                            conv.ai_agent_session_id,
+                            conv.project_path
+                        )
+                        if token_usage:
+                            total_tokens += token_usage.get("total_tokens", 0)
+                    except Exception:
+                        pass  # Silently ignore errors for this conversation
+
+            # Format total tokens
+            if total_tokens > 0:
+                if total_tokens >= 1_000_000:
+                    token_display = f"{total_tokens / 1_000_000:.1f}M"
+                elif total_tokens >= 1_000:
+                    token_display = f"{total_tokens / 1_000:.1f}K"
+                else:
+                    token_display = str(total_tokens)
 
         # Add row
         table.add_row(


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR fixes an issue where token counts were not displayed for some sessions when running `daf list`. The token calculation was only being performed for sessions that were opened with `daf open`, leaving other sessions without token count information.

The fix addresses two key issues:
1. Resolves macOS symlink-related path issues that prevented proper conversation file discovery
2. Ensures token counts are summed across all conversations for each session, regardless of how the session was created or accessed

Changes made:
- Updated `devflow/agent/claude_agent.py` to properly resolve symlinked paths on macOS
- Modified `devflow/cli/commands/list_command.py` to calculate and display token counts for all sessions in the list output

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run `daf list` to display all sessions
3. Verify that token counts are now displayed for all sessions in the output
4. If on macOS, verify that sessions with symlinked paths correctly show token counts
5. Compare the output with the previous behavior to confirm all sessions now include token information

### Scenarios tested
- Verified `daf list` displays token counts for all sessions
- Confirmed symlink resolution works correctly on macOS
- Validated token summation across multiple conversations within a session

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: