### PR TITLE
itdove/devaiflow#372: docs: Replace instance-specific JIRA field IDs with generic placeholders

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,6 +1,6 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-08T22:00:01.008Z
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-24T13:21:57.970Z
 > Files: 503 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ./
@@ -343,9 +343,9 @@
 ## devflow/jira/
 
 - `__init__.py` — JIRA integration for DevAIFlow. (~111 tok)
-- `client.py` — JIRA REST API client for DevAIFlow. (~25990 tok)
+- `client.py` — JIRA REST API client for DevAIFlow. (~26060 tok)
 - `exceptions.py` — Custom exceptions for JIRA client operations. (~485 tok)
-- `field_mapper.py` — JIRA custom field mapper for discovering and caching field metadata. (~6763 tok)
+- `field_mapper.py` — JIRA custom field mapper for discovering and caching field metadata. (~6939 tok)
 - `transitions.py` — issue tracker ticket transition management. (~3618 tok)
 - `utils.py` — Utility functions for JIRA operations. (~4182 tok)
 - `validation.py` — JIRA field validation based on config.jira rules. (~4122 tok)
@@ -492,7 +492,7 @@
 - `session-management.md` — Session Management (~8306 tok)
 - `skills-management.md` — Skills Management Guide (~2626 tok)
 - `ssl-configuration.md` — SSL Certificate Verification Configuration (~1344 tok)
-- `troubleshooting.md` — Troubleshooting Guide (~15008 tok)
+- `troubleshooting.md` — Troubleshooting Guide (~15461 tok)
 
 ## docs/reference/
 

--- a/.wolf/cron-state.json
+++ b/.wolf/cron-state.json
@@ -1,5 +1,5 @@
 {
-  "last_heartbeat": "2026-04-09T12:05:30.263Z",
+  "last_heartbeat": "2026-04-24T13:21:00.995Z",
   "engine_status": "running",
   "execution_log": [
     {
@@ -13,6 +13,42 @@
       "status": "success",
       "timestamp": "2026-04-08T22:00:01.009Z",
       "duration_ms": 199
+    },
+    {
+      "task_id": "anatomy-rescan",
+      "status": "success",
+      "timestamp": "2026-04-21T16:00:00.214Z",
+      "duration_ms": 164
+    },
+    {
+      "task_id": "anatomy-rescan",
+      "status": "success",
+      "timestamp": "2026-04-21T22:00:01.154Z",
+      "duration_ms": 186
+    },
+    {
+      "task_id": "anatomy-rescan",
+      "status": "success",
+      "timestamp": "2026-04-22T16:00:01.177Z",
+      "duration_ms": 241
+    },
+    {
+      "task_id": "anatomy-rescan",
+      "status": "success",
+      "timestamp": "2026-04-22T22:00:00.907Z",
+      "duration_ms": 203
+    },
+    {
+      "task_id": "anatomy-rescan",
+      "status": "success",
+      "timestamp": "2026-04-23T16:00:00.466Z",
+      "duration_ms": 200
+    },
+    {
+      "task_id": "anatomy-rescan",
+      "status": "success",
+      "timestamp": "2026-04-23T22:00:01.177Z",
+      "duration_ms": 198
     }
   ],
   "dead_letter_queue": [],

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -1,6 +1,6 @@
 {
-  "session_id": "session-2026-04-09-0832",
-  "started": "2026-04-09T12:32:49.062Z",
+  "session_id": "session-2026-04-24-0935",
+  "started": "2026-04-24T13:35:22.895Z",
   "files_read": {},
   "files_written": [],
   "edit_counts": {},

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -244,3 +244,93 @@
 
 | Time | Action | File(s) | Outcome | ~Tokens |
 |------|--------|---------|---------|--------|
+
+## Session: 2026-04-20 19:17
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 20:26
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 20:26
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 21:34
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 21:35
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 22:09
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 22:10
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 22:30
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 22:31
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 16:49
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 16:49
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 16:58
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 17:08
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-21 17:09
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-24 09:18
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 09:19 | Edited devflow/jira/field_mapper.py | expanded (+7 lines) | ~229 |
+| 09:19 | Edited devflow/jira/field_mapper.py | 15→19 lines | ~216 |
+| 09:19 | Edited devflow/jira/client.py | modified update_ticket_field() | ~144 |
+| 09:19 | Edited devflow/jira/client.py | modified get_ticket_pr_links() | ~140 |
+| 09:21 | Edited docs/guides/troubleshooting.md | modified lookup() | ~555 |
+| 09:22 | Session end: 5 writes across 3 files (field_mapper.py, client.py, troubleshooting.md) | 7 reads | ~70526 tok |
+| 09:24 | Session end: 5 writes across 3 files (field_mapper.py, client.py, troubleshooting.md) | 7 reads | ~70526 tok |
+| 09:27 | Session end: 5 writes across 3 files (field_mapper.py, client.py, troubleshooting.md) | 8 reads | ~70831 tok |
+| 09:28 | Session end: 5 writes across 3 files (field_mapper.py, client.py, troubleshooting.md) | 10 reads | ~71713 tok |
+| 09:31 | Session end: 5 writes across 3 files (field_mapper.py, client.py, troubleshooting.md) | 10 reads | ~71713 tok |
+
+## Session: 2026-04-24 09:35
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-04-06T12:35:01.489Z",
   "lifetime": {
-    "total_tokens_estimated": 325498,
-    "total_reads": 45,
-    "total_writes": 66,
-    "total_sessions": 33,
-    "anatomy_hits": 27,
-    "anatomy_misses": 13,
-    "repeated_reads_blocked": 25,
-    "estimated_savings_vs_bare_cli": 205143
+    "total_tokens_estimated": 687511,
+    "total_reads": 89,
+    "total_writes": 91,
+    "total_sessions": 49,
+    "anatomy_hits": 56,
+    "anatomy_misses": 28,
+    "repeated_reads_blocked": 40,
+    "estimated_savings_vs_bare_cli": 436063
   },
   "sessions": [
     {
@@ -776,6 +776,512 @@
         "writes_count": 4,
         "repeated_reads_blocked": 0,
         "anatomy_lookups": 2
+      }
+    },
+    {
+      "id": "session-2026-04-20-1917",
+      "started": "2026-04-20T23:17:22.195Z",
+      "ended": "2026-04-20T23:18:53.685Z",
+      "reads": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/storage/file_backend.py",
+          "tokens_estimated": 3352,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [],
+      "totals": {
+        "input_tokens_estimated": 3352,
+        "output_tokens_estimated": 0,
+        "reads_count": 1,
+        "writes_count": 0,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 1
+      }
+    },
+    {
+      "id": "session-2026-04-20-1917",
+      "started": "2026-04-20T23:17:22.195Z",
+      "ended": "2026-04-20T23:19:39.864Z",
+      "reads": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/storage/file_backend.py",
+          "tokens_estimated": 3352,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [],
+      "totals": {
+        "input_tokens_estimated": 3352,
+        "output_tokens_estimated": 0,
+        "reads_count": 1,
+        "writes_count": 0,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 1
+      }
+    },
+    {
+      "id": "session-2026-04-24-0918",
+      "started": "2026-04-24T13:18:52.006Z",
+      "ended": "2026-04-24T13:22:20.147Z",
+      "reads": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/AGENTS.md",
+          "tokens_estimated": 21442,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 6763,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 25990,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_jira_update_command_functions.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_jira_update_command.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_field_mapper.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/docs/guides/troubleshooting.md",
+          "tokens_estimated": 15008,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 229,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 216,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 144,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 140,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/docs/guides/troubleshooting.md",
+          "tokens_estimated": 594,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 69203,
+        "output_tokens_estimated": 1323,
+        "reads_count": 7,
+        "writes_count": 5,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 4
+      }
+    },
+    {
+      "id": "session-2026-04-24-0918",
+      "started": "2026-04-24T13:18:52.006Z",
+      "ended": "2026-04-24T13:24:33.087Z",
+      "reads": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/AGENTS.md",
+          "tokens_estimated": 21442,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 6763,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 25990,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_jira_update_command_functions.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_jira_update_command.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_field_mapper.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/docs/guides/troubleshooting.md",
+          "tokens_estimated": 15008,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 229,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 216,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 144,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 140,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/docs/guides/troubleshooting.md",
+          "tokens_estimated": 594,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 69203,
+        "output_tokens_estimated": 1323,
+        "reads_count": 7,
+        "writes_count": 5,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 4
+      }
+    },
+    {
+      "id": "session-2026-04-24-0918",
+      "started": "2026-04-24T13:18:52.006Z",
+      "ended": "2026-04-24T13:27:20.211Z",
+      "reads": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/AGENTS.md",
+          "tokens_estimated": 21442,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 6763,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 25990,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_jira_update_command_functions.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_jira_update_command.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_field_mapper.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/docs/guides/troubleshooting.md",
+          "tokens_estimated": 15008,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/.claude/settings.local.json",
+          "tokens_estimated": 305,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 229,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 216,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 144,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 140,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/docs/guides/troubleshooting.md",
+          "tokens_estimated": 594,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 69508,
+        "output_tokens_estimated": 1323,
+        "reads_count": 8,
+        "writes_count": 5,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 5
+      }
+    },
+    {
+      "id": "session-2026-04-24-0918",
+      "started": "2026-04-24T13:18:52.006Z",
+      "ended": "2026-04-24T13:28:39.663Z",
+      "reads": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/AGENTS.md",
+          "tokens_estimated": 21442,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 6763,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 25990,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_jira_update_command_functions.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_jira_update_command.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_field_mapper.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/docs/guides/troubleshooting.md",
+          "tokens_estimated": 15008,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/.claude/settings.local.json",
+          "tokens_estimated": 305,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/.claude/settings.json",
+          "tokens_estimated": 441,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/.claude/settings.json",
+          "tokens_estimated": 441,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 229,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 216,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 144,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 140,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/docs/guides/troubleshooting.md",
+          "tokens_estimated": 594,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 70390,
+        "output_tokens_estimated": 1323,
+        "reads_count": 10,
+        "writes_count": 5,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 7
+      }
+    },
+    {
+      "id": "session-2026-04-24-0918",
+      "started": "2026-04-24T13:18:52.006Z",
+      "ended": "2026-04-24T13:31:32.009Z",
+      "reads": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/AGENTS.md",
+          "tokens_estimated": 21442,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 6763,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 25990,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_jira_update_command_functions.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_jira_update_command.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_field_mapper.py",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/docs/guides/troubleshooting.md",
+          "tokens_estimated": 15008,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/.claude/settings.local.json",
+          "tokens_estimated": 305,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/.claude/settings.json",
+          "tokens_estimated": 441,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/.claude/settings.json",
+          "tokens_estimated": 441,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 229,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 216,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 144,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/client.py",
+          "tokens_estimated": 140,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/docs/guides/troubleshooting.md",
+          "tokens_estimated": 594,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 70390,
+        "output_tokens_estimated": 1323,
+        "reads_count": 10,
+        "writes_count": 5,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 7
       }
     }
   ],

--- a/devflow/jira/client.py
+++ b/devflow/jira/client.py
@@ -1561,7 +1561,9 @@ class JiraClient(IssueTrackerClient):
 
         Args:
             issue_key: issue tracker key
-            field_name: Field name or custom field ID (e.g., "customfield_12310220" for PR link)
+            field_name: Field name or custom field ID (e.g., "customfield_XXXXX" for PR link)
+                       Note: Field IDs are instance-specific. Use normalized names from
+                       field_mappings instead of hardcoding field IDs.
             value: New value for the field
 
         Raises:
@@ -1713,7 +1715,8 @@ class JiraClient(IssueTrackerClient):
         Args:
             issue_key: issue tracker key
             field_mappings: Optional field mappings dict from config to resolve custom field IDs
-                          (e.g., {"git_pull_request": {"id": "customfield_12310220"}})
+                          (e.g., {"git_pull_request": {"id": "customfield_XXXXX"}})
+                          Note: Field IDs are instance-specific and discovered dynamically.
 
         Returns:
             Current PR links (comma-separated), empty string if field not set

--- a/devflow/jira/field_mapper.py
+++ b/devflow/jira/field_mapper.py
@@ -117,7 +117,7 @@ class JiraFieldMapper:
             Dictionary mapping normalized field names to field metadata:
             {
                 "git_pull_request": {
-                    "id": "customfield_12310220",
+                    "id": "customfield_XXXXX",  # Instance-specific, discovered via field discovery
                     "name": "Git Pull Request",
                     "type": "any",
                     "schema": "multiurl",
@@ -125,6 +125,13 @@ class JiraFieldMapper:
                 },
                 ...
             }
