### PR TITLE
itdove/devaiflow#320: Workspace selection should default to session's previous workspace on reopen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1644,6 +1644,17 @@ class Session(BaseModel):
   - All 2062 tests pass (3 skipped)
   - Documentation updated in docs/07-commands.md (export + import sections)
   - Enables flexible team collaboration with machine-specific workspace preferences
+- ✓ Workspace selection defaults to session's previous workspace on reopen (#320)
+  - Fixed workspace mismatch prompt to show session's previous workspace as option 1 (DEFAULT)
+  - Detected workspace (from current directory) is now option 2 instead of option 1
+  - Pressing Enter accepts the session's previous workspace (maintains session consistency)
+  - Respects workspace selection priority: flag > session > last_used > prompt
+  - Updated _handle_workspace_mismatch() in open_command.py
+  - Updated docstring to reflect new default selection behavior
+  - Comprehensive test coverage (3 new tests + updated existing tests in test_workspace_mismatch.py)
+  - All 3523 tests pass
+  - Documentation updated in docs/reference/commands.md
+  - Ensures session persistence and consistent workspace selection across reopens
 - ✓ Pre-flight JIRA field validation before API calls
   - Created centralized validation module (devflow/jira/validation.py)
   - JiraFieldValidator class validates fields against config.jira.field_mappings

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -1554,7 +1554,7 @@ def _handle_workspace_mismatch(
     This function prompts the user to confirm what to do when the detected workspace
     (from current directory) differs from the session's stored workspace.
 
-    Shows ALL configured workspaces with detected workspace as default selection.
+    Shows ALL configured workspaces with session's previous workspace as default selection.
 
     Args:
         session: Session object
@@ -1590,20 +1590,20 @@ def _handle_workspace_mismatch(
     # Build workspace options menu showing ALL configured workspaces
     console.print("[bold]Select workspace for this session:[/bold]")
 
-    # Build choices list with detected workspace first, then session workspace, then others
+    # Build choices list with session workspace first (as default), then detected, then others
     workspace_choices = []
     choice_to_workspace = {}
     choice_num = 1
 
-    # Option 1: Detected workspace (from current directory) - marked as DEFAULT
-    workspace_choices.append((choice_num, detected_workspace_name, "[DEFAULT]", True))
-    choice_to_workspace[choice_num] = detected_workspace_name
+    # Option 1: Session's previous workspace - marked as DEFAULT for reopens
+    workspace_choices.append((choice_num, selected_workspace_name, "(session's previous workspace) [DEFAULT]", True))
+    choice_to_workspace[choice_num] = selected_workspace_name
     choice_num += 1
 
-    # Option 2: Session's previous workspace (if different from detected)
-    if selected_workspace_name != detected_workspace_name:
-        workspace_choices.append((choice_num, selected_workspace_name, "(session's previous workspace)", False))
-        choice_to_workspace[choice_num] = selected_workspace_name
+    # Option 2: Detected workspace (from current directory) - if different from session workspace
+    if detected_workspace_name != selected_workspace_name:
+        workspace_choices.append((choice_num, detected_workspace_name, "(detected from current directory)", False))
+        choice_to_workspace[choice_num] = detected_workspace_name
         choice_num += 1
 
     # Options 3+: All other configured workspaces

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -716,12 +716,15 @@ Which project? [1-3]: 2
    - Starts time tracking
 
 2. **Resuming existing:**
-   - **Checks workspace context (AAP-64497)**
+   - **Checks workspace context (AAP-64497, #320)**
      - If current directory is in a different workspace than session's saved workspace:
-       - Prompts with three options:
-         1. Use session workspace (continue with workspace where session was created)
-         2. Switch to current workspace (update session to use current workspace)
-         3. Cancel (exit without opening session)
+       - Prompts to select workspace with session's previous workspace as default:
+         1. Session's previous workspace [DEFAULT] (continue with workspace where session was created)
+         2. Detected workspace (update session to use current workspace)
+         3. Other configured workspaces
+         4. Cancel (exit without opening session)
+       - **Default selection:** Session's previous workspace (pressing Enter accepts this)
+       - **Rationale:** Sessions remember their workspace for consistency across reopens
      - Workspace mismatch check is skipped when:
        - `--workspace` flag is explicitly provided (intentional override)
        - `--json` flag is used (non-interactive mode defaults to session workspace)

--- a/tests/test_workspace_mismatch.py
+++ b/tests/test_workspace_mismatch.py
@@ -140,7 +140,7 @@ def test_handle_workspace_mismatch_user_chooses_session_workspace(
     """Test workspace mismatch when user chooses to use session workspace."""
     from devflow.cli.commands.open_command import _handle_workspace_mismatch
 
-    with patch("rich.prompt.IntPrompt.ask", return_value=2):  # Changed: session workspace is now choice 2
+    with patch("rich.prompt.IntPrompt.ask", return_value=1):  # Session workspace is choice 1 (DEFAULT)
         result = _handle_workspace_mismatch(
             mock_session,
             mock_session_manager,
@@ -164,7 +164,7 @@ def test_handle_workspace_mismatch_user_chooses_current_workspace(
     """Test workspace mismatch when user chooses to switch to current workspace."""
     from devflow.cli.commands.open_command import _handle_workspace_mismatch
 
-    with patch("rich.prompt.IntPrompt.ask", return_value=1):  # Changed: detected workspace is now choice 1 (default)
+    with patch("rich.prompt.IntPrompt.ask", return_value=2):  # Detected workspace is choice 2
         result = _handle_workspace_mismatch(
             mock_session,
             mock_session_manager,
@@ -188,7 +188,7 @@ def test_handle_workspace_mismatch_user_cancels(
     """Test workspace mismatch when user cancels."""
     from devflow.cli.commands.open_command import _handle_workspace_mismatch
 
-    with patch("rich.prompt.IntPrompt.ask", return_value=4):  # Changed: cancel is now choice 4 (1=detected, 2=session, 3=workspace-c, 4=cancel)
+    with patch("rich.prompt.IntPrompt.ask", return_value=4):  # Cancel is choice 4 (1=session, 2=detected, 3=workspace-c, 4=cancel)
         result = _handle_workspace_mismatch(
             mock_session,
             mock_session_manager,
@@ -406,3 +406,96 @@ def test_set_workspace_for_session(temp_daf_home, mock_config):
     assert session.workspace_name == "workspace-b"
     # Verify session was saved
     mock_session_manager.update_session.assert_called_once_with(session)
+
+
+def test_handle_workspace_mismatch_default_is_session_workspace(
+    mock_session, mock_session_manager, mock_config
+):
+    """Test that default selection is session's previous workspace when reopening (#320)."""
+    from devflow.cli.commands.open_command import _handle_workspace_mismatch
+
+    # Simulate user pressing Enter to accept default (which should be option 1)
+    with patch("rich.prompt.IntPrompt.ask", return_value=1) as mock_prompt:
+        result = _handle_workspace_mismatch(
+            mock_session,
+            mock_session_manager,
+            "workspace-a",  # session workspace
+            "workspace-b",  # detected workspace
+            mock_config.repos.workspaces,
+            detected_workspace_path="/tmp/workspace-b",
+            skip_prompt=False
+        )
+
+    assert result is True
+    # Verify the prompt was called with default=1
+    mock_prompt.assert_called_once()
+    call_kwargs = mock_prompt.call_args[1]
+    assert call_kwargs.get("default") == 1
+    # Session workspace should not change (default is session workspace)
+    assert mock_session.workspace_name == "workspace-a"
+    mock_session_manager.update_session.assert_not_called()
+
+
+def test_handle_workspace_mismatch_option_order(
+    mock_session, mock_session_manager, mock_config
+):
+    """Test that workspace options are in correct order: session first, detected second (#320)."""
+    from devflow.cli.commands.open_command import _handle_workspace_mismatch
+    from io import StringIO
+    from unittest.mock import patch
+
+    # Capture console output to verify option order
+    captured_output = StringIO()
+
+    with patch("rich.prompt.IntPrompt.ask", return_value=1):
+        with patch("devflow.cli.commands.open_command.console") as mock_console:
+            # Track all print calls
+            print_calls = []
+            mock_console.print.side_effect = lambda *args, **kwargs: print_calls.append(str(args[0]) if args else "")
+
+            result = _handle_workspace_mismatch(
+                mock_session,
+                mock_session_manager,
+                "workspace-a",  # session workspace
+                "workspace-b",  # detected workspace
+                mock_config.repos.workspaces,
+                detected_workspace_path="/tmp/workspace-b",
+                skip_prompt=False
+            )
+
+    # Verify workspace options are displayed in correct order
+    output_text = "\n".join(print_calls)
+
+    # Option 1 should be session workspace with [DEFAULT]
+    assert "1" in output_text
+    assert "workspace-a" in output_text
+    assert "session's previous workspace" in output_text or "DEFAULT" in output_text
+
+    # Option 2 should be detected workspace
+    assert "2" in output_text
+    assert "workspace-b" in output_text
+
+
+def test_handle_workspace_mismatch_accepts_default_with_enter(
+    mock_session, mock_session_manager, mock_config
+):
+    """Test that pressing Enter accepts default (session workspace) (#320)."""
+    from devflow.cli.commands.open_command import _handle_workspace_mismatch
+
+    # User presses Enter without typing anything (accepts default=1)
+    with patch("rich.prompt.IntPrompt.ask", return_value=1):
+        result = _handle_workspace_mismatch(
+            mock_session,
+            mock_session_manager,
+            "workspace-a",  # session workspace
+            "workspace-b",  # detected workspace
+            mock_config.repos.workspaces,
+            detected_workspace_path="/tmp/workspace-b",
+            skip_prompt=False
+        )
+
+    assert result is True
+    # Session workspace should stay as workspace-a (the default)
+    assert mock_session.workspace_name == "workspace-a"
+    # No update needed since workspace didn't change
+    mock_session_manager.update_session.assert_not_called()


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Related Issue: <https://github.com/itdove/devaiflow/issues/320>
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR fixes workspace selection behavior when reopening DevAIFlow sessions. Previously, the workspace selection dialog did not remember the session's last-used workspace. Now when reopening a session, the workspace selection will default to the workspace that was previously used for that session, improving user experience and reducing friction when resuming work.

Changes include:
- Updated `open_command.py` to retrieve and default to the session's previous workspace
- Added test coverage in `test_workspace_mismatch.py` to verify the default workspace behavior
- Updated documentation in `AGENTS.md` and `docs/reference/commands.md` to reflect the new behavior

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Create a new DevAIFlow session in a specific workspace (e.g., `workspace-A`)
3. Work in the session, then close it (e.g., using `daf close` or exiting the session)
4. Reopen the same session using `daf open <session-id>`
5. Verify that the workspace selection defaults to `workspace-A` (the previously used workspace)
6. Test with sessions that have been used in different workspaces to ensure the correct previous workspace is remembered
7. Run the test suite: `pytest tests/test_workspace_mismatch.py -v`

### Scenarios tested
- Reopening a session defaults to its previously used workspace
- New sessions without previous workspace history behave as expected
- Workspace mismatch scenarios are handled correctly

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: