### PR TITLE
itdove/devaiflow#346: Remove explicit command syntax from ticket creation session prompts

### DIFF
--- a/devflow/cli/commands/git_new_command.py
+++ b/devflow/cli/commands/git_new_command.py
@@ -884,8 +884,6 @@ def _build_issue_creation_prompt(
     prompt_parts.extend([
         "⚠️  CRITICAL: Read the daf-git skill to understand the correct command syntax for creating GitHub/GitLab issues.",
         "",
-        "Use the `daf git create` command to create your issue based on your analysis.",
-        "",
         "After you create the issue, the session will be automatically renamed to 'creation-<issue_number>'",
         "for easy identification. Users can reopen with: daf open creation-<issue_number>",
         "",
@@ -1008,8 +1006,6 @@ def _build_multiproject_issue_creation_prompt(
         f"4. Create the GitHub/GitLab issue in {target_repo_name} with your cross-project analysis",
         "",
         "⚠️  CRITICAL: Read the daf-git skill to understand the correct command syntax for creating GitHub/GitLab issues.",
-        "",
-        "Use the `daf git create` command to create your issue based on your cross-project analysis.",
         "",
         "After you create the issue, the session will be automatically renamed to 'creation-<issue_number>'",
         "for easy identification. Users can reopen with: daf open creation-<issue_number>",

--- a/devflow/cli/commands/jira_new_command.py
+++ b/devflow/cli/commands/jira_new_command.py
@@ -885,8 +885,6 @@ def _build_ticket_creation_prompt(
     prompt_parts.extend([
         "⚠️  CRITICAL: Read the daf-jira skill to understand the correct command syntax for creating JIRA issues.",
         "",
-        "Use the `daf jira create` command to create your ticket based on your analysis.",
-        "",
         parent_note,
     ])
 
@@ -985,8 +983,6 @@ def _build_multiproject_ticket_creation_prompt(
         "6. Include detailed description and acceptance criteria based on cross-project analysis",
         "",
         "⚠️  CRITICAL: Read the daf-jira skill to understand the correct command syntax for creating JIRA issues.",
-        "",
-        "Use the `daf jira create` command to create your ticket based on your cross-project analysis.",
         "",
         parent_note,
     ]

--- a/tests/test_jira_new_command.py
+++ b/tests/test_jira_new_command.py
@@ -774,9 +774,9 @@ class TestJiraNewMockMode:
         # Verify initial prompt contains ticket creation instructions
         initial_prompt = claude_session["messages"][0]["content"]
         assert "ANALYSIS-ONLY" in initial_prompt
-        # Verify the prompt instructs to read skill files instead of providing template
+        # Verify the prompt instructs to read skill files for command syntax
         assert "Read the daf-jira skill" in initial_prompt
-        assert "`daf jira create`" in initial_prompt
+        assert "CRITICAL" in initial_prompt  # Verify CRITICAL instruction is present
 
         # Verify assistant response mentions ticket creation
         assistant_response = claude_session["messages"][1]["content"]


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->
Related to: https://github.com/itdove/devaiflow/issues/346

## Description
This PR removes explicit command syntax instructions from the ticket creation session prompts in the devflow CLI. The refactoring focuses on the `git new` and `jira new` commands, cleaning up their prompt templates to remove hardcoded command examples while preserving functionality.

The changes improve the user experience by making prompts more concise and less prescriptive about command usage, allowing the CLI to guide users more naturally through the ticket creation workflow.

**Files modified:**
- `devflow/cli/commands/git_new_command.py` - Updated prompt templates
- `devflow/cli/commands/jira_new_command.py` - Updated prompt templates  
- `tests/test_jira_new_command.py` - Updated tests to reflect prompt changes

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run `devflow jira new` and verify the prompts display correctly without explicit command syntax
3. Run `devflow git new` and verify the prompts display correctly without explicit command syntax
4. Complete a full ticket creation workflow for both commands to ensure functionality is preserved
5. Verify that the test suite passes: run tests for the modified command files

### Scenarios tested
- JIRA ticket creation workflow with new prompt format
- Git issue creation workflow with new prompt format
- Unit tests for jira_new_command with updated prompt expectations

## Deployment considerations
- [x] This code change is ready for deployment on its own