### PR TITLE
itdove/devaiflow#351: Fix confusing instructions in ticket creation session prompts

### DIFF
--- a/devflow/cli/commands/git_new_command.py
+++ b/devflow/cli/commands/git_new_command.py
@@ -876,7 +876,7 @@ def _build_issue_creation_prompt(
         "Your task:",
         f"1. Analyze the codebase to understand how to implement: {goal}",
         "2. Read relevant files, search for patterns, understand the architecture",
-        f"3. Create a detailed GitHub/GitLab issue{' (' + issue_type + ')' if issue_type else ''} using the 'daf git create' command",
+        f"3. Create the GitHub/GitLab issue{' (' + issue_type + ')' if issue_type else ''} using 'daf git create' (this session uses GitHub/GitLab backend)",
         "4. Include detailed description and acceptance criteria based on your analysis",
         "",
     ])

--- a/devflow/cli/commands/jira_new_command.py
+++ b/devflow/cli/commands/jira_new_command.py
@@ -875,7 +875,7 @@ def _build_ticket_creation_prompt(
         "Your task:",
         f"1. Analyze the codebase to understand how to implement: {goal}",
         "2. Read relevant files, search for patterns, understand the architecture",
-        f"3. Create a detailed JIRA {issue_type} using the 'daf jira create' command",
+        f"3. Create the JIRA {issue_type} using 'daf jira create' (this session uses JIRA backend)",
         parent_instruction,
         f"5. Use project: {project}; configured defaults: {defaults_str}",
         "6. Include detailed description and acceptance criteria based on your analysis",


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR refactors the issue creation prompts in the DevAIFlow CLI to clarify backend type instructions. The changes improve user experience by making the prompts in `git new` and `jira new` commands less confusing when creating tickets.

The refactoring focuses on clarifying the backend type selection process during ticket creation sessions, making it more intuitive for users to understand which backend they're working with.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run `devflow git new` command and verify the prompts clearly indicate the backend type
3. Run `devflow jira new` command and verify the prompts clearly indicate the backend type
4. Verify that the instructions during the ticket creation flow are clear and unambiguous
5. Create a test issue using both commands to ensure functionality remains intact

### Scenarios tested
- Verified prompt clarity when creating new Git issues
- Verified prompt clarity when creating new JIRA issues
- Confirmed no functional regression in the issue creation workflow

## Deployment considerations
- [x] This code change is ready for deployment on its own