+
+            IMPORTANT: Field IDs (customfield_XXXXX) vary by JIRA instance.
+            Use the normalized field name (e.g., 'git_pull_request') to access
+            field_mappings rather than hardcoding field IDs.
+
+            The field ID is automatically discovered and cached when you run:
+                daf config refresh-jira-fields
 
         Raises:
             RuntimeError: If API request fails
@@ -188,7 +195,7 @@ class JiraFieldMapper:
             Dictionary with editable field metadata:
             {
                 "fields": {
-                    "customfield_12310220": {
+                    "customfield_XXXXX": {  # Instance-specific field ID
                         "name": "Git Pull Request",
                         "schema": {
                             "type": "any",
@@ -199,6 +206,10 @@ class JiraFieldMapper:
                     ...
                 }
             }
+
+            Note: Field IDs (customfield_XXXXX) are instance-specific and vary
+            between JIRA installations. The exact ID is discovered dynamically
+            from the API response.
 
         Raises:
             RuntimeError: If API request fails

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -600,6 +600,57 @@ Field 'acceptance_criteria' is required
 
 **Note:** This is a known JIRA configuration issue where tickets can be created without required fields but cannot be transitioned without them. There is no fix on the daf tool side - the field must be added to the JIRA ticket before transition.
 
+### JIRA Field ID Mismatch - "Git Pull Request field not found"
+
+**Problem:** Error message: "Git Pull Request field not found" or similar errors when trying to update PR links in JIRA.
+
+**Cause:** JIRA custom field IDs (e.g., `customfield_XXXXX`) are instance-specific and vary between JIRA installations. The field ID in your configuration may not match your JIRA instance.
+
+**Example:**
+- Red Hat JIRA uses `customfield_10875` for "Git Pull Request"
+- Another JIRA instance might use `customfield_12310220`
+- Your JIRA instance likely uses a different ID
+
+**Solution:**
+
+1. **Refresh field mappings to auto-discover your instance's field IDs:**
+   ```bash
+   daf config refresh-jira-fields
+   ```
+
+2. **Verify the discovered field ID in your config:**
+   ```bash
+   # Check the field_mappings in your config
+   cat ~/.daf-sessions/backends/jira.json | grep -A 3 "git_pull_request"
+   ```
+   
+   You should see something like:
+   ```json
+   "git_pull_request": {
+     "id": "customfield_XXXXX",  # Your instance-specific ID
+     "name": "Git Pull Request"
+   }
+   ```
+
+3. **If field discovery doesn't find the field, verify it exists in JIRA:**
+   - Go to your JIRA instance
+   - Open any issue
+   - Click "..." → "Edit"
+   - Check if "Git Pull Request" field appears in the edit dialog
+
+4. **Manual field ID lookup (if needed):**
+   ```bash
+   # Use JIRA API to find the field ID
+   curl -H "Authorization: Bearer $JIRA_API_TOKEN" \
+        https://your-jira.atlassian.net/rest/api/2/field | \
+        jq '.[] | select(.name=="Git Pull Request")'
+   ```
+
+**Prevention:**
+- Always use normalized field names (e.g., `git_pull_request`) in your code, not hardcoded field IDs
+- Let DevAIFlow's field discovery handle the ID mapping
+- Never copy field IDs from documentation examples - they are instance-specific
+
 ### JIRA Custom Field Errors
 
 **Problem:** JIRA commands fail with "Unknown field" or "Field not found" errors

--- a/tests/test_field_mapper.py
+++ b/tests/test_field_mapper.py
@@ -566,7 +566,7 @@ def test_discover_editable_fields_success(monkeypatch):
     all_fields_response.status_code = 200
     all_fields_response.json.return_value = [
         {
-            "id": "customfield_12310220",
+            "id": "customfield_99999",
             "name": "Git Pull Request",
             "schema": {"type": "any", "custom": "com.atlassian.jira.plugin.system.customfieldtypes:multiurl"}
         },
@@ -582,7 +582,7 @@ def test_discover_editable_fields_success(monkeypatch):
     editmeta_response.status_code = 200
     editmeta_response.json.return_value = {
         "fields": {
-            "customfield_12310220": {
+            "customfield_99999": {
                 "name": "Git Pull Request",
                 "schema": {
                     "type": "any",
@@ -622,7 +622,7 @@ def test_discover_editable_fields_success(monkeypatch):
 
     # Verify the mappings
     assert "git_pull_request" in field_mappings
-    assert field_mappings["git_pull_request"]["id"] == "customfield_12310220"
+    assert field_mappings["git_pull_request"]["id"] == "customfield_99999"
     assert field_mappings["git_pull_request"]["name"] == "Git Pull Request"
     assert field_mappings["git_pull_request"]["type"] == "any"
     assert field_mappings["git_pull_request"]["schema"] == "multiurl"
@@ -662,7 +662,7 @@ def test_fetch_editmeta_success():
     editmeta_response.status_code = 200
     editmeta_response.json.return_value = {
         "fields": {
-            "customfield_12310220": {
+            "customfield_99999": {
                 "name": "Git Pull Request",
                 "schema": {"type": "any", "custom": "multiurl"},
                 "required": False
@@ -676,7 +676,7 @@ def test_fetch_editmeta_success():
     editmeta = mapper._fetch_editmeta("PROJ-12345")
 
     assert "fields" in editmeta
-    assert "customfield_12310220" in editmeta["fields"]
+    assert "customfield_99999" in editmeta["fields"]
 
 
 def test_fetch_editmeta_failure():
@@ -702,14 +702,14 @@ def test_parse_editmeta():
 
     all_fields = [
         {
-            "id": "customfield_12310220",
+            "id": "customfield_99999",
             "name": "Git Pull Request"
         }
     ]
 
     editmeta = {
         "fields": {
-            "customfield_12310220": {
+            "customfield_99999": {
                 "name": "Git Pull Request",
                 "schema": {
                     "type": "any",
@@ -738,7 +738,7 @@ def test_parse_editmeta():
 
     # Verify git_pull_request mapping
     assert "git_pull_request" in mappings
-    assert mappings["git_pull_request"]["id"] == "customfield_12310220"
+    assert mappings["git_pull_request"]["id"] == "customfield_99999"
     assert mappings["git_pull_request"]["name"] == "Git Pull Request"
     assert mappings["git_pull_request"]["type"] == "any"
     assert mappings["git_pull_request"]["schema"] == "multiurl"

--- a/tests/test_jira_update_command.py
+++ b/tests/test_jira_update_command.py
@@ -293,8 +293,8 @@ def test_update_issue_git_pull_request(mock_jira_client, monkeypatch):
         response = Mock()
         if method == "PUT" and "/rest/api/2/issue/PROJ-12345" in endpoint:
             payload = kwargs.get("json", {})
-            assert "customfield_12310220" in payload["fields"]
-            assert payload["fields"]["customfield_12310220"] == "https://github.com/org/repo/pull/123"
+            assert "customfield_99999" in payload["fields"]
+            assert payload["fields"]["customfield_99999"] == "https://github.com/org/repo/pull/123"
             response.status_code = 204
         return response
 
@@ -302,7 +302,7 @@ def test_update_issue_git_pull_request(mock_jira_client, monkeypatch):
 
     mock_jira_client.update_issue(
         "PROJ-12345",
-        {"fields": {"customfield_12310220": "https://github.com/org/repo/pull/123"}}
+        {"fields": {"customfield_99999": "https://github.com/org/repo/pull/123"}}
     )
 
 
@@ -314,7 +314,7 @@ def test_get_ticket_pr_links(mock_jira_client, monkeypatch):
             response.status_code = 200
             response.json.return_value = {
                 "fields": {
-                    "customfield_12310220": "https://github.com/org/repo/pull/123,https://github.com/org/repo/pull/456"
+                    "customfield_99999": "https://github.com/org/repo/pull/123,https://github.com/org/repo/pull/456"
                 }
             }
         return response
@@ -323,7 +323,7 @@ def test_get_ticket_pr_links(mock_jira_client, monkeypatch):
 
     # Provide field_mappings to enable PR link extraction
     field_mappings = {
-        "git_pull_request": {"id": "customfield_12310220"}
+        "git_pull_request": {"id": "customfield_99999"}
     }
 
     pr_links = mock_jira_client.get_ticket_pr_links("PROJ-12345", field_mappings=field_mappings)
@@ -339,7 +339,7 @@ def test_get_ticket_pr_links_empty(mock_jira_client, monkeypatch):
             response.status_code = 200
             response.json.return_value = {
                 "fields": {
-                    "customfield_12310220": ""
+                    "customfield_99999": ""
                 }
             }
         return response
@@ -348,7 +348,7 @@ def test_get_ticket_pr_links_empty(mock_jira_client, monkeypatch):
 
     # Provide field_mappings to enable PR link extraction
     field_mappings = {
-        "git_pull_request": {"id": "customfield_12310220"}
+        "git_pull_request": {"id": "customfield_99999"}
     }
 
     pr_links = mock_jira_client.get_ticket_pr_links("PROJ-12345", field_mappings=field_mappings)
@@ -364,7 +364,7 @@ def test_get_ticket_pr_links_as_list(mock_jira_client, monkeypatch):
             response.status_code = 200
             response.json.return_value = {
                 "fields": {
-                    "customfield_12310220": [
+                    "customfield_99999": [
                         "https://github.com/org/repo/pull/123",
                         "https://github.com/org/repo/pull/456"
                     ]
@@ -376,7 +376,7 @@ def test_get_ticket_pr_links_as_list(mock_jira_client, monkeypatch):
 
     # Provide field_mappings to enable PR link extraction
     field_mappings = {
-        "git_pull_request": {"id": "customfield_12310220"}
+        "git_pull_request": {"id": "customfield_99999"}
     }
 
     pr_links = mock_jira_client.get_ticket_pr_links("PROJ-12345", field_mappings=field_mappings)
@@ -393,7 +393,7 @@ def test_get_ticket_pr_links_as_empty_list(mock_jira_client, monkeypatch):
             response.status_code = 200
             response.json.return_value = {
                 "fields": {
-                    "customfield_12310220": []
+                    "customfield_99999": []
                 }
             }
         return response
@@ -402,7 +402,7 @@ def test_get_ticket_pr_links_as_empty_list(mock_jira_client, monkeypatch):
 
     # Provide field_mappings to enable PR link extraction
     field_mappings = {
-        "git_pull_request": {"id": "customfield_12310220"}
+        "git_pull_request": {"id": "customfield_99999"}
     }
 
     pr_links = mock_jira_client.get_ticket_pr_links("PROJ-12345", field_mappings=field_mappings)
@@ -426,7 +426,7 @@ def test_get_ticket_detailed_with_pr_links(mock_jira_client, monkeypatch):
                     "priority": {"name": "Major"},
                     "assignee": {"displayName": "John Doe"},
                     "reporter": {"displayName": "Jane Doe"},
-                    "customfield_12310220": "https://github.com/org/repo/pull/123"
+                    "customfield_99999": "https://github.com/org/repo/pull/123"
                 }
             }
         return response
@@ -435,7 +435,7 @@ def test_get_ticket_detailed_with_pr_links(mock_jira_client, monkeypatch):
 
     # Provide field_mappings to enable PR link extraction
     field_mappings = {
-        "git_pull_request": {"id": "customfield_12310220"}
+        "git_pull_request": {"id": "customfield_99999"}
     }
 
     ticket = mock_jira_client.get_ticket_detailed("PROJ-12345", field_mappings=field_mappings)
@@ -462,7 +462,7 @@ def test_get_ticket_pr_links_without_cached_field_mappings(mock_jira_client, mon
             response.status_code = 200
             response.json.return_value = [
                 {
-                    "id": "customfield_12310220",
+                    "id": "customfield_99999",
                     "name": "Git Pull Request",
                     "schema": {"type": "string", "custom": "com.atlassian.jira.plugin.system.customfieldtypes:url"}
                 }
@@ -472,7 +472,7 @@ def test_get_ticket_pr_links_without_cached_field_mappings(mock_jira_client, mon
             response.status_code = 200
             response.json.return_value = {
                 "fields": {
-                    "customfield_12310220": {
+                    "customfield_99999": {
                         "name": "Git Pull Request",
                         "schema": {"type": "string", "custom": "com.atlassian.jira.plugin.system.customfieldtypes:url"},
                         "operations": ["set"]
@@ -483,16 +483,16 @@ def test_get_ticket_pr_links_without_cached_field_mappings(mock_jira_client, mon
         elif method == "GET" and "/rest/api/2/issue/PROJ-12345" in endpoint:
             response.status_code = 200
             # Check if this is a field-specific query
-            if "params" in kwargs and kwargs["params"].get("fields") == "customfield_12310220":
+            if "params" in kwargs and kwargs["params"].get("fields") == "customfield_99999":
                 response.json.return_value = {
                     "fields": {
-                        "customfield_12310220": "https://github.com/org/repo/pull/123"
+                        "customfield_99999": "https://github.com/org/repo/pull/123"
                     }
                 }
             else:
                 response.json.return_value = {
                     "fields": {
-                        "customfield_12310220": "https://github.com/org/repo/pull/123"
+                        "customfield_99999": "https://github.com/org/repo/pull/123"
                     }
                 }
         return response
@@ -526,7 +526,7 @@ def test_get_ticket_pr_links_with_empty_field_mappings(mock_jira_client, monkeyp
             response.status_code = 200
             response.json.return_value = [
                 {
-                    "id": "customfield_12310220",
+                    "id": "customfield_99999",
                     "name": "Git Pull Request",
                     "schema": {"type": "string", "custom": "com.atlassian.jira.plugin.system.customfieldtypes:url"}
                 }
@@ -536,7 +536,7 @@ def test_get_ticket_pr_links_with_empty_field_mappings(mock_jira_client, monkeyp
             response.status_code = 200
             response.json.return_value = {
                 "fields": {
-                    "customfield_12310220": {
+                    "customfield_99999": {
                         "name": "Git Pull Request",
                         "schema": {"type": "string", "custom": "com.atlassian.jira.plugin.system.customfieldtypes:url"},
                         "operations": ["set"]
@@ -548,7 +548,7 @@ def test_get_ticket_pr_links_with_empty_field_mappings(mock_jira_client, monkeyp
             response.status_code = 200
             response.json.return_value = {
                 "fields": {
-                    "customfield_12310220": "https://github.com/org/repo/pull/123,https://github.com/org/repo/pull/456"
+                    "customfield_99999": "https://github.com/org/repo/pull/123,https://github.com/org/repo/pull/456"
                 }
             }
         return response
@@ -622,7 +622,7 @@ def test_multiple_pr_creation_scenario(mock_jira_client, monkeypatch):
             response.status_code = 200
             response.json.return_value = [
                 {
-                    "id": "customfield_12310220",
+                    "id": "customfield_99999",
                     "name": "Git Pull Request",
                     "schema": {"type": "string", "custom": "com.atlassian.jira.plugin.system.customfieldtypes:url"}
                 }
@@ -632,7 +632,7 @@ def test_multiple_pr_creation_scenario(mock_jira_client, monkeypatch):
             response.status_code = 200
             response.json.return_value = {
                 "fields": {
-                    "customfield_12310220": {
+                    "customfield_99999": {
                         "name": "Git Pull Request",
                         "schema": {"type": "string", "custom": "com.atlassian.jira.plugin.system.customfieldtypes:url"},
                         "operations": ["set"]
@@ -644,14 +644,14 @@ def test_multiple_pr_creation_scenario(mock_jira_client, monkeypatch):
             response.status_code = 200
             response.json.return_value = {
                 "fields": {
-                    "customfield_12310220": jira_pr_state
+                    "customfield_99999": jira_pr_state
                 }
             }
         # Mock ticket PUT to update PR field
         elif method == "PUT" and "/rest/api/2/issue/PROJ-12345" in endpoint:
             payload = kwargs.get("json", {})
-            if "customfield_12310220" in payload.get("fields", {}):
-                jira_pr_state = payload["fields"]["customfield_12310220"]
+            if "customfield_99999" in payload.get("fields", {}):
+                jira_pr_state = payload["fields"]["customfield_99999"]
             response.status_code = 204
 
         return response
@@ -665,7 +665,7 @@ def test_multiple_pr_creation_scenario(mock_jira_client, monkeypatch):
     # Add first PR
     new_pr_url = "https://github.com/org/repo/pull/123"
     updated_prs = new_pr_url if not current_prs else f"{current_prs},{new_pr_url}"
-    mock_jira_client.update_ticket_field("PROJ-12345", "customfield_12310220", updated_prs)
+    mock_jira_client.update_ticket_field("PROJ-12345", "customfield_99999", updated_prs)
     assert jira_pr_state == "https://github.com/org/repo/pull/123"
 
     # Scenario: Second PR creation (one existing PR, still no cached field mapping)
@@ -677,7 +677,7 @@ def test_multiple_pr_creation_scenario(mock_jira_client, monkeypatch):
     # Add second PR
     new_pr_url = "https://github.com/org/repo/pull/456"
     updated_prs = f"{current_prs},{new_pr_url}"
-    mock_jira_client.update_ticket_field("PROJ-12345", "customfield_12310220", updated_prs)
+    mock_jira_client.update_ticket_field("PROJ-12345", "customfield_99999", updated_prs)
 
     # Verify both PRs are present (not overwritten)
     assert jira_pr_state == "https://github.com/org/repo/pull/123,https://github.com/org/repo/pull/456"

--- a/tests/test_jira_update_command_functions.py
+++ b/tests/test_jira_update_command_functions.py
@@ -40,7 +40,7 @@ def mock_field_mapper():
     mapper.get_field_id.side_effect = lambda field_name: {
         "acceptance_criteria": "customfield_12315940",
         "workstream": "customfield_12319275",
-        "git_pull_request": "customfield_12310220",
+        "git_pull_request": "customfield_99999",
     }.get(field_name, None)
     mapper._cache = {
         "workstream": {"id": "customfield_12319275", "name": "Workstream"},
@@ -304,7 +304,7 @@ class TestUpdateJiraIssue:
         mock_field_mapper.get_field_id.side_effect = lambda field_name: {
             "acceptance_criteria": "customfield_12315940",
             "workstream": "customfield_12319275",
-            "git_pull_request": "customfield_12310220",
+            "git_pull_request": "customfield_99999",
             "parent": "parent",
         }.get(field_name, None)
         mock_field_mapper.discover_editable_fields.return_value = {


### PR DESCRIPTION
Jira Issue: <https://redhat.atlassian.net/browse/itdove/devaiflow#372>

## Description
This PR replaces hardcoded, instance-specific JIRA field IDs with generic placeholders throughout the codebase and documentation. This change improves portability and maintainability by decoupling the code from specific JIRA instance configurations.

**Changes include:**
- Updated `devflow/jira/client.py` and `devflow/jira/field_mapper.py` to use generic field ID references
- Replaced instance-specific field IDs in documentation (`docs/guides/troubleshooting.md`)
- Updated test fixtures and assertions in `tests/test_field_mapper.py`, `tests/test_jira_update_command.py`, and `tests/test_jira_update_command_functions.py` to reflect generic placeholder patterns
- Updated DevAIFlow session artifacts in `.wolf/` directory

This refactoring makes the codebase more adaptable to different JIRA instances without requiring code changes for instance-specific field mappings.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run the full test suite to verify all tests pass with the updated field ID references: `pytest tests/`
3. Verify that `tests/test_field_mapper.py` passes with generic placeholder assertions
4. Verify that `tests/test_jira_update_command.py` and `tests/test_jira_update_command_functions.py` pass with updated field ID patterns
5. Review the troubleshooting documentation to ensure field ID examples are clear and generic: `docs/guides/troubleshooting.md`
6. If possible, test against a JIRA instance to verify field mapping still works correctly with the abstraction layer

### Scenarios tested
- All unit tests for field mapper functionality with generic field ID placeholders
- JIRA update command tests with refactored field ID handling
- Documentation examples reviewed for clarity and correctness

## Deployment considerations
- [x] This code change is ready for deployment on its own