### PR TITLE
itdove/devaiflow#319: Display pre-commit error messages when commit fails in daf complete

### DIFF
--- a/devflow/cli/commands/complete_command.py
+++ b/devflow/cli/commands/complete_command.py
@@ -269,9 +269,15 @@ def complete_session(
 
 Co-Authored-By: Claude <noreply@anthropic.com>"""
 
-                        if GitUtils.commit_all(working_dir, full_message):
+                        success, error_msg = GitUtils.commit_all(working_dir, full_message)
+                        if success:
                             console.print(f"  [green]✓[/green] Changes committed")
                             commit_made_this_cycle = True
+                        else:
+                            console.print(f"  [red]✗[/red] Failed to commit changes")
+                            if error_msg:
+                                console.print(f"\n[yellow]Commit error:[/yellow]")
+                                console.print(error_msg)
 
                         # Push to remote
                         if GitUtils.has_unpushed_commits(working_dir, proj_info.branch):
@@ -411,9 +417,15 @@ Co-Authored-By: Claude <noreply@anthropic.com>"""
 
 Co-Authored-By: Claude <noreply@anthropic.com>"""
 
-                        if GitUtils.commit_all(working_dir, full_message):
+                        success, error_msg = GitUtils.commit_all(working_dir, full_message)
+                        if success:
                             console.print(f"  [green]✓[/green] Changes committed")
                             commit_made_this_cycle = True
+                        else:
+                            console.print(f"  [red]✗[/red] Failed to commit changes")
+                            if error_msg:
+                                console.print(f"\n[yellow]Commit error:[/yellow]")
+                                console.print(error_msg)
 
                         # Push to remote
                         if GitUtils.has_unpushed_commits(working_dir, conv.branch):
@@ -531,13 +543,20 @@ Co-Authored-By: Claude <noreply@anthropic.com>"""
                     # User cancelled the commit
                     should_commit = False
 
-                if should_commit and GitUtils.commit_all(working_dir, full_message):
-                    console.print("[green]✓[/green] Changes committed")
-                    commit_made_this_cycle = True  # Track that we made a commit
+                if should_commit:
+                    success, error_msg = GitUtils.commit_all(working_dir, full_message)
+                    if success:
+                        console.print("[green]✓[/green] Changes committed")
+                        commit_made_this_cycle = True  # Track that we made a commit
+                    else:
+                        console.print("[red]✗[/red] Failed to commit changes")
+                        if error_msg:
+                            console.print(f"\n[yellow]Commit error:[/yellow]")
+                            console.print(error_msg)
 
                     # Push commits to remote immediately after committing
                     # This ensures commits are backed up even if user declines PR creation
-                    if GitUtils.has_unpushed_commits(working_dir, active_conv.branch):
+                    if success and GitUtils.has_unpushed_commits(working_dir, active_conv.branch):
                         # Check if auto_push_to_remote is configured
                         should_push = True
                         if config and config.prompts and config.prompts.auto_push_to_remote is not None:
@@ -986,10 +1005,14 @@ def _sync_branch_for_export(session, issue_key: str, config_loader) -> None:
 
 Co-Authored-By: Claude <noreply@anthropic.com>"""
 
-            if GitUtils.commit_all(working_dir, commit_message):
+            success, error_msg = GitUtils.commit_all(working_dir, commit_message)
+            if success:
                 console.print(f"[green]✓[/green] Created WIP commit for export")
             else:
-                console.print(f"[yellow]⚠[/yellow] Failed to commit changes")
+                console.print(f"[red]✗[/red] Failed to commit changes")
+                if error_msg:
+                    console.print(f"\n[yellow]Commit error:[/yellow]")
+                    console.print(error_msg)
                 return
 
     # Push branch to remote

--- a/devflow/cli/commands/export_command.py
+++ b/devflow/cli/commands/export_command.py
@@ -224,10 +224,12 @@ def _sync_single_conversation_branch(
 Co-Authored-By: Claude <noreply@anthropic.com>"""
 
         # Commit all changes (REQUIRED)
-        if not GitUtils.commit_all(working_dir, commit_message):
+        success, error_msg = GitUtils.commit_all(working_dir, commit_message)
+        if not success:
+            error_detail = f"\n{error_msg}" if error_msg else ""
             raise ValueError(
                 f"Failed to commit changes in {working_dir_name or branch}\n"
-                f"Cannot export without committing all changes."
+                f"Cannot export without committing all changes.{error_detail}"
             )
         console.print(f"[green]✓[/green] Committed all changes")
 

--- a/devflow/git/utils.py
+++ b/devflow/git/utils.py
@@ -437,7 +437,7 @@ class GitUtils:
             return None
 
     @staticmethod
-    def commit_all(path: Path, message: str) -> bool:
+    def commit_all(path: Path, message: str) -> tuple[bool, Optional[str]]:
         """Stage all changes and create a commit.
 
         Args:
@@ -445,7 +445,9 @@ class GitUtils:
             message: Commit message
 
         Returns:
-            True if successful, False otherwise
+            Tuple of (success: bool, error_message: Optional[str])
+            - (True, None) if successful
+            - (False, error_message) if failed
 
         Raises:
             ToolNotFoundError: If git is not installed
@@ -461,7 +463,8 @@ class GitUtils:
                 timeout=10,
             )
             if add_result.returncode != 0:
-                return False
+                error_msg = add_result.stderr.decode("utf-8").strip() if add_result.stderr else "Failed to stage changes"
+                return (False, error_msg)
 
             # Create commit
             commit_result = subprocess.run(
@@ -470,9 +473,15 @@ class GitUtils:
                 capture_output=True,
                 timeout=10,
             )
-            return commit_result.returncode == 0
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            return False
+            if commit_result.returncode == 0:
+                return (True, None)
+            else:
+                error_msg = commit_result.stderr.decode("utf-8").strip() if commit_result.stderr else "Commit failed"
+                return (False, error_msg)
+        except subprocess.TimeoutExpired:
+            return (False, "Git command timed out")
+        except FileNotFoundError:
+            return (False, "Git command not found")
 
     @staticmethod
     def detect_repo_type(path: Path) -> Optional[str]:

--- a/tests/cli/commands/test_export_command.py
+++ b/tests/cli/commands/test_export_command.py
@@ -129,7 +129,7 @@ def test_sync_commits_uncommitted_changes_required(mock_git_utils, tmp_path):
     mock_git_utils.is_branch_pushed.return_value = False
     mock_git_utils.has_uncommitted_changes.return_value = True
     mock_git_utils.get_status_summary.return_value = "M file1.py\nA file2.py"
-    mock_git_utils.commit_all.return_value = True
+    mock_git_utils.commit_all.return_value = (True, None)
     mock_git_utils.push_branch.return_value = True
 
     _sync_single_conversation_branch(
@@ -155,7 +155,7 @@ def test_sync_raises_error_on_commit_failure(mock_git_utils, tmp_path):
     mock_git_utils.is_branch_pushed.return_value = False
     mock_git_utils.has_uncommitted_changes.return_value = True
     mock_git_utils.get_status_summary.return_value = "M file1.py"
-    mock_git_utils.commit_all.return_value = False
+    mock_git_utils.commit_all.return_value = (False, "Mock commit error")
 
     with pytest.raises(ValueError, match=r"Failed to commit changes[\s\S]*Cannot export without committing"):
         _sync_single_conversation_branch(
@@ -271,7 +271,7 @@ def test_sync_complete_workflow_with_checkout_pull_commit_push(mock_git_utils, t
     mock_git_utils.pull_current_branch.return_value = True
     mock_git_utils.has_uncommitted_changes.return_value = True
     mock_git_utils.get_status_summary.return_value = "M file1.py"
-    mock_git_utils.commit_all.return_value = True
+    mock_git_utils.commit_all.return_value = (True, None)
     mock_git_utils.push_branch.return_value = True
     mock_git_utils.get_branch_remote_url.return_value = "git@github.com:user/repo.git"
 
@@ -319,7 +319,7 @@ def test_sync_uses_session_name_when_no_issue_key(mock_git_utils, tmp_path):
     mock_git_utils.is_branch_pushed.return_value = False
     mock_git_utils.has_uncommitted_changes.return_value = True
     mock_git_utils.get_status_summary.return_value = "M file1.py"
-    mock_git_utils.commit_all.return_value = True
+    mock_git_utils.commit_all.return_value = (True, None)
     mock_git_utils.push_branch.return_value = True
 
     _sync_single_conversation_branch(

--- a/tests/test_complete_multiproject_commit_message_display.py
+++ b/tests/test_complete_multiproject_commit_message_display.py
@@ -71,7 +71,7 @@ def test_multiproject_workflow_displays_commit_message_before_committing(temp_da
          patch('devflow.git.utils.GitUtils.get_current_branch', return_value="feature-caching"), \
          patch('devflow.git.utils.GitUtils.has_uncommitted_changes', return_value=True), \
          patch('devflow.git.utils.GitUtils.get_status_summary', return_value="M  api.py\nM  cache.py"), \
-         patch('devflow.git.utils.GitUtils.commit_all', return_value=True), \
+         patch('devflow.git.utils.GitUtils.commit_all', return_value=(True, None)), \
          patch('devflow.git.utils.GitUtils.has_unpushed_commits', return_value=False), \
          patch('devflow.cli.commands.complete_command.Confirm.ask', side_effect=mock_confirm), \
          patch('devflow.cli.commands.complete_command.Prompt.ask', side_effect=mock_prompt), \
@@ -155,7 +155,7 @@ def test_multiproject_with_multiple_repos_displays_commit_messages(temp_daf_home
          patch('devflow.git.utils.GitUtils.get_current_branch', return_value="sync-changes"), \
          patch('devflow.git.utils.GitUtils.has_uncommitted_changes', return_value=True), \
          patch('devflow.git.utils.GitUtils.get_status_summary', return_value="M  api.py\nM  routes.py"), \
-         patch('devflow.git.utils.GitUtils.commit_all', return_value=True), \
+         patch('devflow.git.utils.GitUtils.commit_all', return_value=(True, None)), \
          patch('devflow.git.utils.GitUtils.has_unpushed_commits', return_value=False), \
          patch('devflow.cli.commands.complete_command.Confirm.ask', side_effect=mock_confirm), \
          patch('devflow.cli.commands.complete_command.Prompt.ask', side_effect=mock_prompt), \
@@ -232,7 +232,7 @@ def test_multiproject_user_can_decline_and_edit_message(temp_daf_home, monkeypat
 
     def mock_commit_all(working_dir, message):
         commit_messages_used.append(message)
-        return True
+        return (True, None)
 
     # Mock git operations
     with patch('devflow.git.utils.GitUtils.is_git_repository', return_value=True), \
@@ -313,7 +313,7 @@ def test_multiproject_allows_user_to_edit_commit_message(temp_daf_home, monkeypa
 
     def mock_commit_all(working_dir, message):
         commit_messages_used.append(message)
-        return True
+        return (True, None)
 
     with patch('devflow.git.utils.GitUtils.is_git_repository', return_value=True), \
          patch('devflow.git.utils.GitUtils.get_current_branch', return_value="add-redis"), \
@@ -371,7 +371,7 @@ def test_single_project_session_still_works_correctly(temp_daf_home, monkeypatch
          patch('devflow.git.utils.GitUtils.has_uncommitted_changes', return_value=True), \
          patch('devflow.git.utils.GitUtils.get_status_summary', return_value="M  login.py"), \
          patch('devflow.git.utils.GitUtils.get_uncommitted_diff', return_value="diff --git a/login.py"), \
-         patch('devflow.git.utils.GitUtils.commit_all', return_value=True), \
+         patch('devflow.git.utils.GitUtils.commit_all', return_value=(True, None)), \
          patch('devflow.git.utils.GitUtils.has_unpushed_commits', return_value=False), \
          patch('devflow.cli.commands.complete_command.Confirm.ask', side_effect=mock_confirm), \
          patch('devflow.cli.commands.complete_command.Prompt.ask', side_effect=mock_prompt), \

--- a/tests/test_export_command.py
+++ b/tests/test_export_command.py
@@ -278,7 +278,7 @@ def test_sync_single_conversation_commit_failure(temp_daf_home):
             with patch('devflow.git.utils.GitUtils.fetch_origin'):
                 with patch('devflow.git.utils.GitUtils.has_uncommitted_changes', return_value=True):
                     with patch('devflow.git.utils.GitUtils.get_status_summary', return_value="M file.py"):
-                        with patch('devflow.git.utils.GitUtils.commit_all', return_value=False):
+                        with patch('devflow.git.utils.GitUtils.commit_all', return_value=(False, "Mock commit error")):
                             with pytest.raises(ValueError, match="Failed to commit changes"):
                                 _sync_single_conversation_branch(
                                     project_path=Path("/path/to/project"),

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -572,9 +572,10 @@ def test_get_status_summary_with_changes(tmp_path):
 
 def test_commit_all_not_git(tmp_path):
     """Test commit_all with non-git directory."""
-    result = GitUtils.commit_all(tmp_path, "Test commit")
+    success, error_msg = GitUtils.commit_all(tmp_path, "Test commit")
 
-    assert result is False
+    assert success is False
+    assert error_msg is not None  # Should have an error message
 
 
 @pytest.mark.skipif(
@@ -596,10 +597,53 @@ def test_commit_all_success(tmp_path):
     # Make uncommitted change
     (tmp_path / "test.txt").write_text("modified")
 
-    result = GitUtils.commit_all(tmp_path, "Test commit message")
+    success, error_msg = GitUtils.commit_all(tmp_path, "Test commit message")
 
-    assert result is True
+    assert success is True
+    assert error_msg is None  # No error message on success
     assert not GitUtils.has_uncommitted_changes(tmp_path)
+
+
+@pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git not available"
+)
+def test_commit_all_with_pre_commit_hook_failure(tmp_path):
+    """Test commit_all returns error message when pre-commit hook fails."""
+    # Initialize git repo
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, capture_output=True)
+
+    # Create .git/hooks directory
+    hooks_dir = tmp_path / ".git" / "hooks"
+    hooks_dir.mkdir(exist_ok=True)
+
+    # Create a pre-commit hook that always fails with an error message
+    hook_file = hooks_dir / "pre-commit"
+    hook_file.write_text("""#!/bin/sh
+echo "[ERROR] Pre-commit hook blocked the commit" >&2
+echo "[ERROR] Trailing whitespace found in file.py:42" >&2
+echo "[ERROR] Missing import sorting in utils.py" >&2
+exit 1
+""")
+    hook_file.chmod(0o755)
+
+    # Create initial commit
+    (tmp_path / "test.txt").write_text("test")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial", "--no-verify"], cwd=tmp_path, capture_output=True)
+
+    # Make uncommitted change
+    (tmp_path / "test.txt").write_text("modified")
+
+    # Attempt to commit (pre-commit hook will block it)
+    success, error_msg = GitUtils.commit_all(tmp_path, "Test commit message")
+
+    # Should fail with error message
+    assert success is False
+    assert error_msg is not None
+    assert "Pre-commit hook blocked the commit" in error_msg or "pre-commit" in error_msg.lower()
 
 
 def test_detect_repo_type_not_git(tmp_path):

--- a/tests/test_multi_project_session_creation.py
+++ b/tests/test_multi_project_session_creation.py
@@ -439,7 +439,7 @@ def test_multi_project_complete_workflow_integration(temp_daf_home, tmp_path):
         mock_git_complete.is_git_repository.return_value = True
         mock_git_complete.has_uncommitted_changes.return_value = True
         mock_git_complete.get_status_summary.return_value = "M api.py\nM app.js"
-        mock_git_complete.commit_all.return_value = True
+        mock_git_complete.commit_all.return_value = (True, None)
         mock_git_complete.push_branch.return_value = True
         mock_git_complete.is_branch_pushed.return_value = True
         mock_git_complete.has_unpushed_commits.return_value = True


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->
Related Issue: itdove/devaiflow#319

## Description
Enhanced git commit error handling and reporting in the DevAIFlow tool, specifically when pre-commit hooks fail during the `daf complete` command. This change improves the user experience by displaying clear, detailed error messages from pre-commit hooks instead of generic failure messages.

**Technical changes:**
- Refactored `devflow/git/utils.py` to capture and preserve stderr output from failed git commit operations
- Updated `devflow/cli/commands/complete_command.py` to surface pre-commit error messages to users
- Enhanced error handling in `devflow/cli/commands/export_command.py` for consistency
- Added comprehensive test coverage for commit error scenarios across multiple test files

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Create a test repository with a failing pre-commit hook (e.g., `pre-commit install` with a hook that always fails)
3. Make some code changes and stage them
4. Run `daf complete` to trigger the commit process
5. Verify that the error message from the pre-commit hook is clearly displayed in the output
6. Confirm that the error message is specific and helpful (not a generic failure message)
7. Run the test suite: `pytest tests/test_complete_multiproject_commit_message_display.py tests/test_git_utils.py tests/test_export_command.py`

### Scenarios tested
- Commit failures due to pre-commit hook errors with error messages properly captured and displayed
- Export command error handling with git commit failures
- Multi-project session commit message display
- Git utility error reporting functions

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: