### PR TITLE
itdove/devaiflow#348: Improve daf-jira and daf-jira-mcp skills based on MCP integration learnings

### DIFF
--- a/devflow/cli_skills/daf-jira-mcp/SKILL.md
+++ b/devflow/cli_skills/daf-jira-mcp/SKILL.md
@@ -10,14 +10,20 @@ When using MCP JIRA tools (e.g., `mcp__mcp-atlassian__jira_*`), you can leverage
 
 ## Core Concept
 
-**DevAIFlow stores JIRA field metadata that MCP tools need:**
+**CRITICAL: When using MCP JIRA tools, you MUST read DevAIFlow configuration first.**
+
+Unlike `daf jira create` commands (which are self-contained), MCP tools require you to manually:
+1. **Read configuration** via `daf config show --json`
+2. **Apply validation** logic yourself
+3. **Map field names** to JIRA field IDs
+4. **Format values** based on field types
+
+**DevAIFlow configuration provides JIRA field metadata that MCP tools need:**
 - Field IDs (customfield_12345) mapped to friendly names
 - Required fields per issue type
 - Allowed values for select/option fields
 - Field availability per issue type
 - Team/organization defaults
-
-**Get this data:** `daf config show --json`
 
 ## Step-by-Step: Using MCP with daf Intelligence
 
@@ -280,19 +286,63 @@ Invalid value 'High' for field 'customfield_12345'
 
 **Better approach:** Validate BEFORE calling MCP using daf config intelligence.
 
+## Field Format Requirements: ADF vs Wiki Markup
+
+**CRITICAL: Field format requirements differ between daf commands and MCP tools.**
+
+### With daf Commands (Recommended)
+- ✅ **Use JIRA Wiki markup** for all text fields
+- ✅ **Automatic conversion** - JIRA API converts Wiki markup to ADF for Cloud instances
+- ✅ **No format issues** - daf handles the complexity
+
+### With MCP Tools (Advanced)
+- ⚠️ **Format varies by field and JIRA instance**
+- **Description field**: May auto-convert Wiki markup to ADF (inconsistent)
+- **Custom rich text fields**: May require explicit **Atlassian Document Format (ADF)**
+- **Plain text fields**: Use plain strings
+
+**Example ADF format** (for custom fields that require it):
+```json
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "type": "text",
+          "text": "Your text content here"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Known issues with MCP:**
+- `acceptance_criteria` custom field may fail with: "Operation value must be an Atlassian Document Format"
+- Auto-conversion behavior is inconsistent across JIRA field types
+- No reliable way to predict which fields need ADF vs plain text
+
+**Recommendation**: Use `daf jira create/update` for creating/updating tickets with rich text fields. MCP tools are best for reading data, searching, and advanced operations like sprint management.
+
 ## When to Use daf Commands Instead
 
 **Use `daf jira create/update` when:**
 - ✅ You want automatic validation (no manual checking)
 - ✅ You want friendly field names (no field ID mapping)
 - ✅ You want session integration (links issue to current session)
-- ✅ You're creating issues frequently (daf handles all this automatically)
+- ✅ You want automatic field format handling (Wiki markup → ADF conversion)
+- ✅ You're creating issues frequently (daf handles all complexity automatically)
+- ✅ **You're working with rich text custom fields** (avoids ADF format complexity)
 
 **Use MCP with daf intelligence when:**
 - ✅ You need advanced JIRA operations not in daf (e.g., sprint management)
-- ✅ You want direct API access with validation
+- ✅ You want direct API access for reading data
 - ✅ You're exploring JIRA data (searches, complex queries)
-- ✅ You understand the field mapping and validation process
+- ✅ You understand field mapping, validation, AND format requirements (ADF vs Wiki markup)
+- ⚠️ **Avoid MCP for creating/updating** if you have rich text custom fields (use daf commands instead)
 
 ## See Also
 

--- a/devflow/cli_skills/daf-jira/SKILL.md
+++ b/devflow/cli_skills/daf-jira/SKILL.md
@@ -14,14 +14,16 @@ argument-hint: "[TICKET-ID]"
 - **daf Commands**: Validated operations, friendly field names, session integration, team defaults
 
 **For complete MCP integration guide**, see **daf-jira-mcp skill** which shows how to:
-- Apply DevAIFlow's validation logic with MCP tools
-- Use field mappings and defaults from `daf config show --json`
+- Read field mappings and defaults from `daf config show --json` (for MCP tools)
+- Apply DevAIFlow's validation logic manually with MCP tools
 - Map friendly field names to JIRA field IDs
 - Apply issue type templates
 
 **When to use each:**
 - ✅ **Use MCP** for: reading tickets, searching, exploring JIRA data
-- ✅ **Use daf** for: creating/updating with validation, session integration, applying team defaults
+- ✅ **Use daf** for: creating/updating with validation (auto-applies config, no manual reading needed), session integration, team defaults
+
+**Note:** `daf jira create` commands are self-contained - they automatically load configuration, apply validation, and handle field mappings. You do NOT need to read `daf config show --json` before using daf commands.
 
 ---
 


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->
Related GitHub Issue: <https://github.com/itdove/devaiflow/issues/348>

## Description
This PR improves the documentation for JIRA integration skills by clarifying field format requirements for JIRA MCP tools. Based on learnings from MCP integration work, the documentation updates provide clearer guidance on proper field formatting when using the daf-jira and daf-jira-mcp skills.

The changes update SKILL.md files in both the daf-jira and daf-jira-mcp skill directories to help users avoid common formatting issues when interacting with JIRA through the MCP server.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Review the updated documentation in `devflow/cli_skills/daf-jira-mcp/SKILL.md`
3. Review the updated documentation in `devflow/cli_skills/daf-jira/SKILL.md`
4. Verify that field format requirements are clearly documented and understandable
5. Optionally, test the documented field formats with actual JIRA MCP operations to confirm accuracy

### Scenarios tested
- Reviewed documentation changes for clarity and technical accuracy
- Verified formatting improvements align with MCP integration requirements

## Deployment considerations
- [x] This code change is ready for deployment on its own