### PR TITLE
refactor: unify project selection UX across daf commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ T-*.md
 tests/*.md
 /test_*.sh
 integration-tests/*.bak
+
+#ai-guardian
+/.ai-guardian

--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,10 +1,11 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-05-29T12:20:37.265Z
-> Files: 507 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-05-30T17:58:11.475Z
+> Files: 518 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../../../.claude/plans/
 
+- `giggly-strolling-balloon.md` — Unify Project Selection UX Across daf Commands (~1254 tok)
 - `sparkling-munching-hennessy.md` — Fix PR Template Not Being Filled During `daf complete` (~766 tok)
 
 ## ./
@@ -120,7 +121,7 @@
 - `main.py` — Main CLI entry point for DevAIFlow. (~47322 tok)
 - `signal_handler.py` — Unified signal handler for CLI commands that launch Claude sessions. (~2578 tok)
 - `skills_discovery.py` — Utility for discovering skills from all hierarchical locations. (~1331 tok)
-- `utils.py` — Common utility functions for CLI commands. (~15760 tok)
+- `utils.py` — Common utility functions for CLI commands. (~18055 tok)
 
 ## devflow/cli/commands/
 
@@ -131,7 +132,7 @@
 - `check_command.py` — Implementation of 'daf check' command. (~1058 tok)
 - `cleanup_command.py` — Implementation of 'daf cleanup-conversation' command. (~6300 tok)
 - `cleanup_sessions_command.py` — Implementation of 'daf cleanup-sessions' command. (~1484 tok)
-- `complete_command.py` — Implementation of 'daf complete' command. (~51807 tok)
+- `complete_command.py` — Implementation of 'daf complete' command. (~51282 tok)
 - `config_export_command.py` — Implementation of 'daf config export' command. (~476 tok)
 - `config_import_command.py` — Implementation of 'daf config import' command. (~619 tok)
 - `context_commands.py` — Implementation of 'daf config context' commands. (~2136 tok)
@@ -144,19 +145,19 @@
 - `git_check_auth_command.py` — Implementation of 'daf git check-auth' command. (~1411 tok)
 - `git_commands.py` — Git-based issue tracker CLI command group for DevAIFlow. (~164 tok)
 - `git_create_command.py` — Implementation of 'daf git create' command. (~5406 tok)
-- `git_new_command.py` — Command for daf git new - create GitHub/GitLab issue with session-type for ticket creation workflow. (~14122 tok)
+- `git_new_command.py` — Command for daf git new - create GitHub/GitLab issue with session-type for ticket creation workflow. (~13567 tok)
 - `git_open_command.py` — Command for daf git open - open or create session from GitHub/GitLab issue. (~2094 tok)
 - `git_update_command.py` — Implementation of 'daf git update' command. (~2244 tok)
 - `git_view_command.py` — Implementation of 'daf git view' command. (~2215 tok)
 - `import_command.py` — Implementation of 'daf import' command. (~3262 tok)
 - `import_session_command.py` — Implementation of 'daf import-session' command. (~2195 tok)
 - `info_command.py` — Implementation of 'daf info' command. (~6561 tok)
-- `investigate_command.py` — Command for daf investigate - create investigation-only session without ticket creation. (~12343 tok)
+- `investigate_command.py` — Command for daf investigate - create investigation-only session without ticket creation. (~12701 tok)
 - `jira_add_comment_command.py` — Implementation of 'daf jira add-comment' command. (~1756 tok)
 - `jira_create_commands.py` — Implementation of 'daf jira create' command. (~18107 tok)
 - `jira_create_dynamic.py` — Dynamic command builder for daf jira create with field discovery. (~3074 tok)
 - `jira_field_utils.py` — Common utilities for JIRA field processing in dynamic commands. (~1410 tok)
-- `jira_new_command.py` — Command for daf jira new - create issue tracker ticket with session-type for ticket creation workflow. (~14348 tok)
+- `jira_new_command.py` — Command for daf jira new - create issue tracker ticket with session-type for ticket creation workflo (~13783 tok)
 - `jira_open_command.py` — Command for daf jira open - open or create session from issue tracker ticket. (~2270 tok)
 - `jira_update_command.py` — Implementation of 'daf jira update' command. (~7088 tok)
 - `jira_update_dynamic.py` — Dynamic command builder for daf jira update with field discovery. (~1988 tok)
@@ -164,9 +165,9 @@
 - `link_command.py` — Implementation of 'daf link' command. (~2314 tok)
 - `list_command.py` — Implementation of 'daf list' command. (~4987 tok)
 - `new_command_multiproject.py` — Multi-project session creation logic for DevAIFlow (Issue #149). (~4292 tok)
-- `new_command.py` — Implementation of 'daf new' command. (~27498 tok)
+- `new_command.py` — Implementation of 'daf new' command. (~24904 tok)
 - `note_command.py` — Implementation of 'daf note' and 'daf notes' commands. (~1903 tok)
-- `open_command.py` — Implementation of 'daf open' command. (~51350 tok)
+- `open_command.py` — Implementation of 'daf open' command. (~48238 tok)
 - `pause_command.py` — Implementation of 'daf pause' command. (~619 tok)
 - `provider_commands.py` — Implementation of 'daf model' commands for managing model provider profiles. (~6464 tok)
 - `rebuild_index_command.py` — Implementation of 'daf rebuild-index' command. (~2992 tok)
@@ -318,7 +319,7 @@
 ## devflow/git/
 
 - `__init__.py` — Git integration utilities for DevAIFlow. (~14 tok)
-- `pr_template.py` — AI-powered PR/MR template parsing and filling. (~3701 tok)
+- `pr_template.py` — AI-powered PR/MR template parsing and filling. (~3063 tok)
 - `utils.py` — Git utilities for branch management. (~15440 tok)
 
 ## devflow/github/
@@ -373,7 +374,7 @@
 ## devflow/release/
 
 - `__init__.py` — Release management utilities. (~133 tok)
-- `manager.py` — Release manager for automating release mechanics. (~14891 tok)
+- `manager.py` — Release manager for automating release mechanics. (~14992 tok)
 - `permissions.py` — Permission checking for release operations. (~2884 tok)
 - `version.py` — Version parsing and comparison utilities for release management. (~1692 tok)
 
@@ -413,7 +414,7 @@
 
 ## devflow/utils/
 
-- `__init__.py` — Utility functions for DevAIFlow. (~60 tok)
+- `__init__.py` — Utility functions for DevAIFlow. (~186 tok)
 - `audit_log.py` — Audit logging for DevAIFlow operations. (~1444 tok)
 - `backend_detection.py` — Utilities for detecting issue tracker backend from session metadata and issue keys. (~1809 tok)
 - `claude_commands.py` — Utilities for managing bundled Claude Code skills. (~6464 tok)
@@ -425,7 +426,7 @@
 - `model_provider.py` — Utilities for managing model provider configuration and profiles. (~1813 tok)
 - `paths.py` — Path utilities for DevAIFlow. (~659 tok)
 - `ssl_helper.py` — SSL verification helper for HTTP requests. (~840 tok)
-- `temp_directory.py` — Temporary directory utilities for ticket creation sessions. Includes extract_repo_name, clone_to_temp_directory, prompt_and_clone_to_temp, cleanup. Creates nested structure: /tmp/daf-session-xxx/repo-name/ (~3966 tok)
+- `temp_directory.py` — " to work correctly. (~3686 tok)
 - `time_parser.py` — Time expression parser for filtering. (~1026 tok)
 - `update_checker.py` — Update checker for DevAIFlow. (~2612 tok)
 - `url_parser.py` — URL parser for issue tracker URLs. (~1411 tok)
@@ -719,9 +720,19 @@
 - `test_branch_workflow_ux_fixes.py` — Tests for issue #331: Branch workflow UX issues. (~5629 tok)
 - `test_check_command.py` — Tests for daf check command. (~3490 tok)
 - `test_claude_agent_skills_filtering.py` — Tests for Claude agent skills filtering in launch_with_prompt. (~4144 tok)
-- `test_git_pr_template.py` — Tests for AI-powered PR/MR template parsing and filling. (~7570 tok)
+- `test_git_new_multiproject.py` — Tests for multi-project support in daf git new command (Issue #179). (~2594 tok)
+- `test_git_pr_template.py` — Tests for AI-powered PR/MR template parsing and filling. (~7548 tok)
+- `test_github_repo_suggestion.py` — Tests for GitHub/GitLab repository auto-suggestion in daf open command. (~2849 tok)
+- `test_investigate_command.py` — Tests for daf investigate command. (~11028 tok)
+- `test_jira_new_command.py` — Tests for daf jira new command. (~18520 tok)
+- `test_jira_new_multiproject.py` — Tests for multi-project support in daf jira new command (Issue #179). (~2417 tok)
 - `test_open_command.py` — Tests for daf open command. (~23046 tok)
+- `test_open_multiproject_selection.py` — Tests for multi-project selection in daf open _prompt_for_working_directory (Issue #177). (~1998 tok)
+- `test_repository_selection_jira_new.py` — Tests for unified project selection used by 'daf jira new' and other commands. (~1260 tok)
+- `test_repository_selection.py` — Tests for repository selection prompt in 'daf new' command (PROJ-61069). (~2576 tok)
 - `test_temp_directory_utils.py` — Tests for devflow/utils/temp_directory.py. (~8370 tok)
+- `test_workspace_selection_bug.py` — Test for workspace selection bug fix (AAP-64504). (~1319 tok)
+- `test_workspace.py` — Tests for workspace functionality (AAP-63377). (~4513 tok)
 
 ## tests/cli/commands/
 

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -132,6 +132,246 @@
       "related_bugs": [],
       "occurrences": 2,
       "last_seen": "2026-05-29T12:19:39.794Z"
+    },
+    {
+      "id": "bug-009",
+      "timestamp": "2026-05-30T13:27:29.760Z",
+      "error_message": "Significant refactor of ",
+      "file": "devflow/cli/commands/complete_command.py",
+      "root_cause": "7 lines replaced/restructured",
+      "fix": "Rewrote 13→7 lines (7 removed) | Also: commit_text = message.content[0].text.strip(); # Clean up any code fences | Also: commit_text = result.stdout.strip(); # Clean up any code fences or extra formatting",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 3,
+      "last_seen": "2026-05-30T13:27:47.748Z"
+    },
+    {
+      "id": "bug-010",
+      "timestamp": "2026-05-30T13:28:22.165Z",
+      "error_message": "Significant refactor of ",
+      "file": "devflow/git/pr_template.py",
+      "root_cause": "9 lines replaced/restructured",
+      "fix": "Rewrote 11→3 lines (9 removed) | Also: # Clean up code fences if present; if filled_template.startswith('```'): | Also: def _fill_template_with_api(template_content: str,; template_content: Raw template content",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 3,
+      "last_seen": "2026-05-30T13:29:31.584Z"
+    },
+    {
+      "id": "bug-011",
+      "timestamp": "2026-05-30T13:28:52.101Z",
+      "error_message": "Significant refactor of ",
+      "file": "devflow/cli/commands/open_command.py",
+      "root_cause": "27 lines replaced/restructured",
+      "fix": "Rewrote 34→4 lines (27 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-30T13:28:52.101Z"
+    },
+    {
+      "id": "bug-012",
+      "timestamp": "2026-05-30T13:45:36.786Z",
+      "error_message": "Incorrect value in code",
+      "file": "tests/test_git_pr_template.py",
+      "root_cause": "Had \"Test context\"",
+      "fix": "Changed to \"Test prompt\"",
+      "tags": [
+        "auto-detected",
+        "wrong-value",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-30T13:45:36.786Z"
+    },
+    {
+      "id": "bug-013",
+      "timestamp": "2026-05-30T14:07:46.328Z",
+      "error_message": "Significant refactor of ",
+      "file": "devflow/cli/commands/complete_command.py",
+      "root_cause": "16 lines replaced/restructured",
+      "fix": "Rewrote 20→4 lines (16 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-30T14:07:46.328Z"
+    },
+    {
+      "id": "bug-014",
+      "timestamp": "2026-05-30T16:14:36.923Z",
+      "error_message": "Significant refactor of ",
+      "file": "devflow/cli/utils.py",
+      "root_cause": "3 lines replaced/restructured",
+      "fix": "Rewrote 76→101 lines (3 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-30T16:14:36.923Z"
+    },
+    {
+      "id": "bug-015",
+      "timestamp": "2026-05-30T16:15:16.720Z",
+      "error_message": "Wrong reference: should_launch_claude_code should be scan_workspace_repositories",
+      "file": "devflow/cli/commands/investigate_command.py",
+      "root_cause": "Used \"should_launch_claude_code\" instead of \"scan_workspace_repositories\"",
+      "fix": "Changed should_launch_claude_code → scan_workspace_repositories",
+      "tags": [
+        "auto-detected",
+        "wrong-reference",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-30T16:15:16.720Z"
+    },
+    {
+      "id": "bug-016",
+      "timestamp": "2026-05-30T16:15:33.857Z",
+      "error_message": "Significant refactor of ",
+      "file": "devflow/cli/commands/investigate_command.py",
+      "root_cause": "12 lines replaced/restructured",
+      "fix": "Rewrote 31→61 lines (12 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-30T16:15:33.857Z"
+    },
+    {
+      "id": "bug-017",
+      "timestamp": "2026-05-30T16:16:34.544Z",
+      "error_message": "Significant refactor of ",
+      "file": "devflow/cli/commands/jira_new_command.py",
+      "root_cause": "12 lines replaced/restructured",
+      "fix": "Rewrote 30→53 lines (12 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-30T16:16:34.544Z"
+    },
+    {
+      "id": "bug-018",
+      "timestamp": "2026-05-30T16:17:20.360Z",
+      "error_message": "Significant refactor of ",
+      "file": "devflow/cli/commands/git_new_command.py",
+      "root_cause": "14 lines replaced/restructured",
+      "fix": "Rewrote 37→59 lines (14 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-30T16:17:20.360Z"
+    },
+    {
+      "id": "bug-019",
+      "timestamp": "2026-05-30T16:20:59.315Z",
+      "error_message": "Significant refactor of ",
+      "file": "devflow/cli/commands/new_command.py",
+      "root_cause": "131 lines replaced/restructured",
+      "fix": "Rewrote 271→123 lines (131 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-30T16:20:59.315Z"
+    },
+    {
+      "id": "bug-020",
+      "timestamp": "2026-05-30T16:22:15.760Z",
+      "error_message": "Wrong reference: _extract_repository_from_issue_key should be extract_repository_from_issue_key",
+      "file": "devflow/cli/commands/open_command.py",
+      "root_cause": "Used \"_extract_repository_from_issue_key\" instead of \"extract_repository_from_issue_key\"",
+      "fix": "Changed _extract_repository_from_issue_key → extract_repository_from_issue_key",
+      "tags": [
+        "auto-detected",
+        "wrong-reference",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-30T16:22:15.760Z"
+    },
+    {
+      "id": "bug-021",
+      "timestamp": "2026-05-30T16:22:40.971Z",
+      "error_message": "Significant refactor of ",
+      "file": "devflow/cli/commands/open_command.py",
+      "root_cause": "36 lines replaced/restructured",
+      "fix": "Rewrote 43→3 lines (36 removed) | Also: from rich.prompt import Prompt; if suggested_repo:",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 2,
+      "last_seen": "2026-05-30T16:23:37.474Z"
+    },
+    {
+      "id": "bug-022",
+      "timestamp": "2026-05-30T16:25:25.175Z",
+      "error_message": "Significant refactor of ",
+      "file": "tests/test_investigate_command.py",
+      "root_cause": "2 lines replaced/restructured",
+      "fix": "Rewrote 11→15 lines (2 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-30T16:25:25.175Z"
+    },
+    {
+      "id": "bug-023",
+      "timestamp": "2026-05-30T16:46:10.384Z",
+      "error_message": "Significant refactor of ",
+      "file": "tests/test_jira_new_command.py",
+      "root_cause": "2 lines replaced/restructured",
+      "fix": "Rewrote 7→8 lines (2 removed) | Also: # Call the function; name=\"custom-session-name\"",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "py"
+      ],
+      "related_bugs": [],
+      "occurrences": 2,
+      "last_seen": "2026-05-30T16:46:24.109Z"
     }
   ]
 }

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -1,6 +1,6 @@
 {
-  "session_id": "session-2026-05-29-0833",
-  "started": "2026-05-29T12:33:29.618Z",
+  "session_id": "session-2026-05-30-1405",
+  "started": "2026-05-30T18:05:06.902Z",
   "files_read": {},
   "files_written": [],
   "edit_counts": {},

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -419,3 +419,187 @@
 
 | Time | Action | File(s) | Outcome | ~Tokens |
 |------|--------|---------|---------|--------|
+
+## Session: 2026-05-29 08:33
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 09:11
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 09:25 | Edited devflow/cli/commands/open_command.py | 14→9 lines | ~106 |
+| 09:27 | Edited devflow/utils/__init__.py | modified strip_code_fences() | ~186 |
+| 09:27 | Edited devflow/cli/commands/complete_command.py | added 1 import(s) | ~62 |
+| 09:27 | Edited devflow/cli/commands/complete_command.py | reduced (-6 lines) | ~53 |
+| 09:27 | Edited devflow/cli/commands/complete_command.py | reduced (-6 lines) | ~60 |
+| 09:27 | Edited devflow/cli/commands/complete_command.py | reduced (-8 lines) | ~92 |
+| 09:28 | Edited devflow/cli/commands/complete_command.py | removed 12 lines | ~29 |
+| 09:28 | Edited devflow/git/pr_template.py | added 1 import(s) | ~72 |
+| 09:28 | Edited devflow/git/pr_template.py | reduced (-8 lines) | ~42 |
+| 09:28 | Edited devflow/git/pr_template.py | reduced (-7 lines) | ~43 |
+| 09:28 | Edited devflow/cli/commands/open_command.py | removed 34 lines | ~69 |
+| 09:29 | Edited devflow/git/pr_template.py | 31→28 lines | ~366 |
+| 09:29 | Edited devflow/git/pr_template.py | modified _fill_template_with_api() | ~144 |
+| 09:29 | Edited devflow/git/pr_template.py | modified _fill_template_fallback() | ~261 |
+| 09:39 | Edited devflow/release/manager.py | 5→6 lines | ~91 |
+| 09:39 | Edited devflow/release/manager.py | modified package_file_name() | ~194 |
+| 09:39 | Edited devflow/release/manager.py | inline fix | ~14 |
+| 09:41 | Edited devflow/utils/temp_directory.py | modified _clone_repo_to_temp() | ~1053 |
+| 09:45 | Edited tests/test_git_pr_template.py | modified test_claude_cli_error_fallback() | ~66 |
+| 09:45 | Edited tests/test_git_pr_template.py | "Test context" → "Test prompt" | ~11 |
+
+## Session: 2026-05-30 09:52
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 09:52
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 09:53
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 10:07 | Edited devflow/cli/commands/complete_command.py | modified _cleanup_temp_directory() | ~60 |
+| 10:08 | Edited devflow/git/pr_template.py | modified get() | ~1300 |
+| 10:08 | Edited devflow/cli/commands/investigate_command.py | 4→4 lines | ~58 |
+| 10:08 | Edited devflow/cli/commands/investigate_command.py | added 1 import(s) | ~22 |
+| 10:09 | Edited devflow/git/pr_template.py | 8→9 lines | ~80 |
+| 10:09 | Edited devflow/git/pr_template.py | 7→7 lines | ~77 |
+| 10:09 | Edited devflow/utils/temp_directory.py | modified exists() | ~102 |
+| 10:10 | Edited devflow/cli/commands/investigate_command.py | 4→5 lines | ~76 |
+
+## Session: 2026-05-30 10:12
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 10:13
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 10:13
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 11:59
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 12:08 | Created ../../../.claude/plans/giggly-strolling-balloon.md | — | ~1337 |
+| 12:13 | Edited devflow/cli/utils.py | inline fix | ~20 |
+| 12:13 | Edited devflow/cli/utils.py | modified extract_repository_from_issue_key() | ~1913 |
+| 12:14 | Edited devflow/cli/utils.py | modified unified_project_selection() | ~1288 |
+| 12:14 | Edited devflow/cli/utils.py | modified _save_last_used() | ~534 |
+| 12:15 | Edited devflow/cli/commands/investigate_command.py | inline fix | ~69 |
+| 12:15 | Edited devflow/cli/commands/investigate_command.py | modified is_json_mode() | ~720 |
+| 12:16 | Edited devflow/cli/commands/jira_new_command.py | inline fix | ~62 |
+| 12:16 | Edited devflow/cli/commands/jira_new_command.py | expanded (+23 lines) | ~528 |
+| 12:17 | Edited devflow/cli/commands/jira_new_command.py | — | ~0 |
+| 12:17 | Edited devflow/cli/commands/git_new_command.py | inline fix | ~62 |
+| 12:17 | Edited devflow/cli/commands/git_new_command.py | expanded (+22 lines) | ~600 |
+| 12:18 | Edited devflow/cli/commands/git_new_command.py | — | ~0 |
+| 12:19 | Edited devflow/cli/commands/new_command.py | inline fix | ~81 |
+| 12:19 | Edited devflow/cli/commands/new_command.py | modified from() | ~1844 |
+| 12:20 | Edited devflow/cli/commands/new_command.py | modified _suggest_and_select_repository() | ~1480 |
+| 12:22 | Edited devflow/cli/commands/open_command.py | inline fix | ~75 |
+| 12:22 | Edited devflow/cli/commands/open_command.py | inline fix | ~22 |
+| 12:22 | Edited devflow/cli/commands/open_command.py | removed 43 lines | ~74 |
+| 12:23 | Edited devflow/cli/commands/open_command.py | reduced (-158 lines) | ~732 |
+| 12:24 | Created tests/test_repository_selection_jira_new.py | — | ~1260 |
+| 12:24 | Edited tests/test_github_repo_suggestion.py | added 1 import(s) | ~51 |
+| 12:25 | Edited tests/test_investigate_command.py | 39→43 lines | ~658 |
+| 12:25 | Edited tests/test_investigate_command.py | 11→15 lines | ~260 |
+| 12:25 | Edited tests/test_investigate_command.py | 2→6 lines | ~134 |
+| 12:26 | Created tests/test_repository_selection.py | — | ~2576 |
+| 12:26 | Edited tests/test_workspace.py | 11→14 lines | ~149 |
+| 12:29 | Edited devflow/cli/commands/git_new_command.py | 3→2 lines | ~26 |
+| 12:29 | Edited devflow/cli/commands/git_new_command.py | removed 2 lines | ~1 |
+| 12:40 | Edited devflow/cli/commands/jira_new_command.py | removed 2 lines | ~1 |
+| 12:43 | Created tests/test_git_new_multiproject.py | — | ~2594 |
+| 12:46 | Edited tests/test_jira_new_command.py | 7→8 lines | ~101 |
+| 12:46 | Edited tests/test_jira_new_command.py | 11→15 lines | ~160 |
+| 12:46 | Edited tests/test_jira_new_command.py | 7→12 lines | ~132 |
+| 12:49 | Edited tests/test_jira_new_command.py | modified create_jira_ticket_session() | ~111 |
+| 12:49 | Edited tests/test_jira_new_command.py | 7→12 lines | ~108 |
+| 12:49 | Edited tests/test_jira_new_command.py | 7→11 lines | ~114 |
+| 12:53 | Edited tests/test_jira_new_command.py | 6→11 lines | ~137 |
+| 12:53 | Edited tests/test_jira_new_command.py | 7→12 lines | ~127 |
+| 12:55 | Edited devflow/cli/commands/open_command.py | removed 2 lines | ~1 |
+| 12:56 | Edited devflow/cli/commands/open_command.py | 3→2 lines | ~40 |
+| 12:57 | Edited devflow/cli/commands/open_command.py | 2→2 lines | ~28 |
+| 12:57 | Edited tests/test_jira_new_command.py | 7→12 lines | ~144 |
+| 12:59 | Edited tests/test_jira_new_command.py | modified create_test_project_dir() | ~132 |
+| 12:59 | Edited tests/test_jira_new_command.py | modified create_test_project_dir() | ~136 |
+| 13:00 | Edited tests/test_jira_new_command.py | modified create_test_project_dir() | ~140 |
+| 13:00 | Edited tests/test_jira_new_command.py | modified create_test_project_dir() | ~152 |
+| 13:03 | Created tests/test_jira_new_multiproject.py | — | ~2417 |
+
+## Session: 2026-05-30 13:06
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 13:06
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 13:07 | Created tests/test_open_multiproject_selection.py | — | ~1998 |
+
+## Session: 2026-05-30 13:10
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 13:10
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 13:11
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 13:56
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 13:56
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 13:56
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 13:58 | Created tests/test_workspace_selection_bug.py | — | ~1319 |
+
+## Session: 2026-05-30 14:00
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 14:01
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 14:01
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 15:30 | Unified project selection across daf commands | devflow/cli/utils.py, open/new/investigate/jira_new/git_new commands, tests | 3694 tests pass | ~50000 |
+
+## Session: 2026-05-30 14:05
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-04-06T12:35:01.489Z",
   "lifetime": {
-    "total_tokens_estimated": 687511,
-    "total_reads": 89,
+    "total_tokens_estimated": 893722,
+    "total_reads": 101,
     "total_writes": 91,
-    "total_sessions": 62,
-    "anatomy_hits": 56,
-    "anatomy_misses": 28,
-    "repeated_reads_blocked": 40,
-    "estimated_savings_vs_bare_cli": 436063
+    "total_sessions": 83,
+    "anatomy_hits": 67,
+    "anatomy_misses": 29,
+    "repeated_reads_blocked": 58,
+    "estimated_savings_vs_bare_cli": 1017124
   },
   "sessions": [
     {
@@ -1282,6 +1282,110 @@
         "writes_count": 5,
         "repeated_reads_blocked": 3,
         "anatomy_lookups": 7
+      }
+    },
+    {
+      "id": "session-2026-05-30-0953",
+      "started": "2026-05-30T13:53:11.805Z",
+      "ended": "2026-05-30T14:06:45.775Z",
+      "reads": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/utils/temp_directory.py",
+          "tokens_estimated": 3680,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/git/pr_template.py",
+          "tokens_estimated": 3087,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/cli/commands/investigate_command.py",
+          "tokens_estimated": 12343,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/cli/commands/complete_command.py",
+          "tokens_estimated": 51422,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/release/manager.py",
+          "tokens_estimated": 14992,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/.claude/skills/release/release_helper.py",
+          "tokens_estimated": 3826,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/cli/commands/open_command.py",
+          "tokens_estimated": 51016,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/cli/commands/release_command.py",
+          "tokens_estimated": 7071,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/jira/field_mapper.py",
+          "tokens_estimated": 6939,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/devflow/cli/main.py",
+          "tokens_estimated": 47322,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/tmp/findings.md",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [],
+      "totals": {
+        "input_tokens_estimated": 201698,
+        "output_tokens_estimated": 0,
+        "reads_count": 11,
+        "writes_count": 0,
+        "repeated_reads_blocked": 18,
+        "anatomy_lookups": 10
+      }
+    },
+    {
+      "id": "session-2026-05-30-1401",
+      "started": "2026-05-30T18:01:43.428Z",
+      "ended": "2026-05-30T18:03:05.497Z",
+      "reads": [
+        {
+          "file": "/Users/dvernier/development/devaiflow/devaiflow/tests/test_workspace.py",
+          "tokens_estimated": 4513,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [],
+      "totals": {
+        "input_tokens_estimated": 4513,
+        "output_tokens_estimated": 0,
+        "reads_count": 1,
+        "writes_count": 0,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 1
       }
     }
   ],

--- a/devflow/cli/commands/git_new_command.py
+++ b/devflow/cli/commands/git_new_command.py
@@ -10,7 +10,7 @@ from typing import Optional
 from rich.console import Console
 from rich.prompt import Prompt, Confirm
 
-from devflow.cli.utils import console_print, is_json_mode, output_json, prompt_repository_selection, require_outside_claude, scan_workspace_repositories, select_workspace, should_launch_claude_code
+from devflow.cli.utils import console_print, get_workspace_path, is_json_mode, output_json, require_outside_claude, scan_workspace_repositories, select_workspace, should_launch_claude_code, unified_project_selection
 from devflow.cli.commands.sync_command import issue_key_to_session_name
 from devflow.git.utils import GitUtils
 
@@ -133,7 +133,7 @@ def _create_mock_git_issue(
     store.set_jira_ticket(full_issue_key, mock_issue)
 
     # Build initial prompt with session name
-    from devflow.cli.utils import get_workspace_path
+
     workspace_path = None
     if session.workspace_name and config and config.repos:
         workspace_path = get_workspace_path(config, session.workspace_name)
@@ -410,7 +410,6 @@ def create_git_issue_session(
         project_names = [p.strip() for p in projects.split(',')]
 
         # Get workspace path
-        from devflow.cli.utils import get_workspace_path
         workspace_path = get_workspace_path(config, workspace)
         if not workspace_path:
             console_print(f"[red]✗[/red] Workspace '{workspace}' not found")
@@ -463,26 +462,49 @@ def create_git_issue_session(
             return
         console_print(f"[dim]Using specified path: {project_path}[/dim]")
     else:
-        # Prompt for repository selection from workspace with multi-project support (Issue #179)
-        from devflow.cli.utils import prompt_repository_selection_with_multiproject
-        project_paths, selected_workspace_name = prompt_repository_selection_with_multiproject(
+        # Unified project selection (matches daf open UX)
+        selected_workspace_name = select_workspace(
             config,
             workspace_flag=workspace,
-            allow_multiple=True  # Enable multi-project mode for git new
+            session=None,
+            skip_prompt=is_json_mode(),
         )
-        if not project_paths:
-            # User cancelled or no workspace configured
+
+        if not selected_workspace_name:
+            console_print(f"[yellow]⚠[/yellow] No workspace selected")
             return
 
-        # Check if multi-project mode was selected
-        if len(project_paths) > 1:
-            # Multi-project ticket creation session - need to select target repository
-            target_repo_path = _prompt_for_target_repository(project_paths, repository)
+        ws_path = get_workspace_path(config, selected_workspace_name)
+        if not ws_path:
+            console_print(f"[yellow]⚠[/yellow] Could not find workspace path for: {selected_workspace_name}")
+            return
+
+        try:
+            repo_options = scan_workspace_repositories(ws_path)
+        except (ValueError, RuntimeError) as e:
+            console_print(f"[yellow]Warning: {e}[/yellow]")
+            repo_options = []
+
+        if not repo_options:
+            console_print(f"[yellow]⚠[/yellow] No git repositories found in workspace")
+            return
+
+        project_paths_result, is_multi = unified_project_selection(
+            workspace_path=ws_path,
+            repo_options=repo_options,
+            allow_multi_project=True,
+            config_loader=config_loader,
+            workspace_name=selected_workspace_name,
+        )
+        if not project_paths_result:
+            return
+
+        if is_multi:
+            target_repo_path = _prompt_for_target_repository(project_paths_result, repository)
             if not target_repo_path:
                 console_print("[yellow]Cancelled[/yellow]")
                 return
 
-            # Multi-project issue creation session
             return _create_multi_project_git_session(
                 config=config,
                 config_loader=config_loader,
@@ -490,15 +512,14 @@ def create_git_issue_session(
                 goal=goal,
                 issue_type=issue_type,
                 parent=parent,
-                project_paths=project_paths,
+                project_paths=project_paths_result,
                 target_repo_path=target_repo_path,
                 workspace=workspace,
                 selected_workspace_name=selected_workspace_name,
                 repository=repository,
             )
 
-        # Single project mode - use first (and only) path
-        project_path = project_paths[0]
+        project_path = project_paths_result[0]
 
     working_directory = Path(project_path).name
 
@@ -654,7 +675,7 @@ def create_git_issue_session(
     session_manager.update_session(session)
 
     # Build initial prompt with analysis-only constraints and session metadata
-    from devflow.cli.utils import get_workspace_path
+
     workspace_path = None
     if session.workspace_name and config and config.repos:
         workspace_path = get_workspace_path(config, session.workspace_name)
@@ -1045,7 +1066,7 @@ def _create_multi_project_git_session(
         repository: Optional repository in owner/repo format
     """
     from devflow.cli.commands.ticket_creation_multiproject import create_multi_project_ticket_creation_session
-    from devflow.cli.utils import get_workspace_path
+
     from devflow.session.manager import SessionManager
 
     # Build the goal string that includes the issue creation task
@@ -1124,57 +1145,3 @@ def _create_multi_project_git_session(
         handle_claude_code_launch_failure(session, session_manager, name)
 
 
-def _prompt_for_repository_selection(config, workspace_flag: Optional[str] = None) -> tuple[Optional[str], Optional[str]]:
-    """Prompt user to select a repository from workspace.
-
-    Args:
-        config: Configuration object
-        workspace_flag: Optional workspace name from command line flag
-
-    Returns:
-        Tuple of (project_path, workspace_name) if selected, (None, None) if cancelled
-    """
-    # Select workspace using priority resolution system
-    selected_workspace_name = select_workspace(
-        config,
-        workspace_flag=workspace_flag,
-        session=None,
-        skip_prompt=False
-    )
-
-    if not selected_workspace_name:
-        # No workspace selected - fall back to current directory
-        console_print(f"[yellow]⚠[/yellow] No workspace selected")
-        console_print(f"[dim]Using current directory: {Path.cwd()}[/dim]")
-        return str(Path.cwd()), None
-
-    # Get workspace path from workspace name
-    from devflow.cli.utils import get_workspace_path
-    workspace_path = get_workspace_path(config, selected_workspace_name)
-    if not workspace_path:
-        console_print(f"[yellow]⚠[/yellow] Could not find workspace path for: {selected_workspace_name}")
-        console_print(f"[dim]Using current directory: {Path.cwd()}[/dim]")
-        return str(Path.cwd()), None
-
-    console_print(f"\n[cyan]Scanning workspace:[/cyan] {workspace_path}")
-
-    # Scan for git repositories in workspace
-    try:
-        repo_options = scan_workspace_repositories(workspace_path)
-    except (ValueError, RuntimeError) as e:
-        console_print(f"[yellow]Warning: {e}[/yellow]")
-        console_print(f"[dim]Using current directory: {Path.cwd()}[/dim]")
-        return str(Path.cwd()), None
-
-    if not repo_options:
-        console_print(f"[yellow]⚠[/yellow] No git repositories found in workspace")
-        console_print(f"[dim]Make sure your workspace contains git repositories.[/dim]")
-        console_print(f"[dim]Using current directory: {Path.cwd()}[/dim]")
-        return str(Path.cwd()), None
-
-    # Prompt user to select repository
-    project_path = prompt_repository_selection(repo_options, workspace_path, allow_cancel=True)
-    if not project_path:
-        return None, None
-
-    return project_path, selected_workspace_name

--- a/devflow/cli/commands/investigate_command.py
+++ b/devflow/cli/commands/investigate_command.py
@@ -11,7 +11,7 @@ from typing import Optional
 from rich.console import Console
 from rich.prompt import Prompt, Confirm
 
-from devflow.cli.utils import console_print, get_workspace_path, is_json_mode, output_json, require_outside_claude, resolve_workspace_path, should_launch_claude_code
+from devflow.cli.utils import console_print, get_workspace_path, is_json_mode, output_json, require_outside_claude, resolve_workspace_path, scan_workspace_repositories, select_workspace, should_launch_claude_code, unified_project_selection
 from devflow.git.utils import GitUtils
 from devflow.utils.backend_detection import detect_backend_from_key
 from devflow.issue_tracker.factory import create_issue_tracker_client
@@ -322,36 +322,66 @@ def create_investigation_session(
             sys.exit(1)
         console_print(f"[dim]Using specified path: {project_path}[/dim]")
     else:
-        # Prompt for repository selection from workspace with multi-project support (Issue #182)
-        from devflow.cli.utils import prompt_repository_selection_with_multiproject
-        project_paths, selected_workspace_name = prompt_repository_selection_with_multiproject(
+        # Unified project selection (matches daf open UX)
+        selected_workspace_name = select_workspace(
             config,
             workspace_flag=workspace,
-            allow_multiple=True  # Enable multi-project mode for daf investigate
+            session=None,
+            skip_prompt=is_json_mode(),
         )
-        if not project_paths:
-            # User cancelled or no workspace configured
+
+        if not selected_workspace_name:
+            console_print(f"[yellow]⚠[/yellow] No workspace selected")
+            if is_json_mode():
+                output_json(success=False, error={"message": "No workspace selected", "code": "NO_WORKSPACE"})
+            sys.exit(1)
+
+        ws_path = get_workspace_path(config, selected_workspace_name)
+        if not ws_path:
+            console_print(f"[yellow]⚠[/yellow] Could not find workspace path for: {selected_workspace_name}")
+            if is_json_mode():
+                output_json(success=False, error={"message": f"Workspace path not found: {selected_workspace_name}", "code": "NO_WORKSPACE"})
+            sys.exit(1)
+
+        console_print(f"[dim]Scanning workspace: {ws_path}[/dim]")
+        try:
+            repo_options = scan_workspace_repositories(ws_path)
+        except (ValueError, RuntimeError) as e:
+            console_print(f"[yellow]Warning: {e}[/yellow]")
+            repo_options = []
+
+        if not repo_options:
+            console_print(f"[yellow]⚠[/yellow] No git repositories found in workspace")
+            if is_json_mode():
+                output_json(success=False, error={"message": "No repositories found", "code": "NO_REPOSITORY"})
+            sys.exit(1)
+
+        project_paths_result, is_multi = unified_project_selection(
+            workspace_path=ws_path,
+            repo_options=repo_options,
+            allow_multi_project=True,
+            config_loader=config_loader,
+            workspace_name=selected_workspace_name,
+        )
+        if not project_paths_result:
             if is_json_mode():
                 output_json(success=False, error={"message": "Repository selection cancelled or failed", "code": "NO_REPOSITORY"})
             sys.exit(1)
 
-        # Check if multi-project mode was selected (Issue #182)
-        if len(project_paths) > 1:
-            # Multi-project investigation session
+        if is_multi:
             return _create_multi_project_investigation_session(
                 config=config,
                 config_loader=config_loader,
                 name=name,
                 goal=goal,
                 parent=parent,
-                project_paths=project_paths,
+                project_paths=project_paths_result,
                 workspace=workspace,
                 selected_workspace_name=selected_workspace_name,
                 model_profile=model_profile,
             )
 
-        # Single project mode - use first (and only) path
-        project_path = project_paths[0]
+        project_path = project_paths_result[0]
 
     working_directory = Path(project_path).name
 

--- a/devflow/cli/commands/jira_new_command.py
+++ b/devflow/cli/commands/jira_new_command.py
@@ -10,7 +10,7 @@ from typing import Optional
 from rich.console import Console
 from rich.prompt import Prompt, Confirm
 
-from devflow.cli.utils import console_print, is_json_mode, output_json, prompt_repository_selection, require_outside_claude, scan_workspace_repositories, select_workspace, should_launch_claude_code
+from devflow.cli.utils import console_print, get_workspace_path, is_json_mode, output_json, require_outside_claude, scan_workspace_repositories, select_workspace, should_launch_claude_code, unified_project_selection
 from devflow.git.utils import GitUtils
 
 # Import unified utilities
@@ -99,7 +99,7 @@ def _create_mock_jira_ticket(
 
     # Build initial prompt with session name
     # AAP-64886: Get workspace path from session instead of using default
-    from devflow.cli.utils import get_workspace_path
+
     workspace_path = None
     if session.workspace_name and config and config.repos:
         workspace_path = get_workspace_path(config, session.workspace_name)
@@ -312,7 +312,7 @@ def create_jira_ticket_session(
         project_names = [p.strip() for p in projects.split(',')]
 
         # Get workspace path
-        from devflow.cli.utils import get_workspace_path
+    
         workspace_path = get_workspace_path(config, workspace)
         if not workspace_path:
             console_print(f"[red]✗[/red] Workspace '{workspace}' not found")
@@ -359,20 +359,44 @@ def create_jira_ticket_session(
             return
         console_print(f"[dim]Using specified path: {project_path}[/dim]")
     else:
-        # Prompt for repository selection from workspace with multi-project support (Issue #179)
-        from devflow.cli.utils import prompt_repository_selection_with_multiproject
-        project_paths, selected_workspace_name = prompt_repository_selection_with_multiproject(
+        # Unified project selection (matches daf open UX)
+        selected_workspace_name = select_workspace(
             config,
             workspace_flag=workspace,
-            allow_multiple=True  # Enable multi-project mode for jira new
+            session=None,
+            skip_prompt=is_json_mode(),
         )
-        if not project_paths:
-            # User cancelled or no workspace configured
+
+        if not selected_workspace_name:
+            console_print(f"[yellow]⚠[/yellow] No workspace selected")
             return
 
-        # Check if multi-project mode was selected
-        if len(project_paths) > 1:
-            # Multi-project ticket creation session
+        ws_path = get_workspace_path(config, selected_workspace_name)
+        if not ws_path:
+            console_print(f"[yellow]⚠[/yellow] Could not find workspace path for: {selected_workspace_name}")
+            return
+
+        try:
+            repo_options = scan_workspace_repositories(ws_path)
+        except (ValueError, RuntimeError) as e:
+            console_print(f"[yellow]Warning: {e}[/yellow]")
+            repo_options = []
+
+        if not repo_options:
+            console_print(f"[yellow]⚠[/yellow] No git repositories found in workspace")
+            return
+
+        project_paths_result, is_multi = unified_project_selection(
+            workspace_path=ws_path,
+            repo_options=repo_options,
+            allow_multi_project=True,
+            config_loader=config_loader,
+            workspace_name=selected_workspace_name,
+        )
+        if not project_paths_result:
+            return
+
+        if is_multi:
             return _create_multi_project_jira_session(
                 config=config,
                 config_loader=config_loader,
@@ -380,14 +404,13 @@ def create_jira_ticket_session(
                 goal=goal,
                 issue_type=issue_type,
                 parent=parent,
-                project_paths=project_paths,
+                project_paths=project_paths_result,
                 workspace=workspace,
                 selected_workspace_name=selected_workspace_name,
                 affects_versions=affects_versions,
             )
 
-        # Single project mode - use first (and only) path
-        project_path = project_paths[0]
+        project_path = project_paths_result[0]
 
     working_directory = Path(project_path).name
 
@@ -541,7 +564,7 @@ def create_jira_ticket_session(
 
     # Build initial prompt with analysis-only constraints and session metadata
     # AAP-64886: Get workspace path from session instead of using default
-    from devflow.cli.utils import get_workspace_path
+
     workspace_path = None
     if session.workspace_name and config and config.repos:
         workspace_path = get_workspace_path(config, session.workspace_name)
@@ -1028,7 +1051,7 @@ def _create_multi_project_jira_session(
         affects_versions: Optional affected versions
     """
     from devflow.cli.commands.ticket_creation_multiproject import create_multi_project_ticket_creation_session
-    from devflow.cli.utils import get_workspace_path
+
     from devflow.session.manager import SessionManager
 
     # Build the goal string that includes the ticket creation task
@@ -1099,57 +1122,3 @@ def _create_multi_project_jira_session(
         handle_claude_code_launch_failure(session, session_manager, name)
 
 
-def _prompt_for_repository_selection(config, workspace_flag: Optional[str] = None) -> tuple[Optional[str], Optional[str]]:
-    """Prompt user to select a repository from workspace.
-
-    Args:
-        config: Configuration object
-        workspace_flag: Optional workspace name from command line flag
-
-    Returns:
-        Tuple of (project_path, workspace_name) if selected, (None, None) if cancelled
-    """
-    # Select workspace using priority resolution system
-    selected_workspace_name = select_workspace(
-        config,
-        workspace_flag=workspace_flag,  # Use workspace from --workspace flag if provided
-        session=None,  # No existing session yet
-        skip_prompt=False  # Always prompt for workspace selection
-    )
-
-    if not selected_workspace_name:
-        # No workspace selected - fall back to current directory
-        console_print(f"[yellow]⚠[/yellow] No workspace selected")
-        console_print(f"[dim]Using current directory: {Path.cwd()}[/dim]")
-        return str(Path.cwd()), None
-
-    # Get workspace path from workspace name
-    from devflow.cli.utils import get_workspace_path
-    workspace_path = get_workspace_path(config, selected_workspace_name)
-    if not workspace_path:
-        console_print(f"[yellow]⚠[/yellow] Could not find workspace path for: {selected_workspace_name}")
-        console_print(f"[dim]Using current directory: {Path.cwd()}[/dim]")
-        return str(Path.cwd()), None
-
-    console_print(f"\n[cyan]Scanning workspace:[/cyan] {workspace_path}")
-
-    # Scan for git repositories in workspace
-    try:
-        repo_options = scan_workspace_repositories(workspace_path)
-    except (ValueError, RuntimeError) as e:
-        console_print(f"[yellow]Warning: {e}[/yellow]")
-        console_print(f"[dim]Using current directory: {Path.cwd()}[/dim]")
-        return str(Path.cwd()), None
-
-    if not repo_options:
-        console_print(f"[yellow]⚠[/yellow] No git repositories found in workspace")
-        console_print(f"[dim]Make sure your workspace contains git repositories.[/dim]")
-        console_print(f"[dim]Using current directory: {Path.cwd()}[/dim]")
-        return str(Path.cwd()), None
-
-    # Prompt user to select repository
-    project_path = prompt_repository_selection(repo_options, workspace_path, allow_cancel=True)
-    if not project_path:
-        return None, None
-
-    return project_path, selected_workspace_name

--- a/devflow/cli/commands/new_command.py
+++ b/devflow/cli/commands/new_command.py
@@ -12,7 +12,7 @@ from typing import Optional
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
-from devflow.cli.utils import check_concurrent_session, console_print, get_status_display, is_json_mode, output_json as json_output, require_outside_claude, resolve_workspace_path, scan_workspace_repositories, serialize_session, should_launch_claude_code
+from devflow.cli.utils import check_concurrent_session, console_print, get_status_display, is_json_mode, output_json as json_output, require_outside_claude, resolve_workspace_path, scan_workspace_repositories, serialize_session, should_launch_claude_code, unified_project_selection
 from devflow.config.loader import ConfigLoader
 from devflow.git.utils import GitUtils
 from devflow.jira import JiraClient
@@ -482,64 +482,14 @@ def create_new_session(
                 console.print(f"[yellow]⚠[/yellow] Warning: {error}")
 
     # Multi-project workflow (Issue #149)
-    # If --projects flag is provided OR user wants to select multiple projects interactively
+    # If --projects flag is provided, handle directly
     multi_project_names = None
 
     if projects:
         # --projects flag provided - use those projects
         multi_project_names = [p.strip() for p in projects.split(',')]
-    elif workspace_path and not non_interactive and path is None:
-        # No --projects flag, but we have a workspace - offer interactive multi-project selection
-        workspace_path_obj = Path(workspace_path)
-        available_repos = scan_workspace_repositories(workspace_path_obj)
 
-        if len(available_repos) > 1:
-            # Multiple repos available - ask if user wants multi-project session
-            console.print(f"\n[cyan]Detected {len(available_repos)} git repositories in workspace '{selected_workspace_name}':[/cyan]")
-            for repo in available_repos[:10]:  # Show first 10
-                console.print(f"  • {repo}")
-            if len(available_repos) > 10:
-                console.print(f"  ... and {len(available_repos) - 10} more")
-
-            if Confirm.ask("\nCreate multi-project session (work across multiple repos)?", default=False):
-                # User wants multi-project - let them select projects
-                from rich.prompt import Prompt
-
-                console.print("\n[bold]Select projects (comma-separated numbers or names):[/bold]")
-                for i, repo in enumerate(available_repos, 1):
-                    console.print(f"{i}. {repo}")
-
-                selection = Prompt.ask("\nEnter project numbers or names (e.g., 1,3,5 or backend-api,frontend-app)")
-
-                # Parse selection (could be numbers or names)
-                selected_projects = []
-                for item in selection.split(','):
-                    item = item.strip()
-                    if item.isdigit():
-                        # Numeric selection
-                        idx = int(item) - 1
-                        if 0 <= idx < len(available_repos):
-                            selected_projects.append(available_repos[idx])
-                    else:
-                        # Name selection
-                        if item in available_repos:
-                            selected_projects.append(item)
-                        else:
-                            console.print(f"[yellow]⚠[/yellow] Project '{item}' not found - skipping")
-
-                if len(selected_projects) > 1:
-                    multi_project_names = selected_projects
-                    console.print(f"\n[green]✓[/green] Selected {len(multi_project_names)} projects:")
-                    for proj in multi_project_names:
-                        console.print(f"  • {proj}")
-                elif len(selected_projects) == 1:
-                    # Only one project selected - continue with single-project flow
-                    path = str(workspace_path_obj / selected_projects[0])
-                    console.print(f"\n[dim]Only one project selected - continuing with single-project session[/dim]")
-                else:
-                    console.print("\n[yellow]⚠[/yellow] No valid projects selected - continuing with single-project session")
-
-    # If multi-project mode, create multi-project session
+    # If multi-project mode via --projects flag, create multi-project session
     if multi_project_names:
         # Validate all projects exist in workspace
         if not workspace_path:
@@ -606,36 +556,63 @@ def create_new_session(
                     json_output(success=False, error={"code": "NO_PATH", "message": "Path required in non-interactive mode"})
                 raise click.Abort()
         else:
-            # Interactive mode: offer suggestions and prompts
-            # Always offer intelligent repository suggestions (with or without JIRA)
-            # Pass selected workspace to ensure correct repository discovery
-            suggested_path = _suggest_and_select_repository(
+            # Interactive mode: use unified project selection with AI suggestions
+            result = _suggest_and_select_repository(
                 config_loader,
                 issue_metadata_dict=issue_metadata_dict,
                 issue_key=issue_key,
                 workspace_name=selected_workspace_name,
+                allow_multi_project=(workspace_path is not None),
             )
-            if suggested_path:
-                path = suggested_path
-            elif is_current_dir_a_project:
-                # Current directory is a project - offer to use it
-                if Confirm.ask(f"Use current directory?\n  {current_dir}", default=True):
-                    path = str(current_dir)
+            if result:
+                selected_paths, is_multi = result
+                if is_multi and selected_paths:
+                    # Multi-project selected via unified UI
+                    multi_names = [Path(p).name for p in selected_paths]
+                    from devflow.cli.commands.new_command_multiproject import create_multi_project_session
+                    create_multi_project_session(
+                        session_manager=session_manager,
+                        config_loader=config_loader,
+                        config=config,
+                        name=name,
+                        goal=goal,
+                        issue_key=issue_key,
+                        issue_metadata_dict=issue_metadata_dict,
+                        issue_title=issue_title,
+                        project_names=multi_names,
+                        workspace_path=workspace_path,
+                        selected_workspace_name=selected_workspace_name,
+                        force_new_session=force_new_session,
+                        model_profile=model_profile,
+                        output_json=output_json,
+                        create_branch=create_branch,
+                        source_branch=source_branch,
+                        on_branch_exists=on_branch_exists,
+                        allow_uncommitted=allow_uncommitted,
+                        sync_upstream=sync_upstream,
+                        non_interactive=non_interactive,
+                    )
+                    return
+                elif selected_paths:
+                    path = selected_paths[0]
+            if not path:
+                if is_current_dir_a_project:
+                    if Confirm.ask(f"Use current directory?\n  {current_dir}", default=True):
+                        path = str(current_dir)
+                    else:
+                        path = Prompt.ask("Enter project path")
+                        if not path or not path.strip():
+                            console.print("[red]✗[/red] Project path cannot be empty")
+                            raise click.Abort()
+                        path = path.strip()
                 else:
+                    console.print(f"\n[yellow]Current directory is not a git repository[/yellow]")
+                    console.print(f"[dim]You must select a project directory for the session[/dim]")
                     path = Prompt.ask("Enter project path")
                     if not path or not path.strip():
                         console.print("[red]✗[/red] Project path cannot be empty")
                         raise click.Abort()
                     path = path.strip()
-            else:
-                # Not in a project directory and no suggestions - must specify path
-                console.print(f"\n[yellow]Current directory is not a git repository[/yellow]")
-                console.print(f"[dim]You must select a project directory for the session[/dim]")
-                path = Prompt.ask("Enter project path")
-                if not path or not path.strip():
-                    console.print("[red]✗[/red] Project path cannot be empty")
-                    raise click.Abort()
-                path = path.strip()
 
     project_path = str(Path(path).absolute())
 
@@ -1020,83 +997,69 @@ def _suggest_and_select_repository(
     issue_metadata_dict: Optional[dict] = None,
     issue_key: Optional[str] = None,
     workspace_name: Optional[str] = None,
-) -> Optional[str]:
+    allow_multi_project: bool = False,
+) -> Optional[tuple]:
     """Suggest repositories based on issue tracker ticket and let user select.
+
+    Uses unified_project_selection for consistent UX across all commands,
+    with AI suggestions and per-project memory as enhancements.
 
     Args:
         config_loader: ConfigLoader instance
         issue_metadata_dict: issue tracker ticket metadata (if available)
         issue_key: issue tracker key (if available)
-        workspace_name: Optional workspace name to use (AAP-64886)
+        workspace_name: Optional workspace name to use
+        allow_multi_project: Whether to offer multi-project selection
 
     Returns:
-        Selected repository path or None if user cancelled
+        Tuple of (selected_paths, is_multi_project) or None if cancelled/no workspace
     """
     config = config_loader.load_config()
 
     # Get available repositories from workspace
     available_repos = []
-    workspace_path = None
-    # AAP-64886: Use selected workspace instead of default
     workspace_path_str = resolve_workspace_path(config, workspace_name)
     if workspace_path_str:
-        workspace_path = Path(workspace_path_str).expanduser()
         try:
             available_repos = scan_workspace_repositories(workspace_path_str)
         except (ValueError, RuntimeError) as e:
             console.print(f"[yellow]Warning: {e}[/yellow]")
 
     if not available_repos:
-        # No workspace configured or no repos found
         return None
 
-    # Calculate default repository using 3-tier priority system
+    # Calculate default repository using project-specific memory
     default_repo = None
+    suggested_repo_source = None
 
     if config and config.prompts and issue_key:
-        # Tier 1: Project-specific memory (JIRA project key or Git owner/repo)
-        # Check for JIRA project key (format: "PROJ-123")
+        # Tier 1: Project-specific memory (JIRA project key)
         project_key = issue_key.split('-')[0] if '-' in issue_key and not issue_key.startswith('#') else None
         if project_key and config.prompts.remember_last_repo_per_project:
             remembered_repo = config.prompts.remember_last_repo_per_project.get(project_key)
             if remembered_repo and remembered_repo in available_repos:
                 default_repo = remembered_repo
-                console.print(f"\n[cyan]Remembered repository for {project_key}: {remembered_repo}[/cyan]")
-                console.print("[dim]Press Enter to use it, or type a different selection[/dim]")
+                suggested_repo_source = f"remembered for {project_key}"
 
-        # Check for Git issue key (format: "owner/repo#123" or "#123")
-        if not default_repo and '#' in issue_key:
-            # Extract owner/repo part if present
-            if '/' in issue_key and '#' in issue_key:
-                git_repo_key = issue_key.split('#')[0]  # Extract "owner/repo"
-                if config.prompts.remember_last_repo_per_git_repo:
-                    remembered_repo = config.prompts.remember_last_repo_per_git_repo.get(git_repo_key)
-                    if remembered_repo and remembered_repo in available_repos:
-                        default_repo = remembered_repo
-                        console.print(f"\n[cyan]Remembered repository for {git_repo_key}: {remembered_repo}[/cyan]")
-                        console.print("[dim]Press Enter to use it, or type a different selection[/dim]")
+        # Check for Git issue key (format: "owner/repo#123")
+        if not default_repo and '#' in issue_key and '/' in issue_key:
+            git_repo_key = issue_key.split('#')[0]
+            if config.prompts.remember_last_repo_per_git_repo:
+                remembered_repo = config.prompts.remember_last_repo_per_git_repo.get(git_repo_key)
+                if remembered_repo and remembered_repo in available_repos:
+                    default_repo = remembered_repo
+                    suggested_repo_source = f"remembered for {git_repo_key}"
 
-    # Tier 2: Workspace-level last-used repo (fallback)
-    if not default_repo and config and config.prompts and workspace_name:
-        if config.prompts.last_used_repo_per_workspace:
-            remembered_repo = config.prompts.last_used_repo_per_workspace.get(workspace_name)
-            if remembered_repo and remembered_repo in available_repos:
-                default_repo = remembered_repo
-                console.print(f"\n[cyan]Last used repository in workspace '{workspace_name}': {remembered_repo}[/cyan]")
-                console.print("[dim]Press Enter to use it, or type a different selection[/dim]")
-
-    # Generate repository suggestions using the learning model
+    # Generate AI suggestions for suggested_repo marker
     suggester = RepositorySuggester()
-
+    suggested_repo = None
     suggestions = []
+
     if issue_metadata_dict:
-        # Extract ticket information for suggestions
         summary = issue_metadata_dict.get("summary", "")
         description = issue_metadata_dict.get("description")
         ticket_type = issue_metadata_dict.get("type")
         labels = issue_metadata_dict.get("labels", [])
-
-        # Get config keywords for fallback
         config_keywords = config.repos.keywords if config and config.repos else {}
 
         suggestions = suggester.suggest_repositories(
@@ -1109,121 +1072,16 @@ def _suggest_and_select_repository(
             config_keywords=config_keywords,
         )
 
-    # Display suggestions
-    if suggestions:
-        console.print("\n[bold cyan]Suggested repositories (based on ticket content):[/bold cyan]")
-        for i, suggestion in enumerate(suggestions, 1):
-            confidence_pct = int(suggestion.confidence * 100)
-            console.print(f"  {i}. [bold]{suggestion.repository}[/bold] ({confidence_pct}% confidence)")
-            if suggestion.reasons:
-                console.print(f"     [dim]• {suggestion.reasons[0]}[/dim]")
-        console.print()
+        if suggestions and not default_repo:
+            suggested_repo = suggestions[0].repository
+            suggested_repo_source = "suggested"
+            default_repo = suggested_repo
 
-    # Display all available repositories
-    console.print(f"\n[bold]Available repositories ({len(available_repos)}):[/bold]")
-    for i, repo in enumerate(available_repos, 1):
-        # Highlight if it's in suggestions
-        if suggestions and any(s.repository == repo for s in suggestions[:3]):
-            console.print(f"  {i}. {repo} [dim](suggested)[/dim]")
-        else:
-            console.print(f"  {i}. {repo}")
-
-    # Prompt for selection
-    console.print(f"\n[bold]Select repository:[/bold]")
-    console.print(f"  • Enter a number (1-{len(available_repos)}) to select from the list above")
-    console.print(f"  • Enter a repository name")
-    console.print(f"  • Enter an absolute path (starting with / or ~)")
-    console.print(f"  • Enter 'cancel' or 'q' to use current directory")
-
-    # Tier 3: Calculate default selection based on suggestions or default_repo
-    default_selection = "1"  # Final fallback: first repository
-    if default_repo and default_repo in available_repos:
-        # Use the remembered repo index as default
-        default_index = available_repos.index(default_repo) + 1
-        default_selection = str(default_index)
-    elif suggestions:
-        # Use first suggestion as default
-        suggested_repo = suggestions[0].repository
-        if suggested_repo in available_repos:
-            default_index = available_repos.index(suggested_repo) + 1
-            default_selection = str(default_index)
-
-    selection = Prompt.ask("Selection", default=default_selection)
-
-    # Validate input is not empty
-    if not selection or selection.strip() == "":
-        console.print(f"[red]✗[/red] Empty selection not allowed. Please enter a number (1-{len(available_repos)}), repository name, path, or 'cancel'/'q'")
-        return None
-
-    # Handle cancel
-    if selection.lower() in ["cancel", "q"]:
-        return None
-
-    # Check if it's a number (selecting from list)
-    if selection.isdigit():
-        repo_index = int(selection) - 1
-        if 0 <= repo_index < len(available_repos):
-            repo_name = available_repos[repo_index]
-            console.print(f"[dim]Selected: {repo_name}[/dim]")
-
-            if workspace_path:
-                selected_path = str(workspace_path / repo_name)
-
-                # Record selection for learning
-                if issue_metadata_dict:
-                    suggester.record_selection(
-                        repository=repo_name,
-                        issue_key=issue_key,
-                        ticket_type=issue_metadata_dict.get("type"),
-                        summary=issue_metadata_dict.get("summary"),
-                        description=issue_metadata_dict.get("description"),
-                        labels=issue_metadata_dict.get("labels", []),
-                    )
-
-                # Remember this repository (project-specific, git-specific, and workspace-level)
-                if config:
-                    config_updated = False
-
-                    # Save for JIRA project (format: "PROJ-123")
-                    if issue_key and '-' in issue_key and not issue_key.startswith('#'):
-                        project_key = issue_key.split('-')[0]
-                        config.prompts.remember_last_repo_per_project[project_key] = repo_name
-                        console.print(f"[dim]Remembered {repo_name} for {project_key} tickets[/dim]")
-                        config_updated = True
-
-                    # Save for Git repository (format: "owner/repo#123")
-                    if issue_key and '#' in issue_key and '/' in issue_key:
-                        git_repo_key = issue_key.split('#')[0]  # Extract "owner/repo"
-                        config.prompts.remember_last_repo_per_git_repo[git_repo_key] = repo_name
-                        console.print(f"[dim]Remembered {repo_name} for {git_repo_key} issues[/dim]")
-                        config_updated = True
-
-                    # Always save as last-used repo for this workspace (fallback)
-                    if workspace_name:
-                        config.prompts.last_used_repo_per_workspace[workspace_name] = repo_name
-                        config_updated = True
-
-                    if config_updated:
-                        config_loader.save_config(config)
-
-                return selected_path
-        else:
-            console.print(f"[red]✗[/red] Invalid selection. Please choose 1-{len(available_repos)}")
-            return None
-
-    # Check if it's an absolute path
-    elif selection.startswith("/") or selection.startswith("~"):
-        project_path = Path(selection).expanduser().absolute()
-
-        if not project_path.exists():
-            console.print(f"[yellow]⚠[/yellow] Path does not exist: {project_path}")
-            if not Confirm.ask("Use this path anyway?", default=False):
-                return None
-
-        # Record selection for learning (use directory name as repo)
+    # Build learning callback
+    def on_selection(repo_name, ws_path):
         if issue_metadata_dict:
             suggester.record_selection(
-                repository=project_path.name,
+                repository=repo_name,
                 issue_key=issue_key,
                 ticket_type=issue_metadata_dict.get("type"),
                 summary=issue_metadata_dict.get("summary"),
@@ -1231,61 +1089,32 @@ def _suggest_and_select_repository(
                 labels=issue_metadata_dict.get("labels", []),
             )
 
-        return str(project_path)
+        # Save per-project memory
+        if config and issue_key:
+            config_updated = False
+            if '-' in issue_key and not issue_key.startswith('#'):
+                pk = issue_key.split('-')[0]
+                config.prompts.remember_last_repo_per_project[pk] = repo_name
+                config_updated = True
+            if '#' in issue_key and '/' in issue_key:
+                grk = issue_key.split('#')[0]
+                config.prompts.remember_last_repo_per_git_repo[grk] = repo_name
+                config_updated = True
+            if config_updated:
+                config_loader.save_config(config)
 
-    # Otherwise treat as repository name
-    else:
-        repo_name = selection
-
-        if workspace_path:
-            project_path = workspace_path / repo_name
-
-            if not project_path.exists():
-                console.print(f"[yellow]⚠[/yellow] Repository not found: {project_path}")
-                if not Confirm.ask("Use this path anyway?", default=False):
-                    return None
-
-            # Record selection for learning
-            if issue_metadata_dict:
-                suggester.record_selection(
-                    repository=repo_name,
-                    issue_key=issue_key,
-                    ticket_type=issue_metadata_dict.get("type"),
-                    summary=issue_metadata_dict.get("summary"),
-                    description=issue_metadata_dict.get("description"),
-                    labels=issue_metadata_dict.get("labels", []),
-                )
-
-            # Remember this repository (project-specific, git-specific, and workspace-level)
-            if config:
-                config_updated = False
-
-                # Save for JIRA project (format: "PROJ-123")
-                if issue_key and '-' in issue_key and not issue_key.startswith('#'):
-                    project_key = issue_key.split('-')[0]
-                    config.prompts.remember_last_repo_per_project[project_key] = repo_name
-                    console.print(f"[dim]Remembered {repo_name} for {project_key} tickets[/dim]")
-                    config_updated = True
-
-                # Save for Git repository (format: "owner/repo#123")
-                if issue_key and '#' in issue_key and '/' in issue_key:
-                    git_repo_key = issue_key.split('#')[0]  # Extract "owner/repo"
-                    config.prompts.remember_last_repo_per_git_repo[git_repo_key] = repo_name
-                    console.print(f"[dim]Remembered {repo_name} for {git_repo_key} issues[/dim]")
-                    config_updated = True
-
-                # Always save as last-used repo for this workspace (fallback)
-                if workspace_name:
-                    config.prompts.last_used_repo_per_workspace[workspace_name] = repo_name
-                    config_updated = True
-
-                if config_updated:
-                    config_loader.save_config(config)
-
-            return str(project_path)
-        else:
-            console.print(f"[red]✗[/red] No workspace configured in config")
-            return None
+    # Delegate to unified project selection
+    return unified_project_selection(
+        workspace_path=workspace_path_str,
+        repo_options=available_repos,
+        suggested_repo=suggested_repo or default_repo,
+        suggested_repo_source=suggested_repo_source,
+        default_repo=default_repo,
+        allow_multi_project=allow_multi_project,
+        on_selection=on_selection,
+        config_loader=config_loader,
+        workspace_name=workspace_name,
+    )
 
 
 def _get_default_source_branch(path: Path) -> str:

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -14,7 +14,7 @@ from rich.prompt import Confirm
 from rich.table import Table
 
 from devflow.cli.commands.new_command import _generate_initial_prompt
-from devflow.cli.utils import check_concurrent_session, get_session_with_prompt, get_status_display, require_outside_claude, should_launch_claude_code
+from devflow.cli.utils import check_concurrent_session, extract_repository_from_issue_key, get_session_with_prompt, get_status_display, get_workspace_path, require_outside_claude, scan_workspace_repositories, should_launch_claude_code, unified_project_selection
 from devflow.config.loader import ConfigLoader
 from devflow.git.utils import GitUtils
 from devflow.jira import transition_on_start as jira_transition_on_start
@@ -189,48 +189,8 @@ def prompt_session_selection(session_manager: SessionManager, status_filter: Opt
 
 
 def _extract_repository_from_issue_key(issue_key: str, issue_tracker: Optional[str]) -> Optional[str]:
-    """Extract repository name from GitHub/GitLab issue key.
-
-    Args:
-        issue_key: Issue key (e.g., "owner/repo#123", "#123", "PROJ-123")
-        issue_tracker: Issue tracker type ("github", "gitlab", "jira", etc.)
-
-    Returns:
-        Repository name (e.g., "repo") if extractable, None otherwise
-
-    Examples:
-        >>> _extract_repository_from_issue_key("itdove/devaiflow#146", "github")
-        'devaiflow'
-        >>> _extract_repository_from_issue_key("#123", "github")
-        None
-        >>> _extract_repository_from_issue_key("PROJ-123", "jira")
-        None
-    """
-    # Only process GitHub/GitLab issues
-    if not issue_tracker or issue_tracker not in ["github", "gitlab"]:
-        return None
-
-    if not issue_key:
-        return None
-
-    # Check if issue key contains owner/repo format
-    # Format: owner/repo#123
-    if "/" in issue_key and "#" in issue_key:
-        # Extract the part between / and #
-        try:
-            # Split on / to get [owner, repo#123]
-            parts = issue_key.split("/")
-            if len(parts) >= 2:
-                # Get the last part which should be "repo#123"
-                repo_with_number = parts[-1]
-                # Split on # to get [repo, 123]
-                repo = repo_with_number.split("#")[0]
-                return repo if repo else None
-        except (IndexError, ValueError):
-            return None
-
-    # Issue key doesn't contain repository info (e.g., "#123")
-    return None
+    """Deprecated: use extract_repository_from_issue_key from devflow.cli.utils."""
+    return extract_repository_from_issue_key(issue_key, issue_tracker)
 
 
 def _set_terminal_title(session) -> None:
@@ -369,7 +329,7 @@ def open_session(
 
     # AAP-63377: Workspace selection
     # Select workspace using priority resolution (--workspace flag > session.workspace_name > default > prompt)
-    from devflow.cli.utils import select_workspace, get_workspace_path
+    from devflow.cli.utils import select_workspace
     selected_workspace_name = select_workspace(
         config,
         workspace_flag=workspace,
@@ -439,7 +399,7 @@ def open_session(
             # (session.workspace_name was updated by _handle_workspace_mismatch)
             selected_workspace_name = session.workspace_name
             if selected_workspace_name:
-                from devflow.cli.utils import get_workspace_path
+
                 workspace_path = get_workspace_path(config, selected_workspace_name)
 
     # Check if session is part of a feature orchestration
@@ -2793,8 +2753,6 @@ def _prompt_for_working_directory(
     Returns:
         True if working directory was set successfully, False if user cancelled
     """
-    from rich.prompt import Prompt
-
     console.print(f"\n[bold]Select working directory for session:[/bold] {session.name}")
     if session.issue_key:
         console.print(f"[dim]Issue: {session.issue_key}[/dim]")
@@ -2804,221 +2762,65 @@ def _prompt_for_working_directory(
     # Try to extract repository suggestion from issue key (GitHub/GitLab)
     suggested_repo = None
     if session.issue_key and session.issue_tracker:
-        suggested_repo = _extract_repository_from_issue_key(session.issue_key, session.issue_tracker)
-        if suggested_repo:
-            console.print(f"[cyan]ℹ Issue repository:[/cyan] {suggested_repo} (from {session.issue_key})")
+        suggested_repo = extract_repository_from_issue_key(session.issue_key, session.issue_tracker)
 
-    # Try to detect available repositories from config
+    # Resolve workspace and scan repos
     config = config_loader.load_config()
-    repo_options = []
-    suggested_repo_index = None
+    workspace_path = None
 
     if config and config.repos:
-        # Use selected workspace if provided, otherwise fall back to default
         if selected_workspace_name:
-            from devflow.cli.utils import get_workspace_path
             workspace_path = get_workspace_path(config, selected_workspace_name)
         else:
             workspace_path = config.repos.get_default_workspace_path()
 
-        if workspace_path:
-            workspace = Path(workspace_path).expanduser()
-            console.print(f"\n[cyan]Scanning workspace:[/cyan] {workspace}")
-
-            if workspace.exists() and workspace.is_dir():
-                # List all git repositories in workspace
-                try:
-                    from devflow.git.utils import GitUtils
-                    directories = [d for d in workspace.iterdir() if d.is_dir() and not d.name.startswith('.')]
-                    # Filter to only include git repositories
-                    git_repos = [d.name for d in directories if GitUtils.is_git_repository(d)]
-
-                    # Sort repositories, but put suggested repo first if it exists
-                    if suggested_repo and suggested_repo in git_repos:
-                        # Move suggested repo to front
-                        git_repos.remove(suggested_repo)
-                        repo_options = [suggested_repo] + sorted(git_repos)
-                        suggested_repo_index = 0  # First item
-                    else:
-                        repo_options = sorted(git_repos)
-
-                    if repo_options:
-                        console.print(f"\n[bold]Available repositories ({len(repo_options)}):[/bold]")
-                        for i, repo in enumerate(repo_options, 1):
-                            # Highlight suggested repository
-                            if suggested_repo and repo == suggested_repo:
-                                console.print(f"  {i}. {repo} [dim](from issue)[/dim]")
-                            else:
-                                console.print(f"  {i}. {repo}")
-                except Exception as e:
-                    console.print(f"[yellow]Warning: Could not scan workspace: {e}[/yellow]")
-
-    # Multi-project selection (Issue #177)
-    # If multiple repositories available, offer multi-project mode
-    if len(repo_options) > 1:
-        if Confirm.ask("\nCreate multi-project session (work across multiple repos)?", default=False):
-            # User wants multi-project mode - show selection UI
-            console.print("\n[bold]Select projects (comma-separated numbers or names):[/bold]")
-            for i, repo in enumerate(repo_options, 1):
-                if suggested_repo and repo == suggested_repo:
-                    console.print(f"{i}. {repo} [dim](from issue)[/dim]")
-                else:
-                    console.print(f"{i}. {repo}")
-
-            # Calculate default based on suggested repo
-            default_selection = "1"  # Default to first repository
-            if suggested_repo and suggested_repo in repo_options:
-                default_index = repo_options.index(suggested_repo) + 1
-                default_selection = str(default_index)
-
-            selection = Prompt.ask("\nEnter project numbers or names (e.g., 1,3,5 or backend-api,frontend-app)", default=default_selection)
-
-            # Parse selection (could be numbers or names)
-            selected_projects = []
-            for item in selection.split(','):
-                item = item.strip()
-                if item.isdigit():
-                    # Numeric selection
-                    idx = int(item) - 1
-                    if 0 <= idx < len(repo_options):
-                        selected_projects.append(repo_options[idx])
-                else:
-                    # Name selection
-                    if item in repo_options:
-                        selected_projects.append(item)
-                    else:
-                        console.print(f"[yellow]⚠[/yellow] Project '{item}' not found - skipping")
-
-            if len(selected_projects) > 1:
-                # Create multi-project session
-                console.print(f"\n[green]✓[/green] Selected {len(selected_projects)} projects:")
-                for proj in selected_projects:
-                    console.print(f"  • {proj}")
-
-                # Create multi-project conversation
-                return _create_multi_project_conversation_for_open(
-                    session=session,
-                    project_names=selected_projects,
-                    workspace_path=str(workspace),
-                    config=config,
-                    config_loader=config_loader,
-                    session_manager=session_manager,
-                    selected_workspace_name=selected_workspace_name,
-                    create_branch=create_branch,
-                    source_branch=source_branch,
-                    on_branch_exists=on_branch_exists,
-                    allow_uncommitted=allow_uncommitted,
-                    sync_upstream=sync_upstream,
-                )
-            elif len(selected_projects) == 1:
-                # Only one project selected - continue with single-project flow
-                console.print(f"\n[dim]Only one project selected - continuing with single-project session[/dim]")
-                # Set the selected project and continue to single-project logic below
-                repo_options = selected_projects
-                suggested_repo_index = 0
-            else:
-                console.print("\n[yellow]⚠[/yellow] No valid projects selected - continuing with single-project prompt")
-
-    # Single-project selection (original behavior)
-    # Prompt for working directory with default suggestion
-    console.print(f"\n[bold]Select working directory:[/bold]")
-    if repo_options:
-        console.print(f"  • Enter a number (1-{len(repo_options)}) to select from the list above")
-        console.print(f"  • Enter a repository name")
-        console.print(f"  • Enter an absolute path (starting with / or ~)")
-        console.print(f"  • Enter 'cancel' or 'q' to exit")
-    else:
-        console.print(f"  • Enter a repository name from workspace")
-        console.print(f"  • Enter an absolute path (starting with / or ~)")
-        console.print(f"  • Enter 'cancel' or 'q' to exit")
-
-    # Set default to suggested repository if found, otherwise default to first repo
-    default_value = "1"  # Default to first repository
-    if suggested_repo_index is not None:
-        default_value = str(suggested_repo_index + 1)  # 1-indexed for display
-
-    selection = Prompt.ask("Selection", default=default_value)
-
-    # Validate input is not empty
-    if not selection or selection.strip() == "":
-        if repo_options:
-            console.print(f"[red]✗[/red] Empty selection not allowed. Please enter a number (1-{len(repo_options)}), repository name, path, or 'cancel'/'q'")
-        else:
-            console.print(f"[red]✗[/red] Empty selection not allowed. Please enter a repository name, path, or 'cancel'/'q'")
+    if not workspace_path:
+        console.print("[yellow]⚠[/yellow] No workspace configured")
         return False
 
-    # Handle cancel
-    if selection.lower() in ["cancel", "q"]:
+    try:
+        repo_options = scan_workspace_repositories(workspace_path)
+    except (ValueError, RuntimeError) as e:
+        console.print(f"[yellow]Warning: Could not scan workspace: {e}[/yellow]")
+        repo_options = []
+
+    if not repo_options:
+        console.print(f"[yellow]⚠[/yellow] No git repositories found in workspace")
+        return False
+
+    # Use unified project selection
+    selected_paths, is_multi = unified_project_selection(
+        workspace_path=workspace_path,
+        repo_options=repo_options,
+        suggested_repo=suggested_repo,
+        suggested_repo_source="from issue" if suggested_repo else None,
+        allow_multi_project=True,
+        config_loader=config_loader,
+        workspace_name=selected_workspace_name,
+    )
+
+    if not selected_paths:
         console.print(f"\n[yellow]Cancelled[/yellow] - session not opened")
         return False
 
-    # Check if it's a number (selecting from list)
-    if selection.isdigit() and repo_options:
-        repo_index = int(selection) - 1
-        if 0 <= repo_index < len(repo_options):
-            repo_name = repo_options[repo_index]
-            console.print(f"[dim]Selected: {repo_name}[/dim]")
+    if is_multi:
+        project_names = [Path(p).name for p in selected_paths]
+        return _create_multi_project_conversation_for_open(
+            session=session,
+            project_names=project_names,
+            workspace_path=workspace_path,
+            config=config,
+            config_loader=config_loader,
+            session_manager=session_manager,
+            selected_workspace_name=selected_workspace_name,
+            create_branch=create_branch,
+            source_branch=source_branch,
+            on_branch_exists=on_branch_exists,
+            allow_uncommitted=allow_uncommitted,
+            sync_upstream=sync_upstream,
+        )
 
-            if config and config.repos:
-                # Use selected workspace if provided, otherwise fall back to default
-                if selected_workspace_name:
-                    from devflow.cli.utils import get_workspace_path
-                    workspace_path = get_workspace_path(config, selected_workspace_name)
-                else:
-                    workspace_path = config.repos.get_default_workspace_path()
-
-                if not workspace_path:
-
-                    console.print("[yellow]⚠[/yellow] No default workspace configured")
-
-                    return None
-
-                workspace = Path(workspace_path).expanduser()
-                project_path = workspace / repo_name
-            else:
-                console.print(f"[red]✗[/red] No workspace configured in config")
-                return False
-        else:
-            console.print(f"[red]✗[/red] Invalid selection. Please choose 1-{len(repo_options)}")
-            return False
-    # Check if it's an absolute path
-    elif selection.startswith("/") or selection.startswith("~"):
-        project_path = Path(selection).expanduser().absolute()
-
-        if not project_path.exists():
-            console.print(f"[yellow]⚠[/yellow] Path does not exist: {project_path}")
-            if not Confirm.ask("Use this path anyway?", default=False):
-                console.print(f"\n[yellow]Cancelled[/yellow] - session not opened")
-                return False
-    # Otherwise treat as repository name
-    else:
-        repo_name = selection
-
-        if config and config.repos:
-            # Use selected workspace if provided, otherwise fall back to default
-            if selected_workspace_name:
-                from devflow.cli.utils import get_workspace_path
-                workspace_path = get_workspace_path(config, selected_workspace_name)
-            else:
-                workspace_path = config.repos.get_default_workspace_path()
-
-            if not workspace_path:
-
-                console.print("[yellow]⚠[/yellow] No default workspace configured")
-
-                return None
-
-            workspace = Path(workspace_path).expanduser()
-            project_path = workspace / repo_name
-
-            if not project_path.exists():
-                console.print(f"[yellow]⚠[/yellow] Repository not found: {project_path}")
-                if not Confirm.ask("Use this path anyway?", default=False):
-                    console.print(f"\n[yellow]Cancelled[/yellow] - session not opened")
-                    return False
-        else:
-            console.print(f"[red]✗[/red] No workspace configured in config")
-            return False
+    project_path = Path(selected_paths[0])
 
     # Update session with selected directory
     # For multi-conversation sessions, update or create active conversation
@@ -3031,7 +2833,6 @@ def _prompt_for_working_directory(
         # Get workspace for portable paths - use selected workspace if provided
         config = config_loader.load_config()
         if selected_workspace_name and config and config.repos:
-            from devflow.cli.utils import get_workspace_path
             workspace = get_workspace_path(config, selected_workspace_name)
         else:
             workspace = config.repos.get_default_workspace_path() if config and config.repos else None

--- a/devflow/cli/utils.py
+++ b/devflow/cli/utils.py
@@ -6,7 +6,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import click
@@ -1455,3 +1455,198 @@ def prompt_repository_selection_with_multiproject(
 
     # Return as list for consistency
     return [project_path], selected_workspace_name
+
+
+def extract_repository_from_issue_key(issue_key: str, issue_tracker: Optional[str]) -> Optional[str]:
+    """Extract repository name from GitHub/GitLab issue key.
+
+    Args:
+        issue_key: Issue key (e.g., "owner/repo#123", "#123", "PROJ-123")
+        issue_tracker: Issue tracker type ("github", "gitlab", "jira", etc.)
+
+    Returns:
+        Repository name (e.g., "repo") if extractable, None otherwise
+
+    Examples:
+        >>> extract_repository_from_issue_key("itdove/devaiflow#146", "github")
+        'devaiflow'
+        >>> extract_repository_from_issue_key("#123", "github")
+        >>> extract_repository_from_issue_key("PROJ-123", "jira")
+    """
+    if not issue_tracker or issue_tracker not in ["github", "gitlab"]:
+        return None
+
+    if not issue_key:
+        return None
+
+    # Format: owner/repo#123
+    if "/" in issue_key and "#" in issue_key:
+        try:
+            parts = issue_key.split("/")
+            if len(parts) >= 2:
+                repo_with_number = parts[-1]
+                repo = repo_with_number.split("#")[0]
+                return repo if repo else None
+        except (IndexError, ValueError):
+            return None
+
+    return None
+
+
+def unified_project_selection(
+    workspace_path: str,
+    repo_options: list,
+    *,
+    suggested_repo: Optional[str] = None,
+    suggested_repo_source: Optional[str] = None,
+    default_repo: Optional[str] = None,
+    allow_multi_project: bool = False,
+    on_selection: Optional[Callable] = None,
+    config_loader=None,
+    workspace_name: Optional[str] = None,
+) -> Tuple[Optional[List[str]], bool]:
+    """Unified project/repository selection matching daf open UX.
+
+    Canonical flow:
+    1. Show numbered repo list with optional markers
+    2. If allow_multi_project and 2+ repos: ask multi-project question
+    3. Single selection prompt: number / name / path / cancel
+
+    When config_loader and workspace_name are provided, automatically uses and
+    saves the last-used repository per workspace as default.
+
+    Args:
+        workspace_path: Resolved workspace directory path
+        repo_options: List of repository names found in workspace
+        suggested_repo: Repository name to highlight (e.g., from issue key)
+        suggested_repo_source: Label for suggestion (e.g., "from issue", "remembered")
+        default_repo: Repository name to use as default selection (overrides last-used)
+        allow_multi_project: Whether to offer multi-project session option
+        on_selection: Callback(repo_name, workspace_path) called after selection
+        config_loader: ConfigLoader for reading/saving last-used repo per workspace
+        workspace_name: Workspace name for last-used repo tracking
+
+    Returns:
+        Tuple of (selected_paths, is_multi_project).
+        selected_paths is None if user cancelled.
+    """
+    from rich.prompt import Prompt
+
+    workspace = Path(workspace_path).expanduser()
+
+    if not repo_options:
+        console.print(f"[yellow]⚠[/yellow] No git repositories found in workspace")
+        return None, False
+
+    # Auto-detect last-used repo per workspace when config is available
+    last_used_repo = None
+    if not default_repo and config_loader and workspace_name:
+        try:
+            config = config_loader.load_config()
+            if config and config.prompts and config.prompts.last_used_repo_per_workspace:
+                remembered = config.prompts.last_used_repo_per_workspace.get(workspace_name)
+                if remembered and remembered in repo_options:
+                    last_used_repo = remembered
+                    default_repo = remembered
+        except Exception:
+            pass
+
+    # Put suggested repo first if it exists in the list
+    display_repos = list(repo_options)
+    suggested_repo_index = None
+    if suggested_repo and suggested_repo in display_repos:
+        display_repos.remove(suggested_repo)
+        display_repos = [suggested_repo] + sorted(display_repos)
+        suggested_repo_index = 0
+
+    # 1. Show numbered list
+    source_label = suggested_repo_source or "suggested"
+    console.print(f"\n[bold]Available repositories ({len(display_repos)}):[/bold]")
+    for i, repo in enumerate(display_repos, 1):
+        markers = []
+        if suggested_repo and repo == suggested_repo:
+            markers.append(source_label)
+        if last_used_repo and repo == last_used_repo:
+            markers.append("last used")
+        if markers:
+            console.print(f"  {i}. {repo} [dim]({', '.join(markers)})[/dim]")
+        else:
+            console.print(f"  {i}. {repo}")
+
+    # 2. Multi-project question (after list, matching daf open)
+    if allow_multi_project and len(display_repos) > 1:
+        if Confirm.ask("\nCreate multi-project session (work across multiple repos)?", default=False):
+            project_paths = prompt_multi_project_selection(display_repos, workspace_path, suggested_repo)
+            if not project_paths:
+                return None, False
+            return project_paths, True
+
+    # 3. Single selection prompt
+    console.print(f"\n[bold]Select working directory:[/bold]")
+    console.print(f"  • Enter a number (1-{len(display_repos)}) to select from the list above")
+    console.print(f"  • Enter a repository name")
+    console.print(f"  • Enter an absolute path (starting with / or ~)")
+    console.print(f"  • Enter 'cancel' or 'q' to exit")
+
+    # Calculate default: explicit default_repo > suggested_repo > first repo
+    default_value = "1"
+    if default_repo and default_repo in display_repos:
+        default_value = str(display_repos.index(default_repo) + 1)
+    elif suggested_repo_index is not None:
+        default_value = str(suggested_repo_index + 1)
+
+    selection = Prompt.ask("Selection", default=default_value)
+
+    if not selection or selection.strip() == "":
+        console.print(f"[red]✗[/red] Empty selection not allowed. Please enter a number (1-{len(display_repos)}), repository name, path, or 'cancel'/'q'")
+        return None, False
+
+    # Handle cancel
+    if selection.lower() in ["cancel", "q"]:
+        console.print(f"\n[yellow]Cancelled[/yellow]")
+        return None, False
+
+    def _save_last_used(repo_name: str) -> None:
+        """Save the selected repo as last-used for this workspace."""
+        if on_selection:
+            on_selection(repo_name, workspace_path)
+        if config_loader and workspace_name:
+            try:
+                cfg = config_loader.load_config()
+                if cfg and cfg.prompts:
+                    cfg.prompts.last_used_repo_per_workspace[workspace_name] = repo_name
+                    config_loader.save_config(cfg)
+            except Exception:
+                pass
+
+    # Number selection
+    if selection.isdigit():
+        repo_index = int(selection) - 1
+        if 0 <= repo_index < len(display_repos):
+            repo_name = display_repos[repo_index]
+            console_print(f"[dim]Selected: {repo_name}[/dim]")
+            _save_last_used(repo_name)
+            return [str(workspace / repo_name)], False
+        else:
+            console.print(f"[red]✗[/red] Invalid selection. Please choose 1-{len(display_repos)}")
+            return None, False
+
+    # Absolute path
+    if selection.startswith("/") or selection.startswith("~"):
+        project_path = Path(selection).expanduser().absolute()
+        if not project_path.exists():
+            console.print(f"[yellow]⚠[/yellow] Path does not exist: {project_path}")
+            if not Confirm.ask("Use this path anyway?", default=False):
+                return None, False
+        _save_last_used(project_path.name)
+        return [str(project_path)], False
+
+    # Repository name
+    repo_name = selection
+    project_path = workspace / repo_name
+    if not project_path.exists():
+        console.print(f"[yellow]⚠[/yellow] Repository not found: {project_path}")
+        if not Confirm.ask("Use this path anyway?", default=False):
+            return None, False
+    _save_last_used(repo_name)
+    return [str(project_path)], False

--- a/tests/test_git_new_multiproject.py
+++ b/tests/test_git_new_multiproject.py
@@ -17,7 +17,6 @@ def mock_workspace_with_multiple_repos(tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
-    # Create three mock git repos
     for repo_name in ["backend-api", "frontend-app", "database"]:
         repo_path = workspace / repo_name
         repo_path.mkdir()
@@ -44,18 +43,20 @@ class TestGitNewMultiProjectSelection:
     @patch("devflow.cli.commands.git_new_command.should_launch_claude_code", return_value=False)
     @patch("devflow.session.manager.SessionManager")
     @patch("devflow.config.loader.ConfigLoader")
-    @patch("rich.prompt.Confirm.ask")
+    @patch("devflow.cli.commands.git_new_command.unified_project_selection")
+    @patch("devflow.cli.commands.git_new_command.scan_workspace_repositories")
+    @patch("devflow.cli.commands.git_new_command.select_workspace")
+    @patch("devflow.cli.commands.git_new_command.get_workspace_path")
     @patch("rich.prompt.Prompt.ask")
-    @patch("devflow.cli.utils.select_workspace")
-    @patch("devflow.cli.utils.scan_workspace_repositories")
     @patch("devflow.utils.is_mock_mode", return_value=True)
     def test_git_new_with_multiproject_selection_and_target_repo(
         self,
         mock_is_mock_mode,
-        mock_scan_repos,
-        mock_select_workspace,
         mock_prompt_ask,
-        mock_confirm_ask,
+        mock_get_ws_path,
+        mock_select_workspace,
+        mock_scan_repos,
+        mock_unified_select,
         mock_config_loader,
         mock_session_manager,
         mock_should_launch,
@@ -63,13 +64,19 @@ class TestGitNewMultiProjectSelection:
         config_with_workspace,
     ):
         """Test that daf git new supports multi-project selection with target repo selection."""
-        # Setup mocks
         mock_select_workspace.return_value = "test-workspace"
+        mock_get_ws_path.return_value = str(mock_workspace_with_multiple_repos)
         mock_scan_repos.return_value = ["backend-api", "frontend-app", "database"]
 
-        # User selects multi-project mode and chooses projects 1,2, then target repo
-        mock_confirm_ask.return_value = True  # Accept multi-project mode
-        mock_prompt_ask.side_effect = ["1,2", "1"]  # Select backend-api and frontend-app, then backend-api as target
+        # unified_project_selection returns multi-project result
+        mock_unified_select.return_value = (
+            [str(mock_workspace_with_multiple_repos / "backend-api"),
+             str(mock_workspace_with_multiple_repos / "frontend-app")],
+            True
+        )
+
+        # Target repo selection
+        mock_prompt_ask.return_value = "1"
 
         mock_config_loader.return_value.load_config.return_value = config_with_workspace
 
@@ -77,55 +84,48 @@ class TestGitNewMultiProjectSelection:
         mock_session.name = "test-session"
         mock_session_manager.return_value.create_session.return_value = mock_session
 
-        # Call the function
         create_git_issue_session(
             goal="Add Redis caching",
             issue_type="enhancement",
             name="test-session",
-            path=None,  # Use interactive selection
+            path=None,
             branch=None,
             parent=None,
             workspace="test-workspace",
             repository=None,
         )
 
-        # Verify multi-project selection was offered
-        mock_confirm_ask.assert_called_once()
-        call_args = str(mock_confirm_ask.call_args)
-        assert "multi-project" in call_args.lower()
-
-        # Verify selection prompts were called
-        assert mock_prompt_ask.call_count >= 2  # Project selection + target repo selection
-
+        mock_unified_select.assert_called_once()
 
     @patch("devflow.session.manager.SessionManager")
     @patch("devflow.config.loader.ConfigLoader")
-    @patch("rich.prompt.Confirm.ask")
-    @patch("rich.prompt.Prompt.ask")
-    @patch("devflow.cli.utils.select_workspace")
-    @patch("devflow.cli.utils.scan_workspace_repositories")
+    @patch("devflow.cli.commands.git_new_command.unified_project_selection")
+    @patch("devflow.cli.commands.git_new_command.scan_workspace_repositories")
+    @patch("devflow.cli.commands.git_new_command.select_workspace")
+    @patch("devflow.cli.commands.git_new_command.get_workspace_path")
     @patch("devflow.utils.is_mock_mode", return_value=True)
     def test_git_new_single_project_fallback(
         self,
         mock_is_mock_mode,
-        mock_scan_repos,
+        mock_get_ws_path,
         mock_select_workspace,
-        mock_prompt_ask,
-        mock_confirm_ask,
+        mock_scan_repos,
+        mock_unified_select,
         mock_config_loader,
         mock_session_manager,
         mock_workspace_with_multiple_repos,
         config_with_workspace,
     ):
         """Test that declining multi-project mode falls back to single-project."""
-        # Setup mocks
         mock_select_workspace.return_value = "test-workspace"
+        mock_get_ws_path.return_value = str(mock_workspace_with_multiple_repos)
         mock_scan_repos.return_value = ["backend-api", "frontend-app", "database"]
 
-        # User declines multi-project mode
-        mock_confirm_ask.return_value = False
-        # Then selects single project
-        mock_prompt_ask.side_effect = ["1"]  # Select backend-api
+        # Single-project result
+        mock_unified_select.return_value = (
+            [str(mock_workspace_with_multiple_repos / "backend-api")],
+            False
+        )
 
         mock_config_loader.return_value.load_config.return_value = config_with_workspace
 
@@ -133,7 +133,6 @@ class TestGitNewMultiProjectSelection:
         mock_session.name = "test-session"
         mock_session_manager.return_value.create_session.return_value = mock_session
 
-        # Call the function
         create_git_issue_session(
             goal="Fix bug",
             issue_type="bug",
@@ -145,10 +144,7 @@ class TestGitNewMultiProjectSelection:
             repository=None,
         )
 
-        # Verify multi-project was offered but declined
-        mock_confirm_ask.assert_called_once()
-
-        # Should still create a session (single-project mode)
+        mock_unified_select.assert_called_once()
         mock_session_manager.return_value.create_session.assert_called()
 
 
@@ -158,7 +154,6 @@ class TestTargetRepositorySelection:
     @patch("rich.prompt.Prompt.ask")
     def test_target_repo_selection_by_number(self, mock_prompt, tmp_path):
         """Test selecting target repository by number."""
-        # Create mock project paths
         workspace = tmp_path / "workspace"
         workspace.mkdir()
 
@@ -168,12 +163,10 @@ class TestTargetRepositorySelection:
             repo_path.mkdir()
             project_paths.append(str(repo_path))
 
-        # User selects option 2 (frontend-app)
         mock_prompt.return_value = "2"
 
         result = _prompt_for_target_repository(project_paths, repository=None)
 
-        # Should return the second project path
         assert result == project_paths[1]
         assert "frontend-app" in result
 
@@ -181,7 +174,6 @@ class TestTargetRepositorySelection:
     @patch("rich.prompt.Prompt.ask")
     def test_target_repo_selection_by_name(self, mock_prompt, tmp_path):
         """Test selecting target repository by name."""
-        # Create mock project paths
         workspace = tmp_path / "workspace"
         workspace.mkdir()
 
@@ -191,12 +183,10 @@ class TestTargetRepositorySelection:
             repo_path.mkdir()
             project_paths.append(str(repo_path))
 
-        # User selects by name
         mock_prompt.return_value = "database"
 
         result = _prompt_for_target_repository(project_paths, repository=None)
 
-        # Should return the database project path
         assert result == project_paths[2]
         assert "database" in result
 
@@ -204,7 +194,6 @@ class TestTargetRepositorySelection:
     @patch("rich.prompt.Prompt.ask")
     def test_target_repo_selection_invalid(self, mock_prompt, tmp_path):
         """Test invalid target repository selection."""
-        # Create mock project paths
         workspace = tmp_path / "workspace"
         workspace.mkdir()
 
@@ -214,12 +203,10 @@ class TestTargetRepositorySelection:
             repo_path.mkdir()
             project_paths.append(str(repo_path))
 
-        # User selects invalid option
-        mock_prompt.return_value = "5"  # Invalid index
+        mock_prompt.return_value = "5"
 
         result = _prompt_for_target_repository(project_paths, repository=None)
 
-        # Should return None for invalid selection
         assert result is None
 
 
@@ -232,7 +219,6 @@ class TestMultiProjectGitPromptBuilder:
             _build_multiproject_issue_creation_prompt,
         )
 
-        # Create mock project paths
         workspace = tmp_path / "workspace"
         workspace.mkdir()
 
@@ -242,12 +228,10 @@ class TestMultiProjectGitPromptBuilder:
             repo_path.mkdir()
             project_paths.append(str(repo_path))
 
-        target_repo_path = project_paths[0]  # backend-api
+        target_repo_path = project_paths[0]
 
-        # Create mock config
         mock_config = MagicMock()
 
-        # Build prompt
         prompt = _build_multiproject_issue_creation_prompt(
             issue_type="enhancement",
             goal="Add Redis caching",
@@ -260,18 +244,10 @@ class TestMultiProjectGitPromptBuilder:
             repository=None,
         )
 
-        # Verify prompt mentions all projects
         assert "backend-api" in prompt
         assert "frontend-app" in prompt
         assert "database" in prompt
-
-        # Verify prompt indicates target repository
-        assert "backend-api" in prompt  # Should mention target
-
-        # Verify prompt indicates it's multi-project
         assert "MULTI-PROJECT" in prompt or "multi-project" in prompt
-
-        # Verify prompt has read-only constraints
         assert "READ-ONLY" in prompt
         assert "Do NOT modify" in prompt or "DO NOT modify" in prompt
 

--- a/tests/test_github_repo_suggestion.py
+++ b/tests/test_github_repo_suggestion.py
@@ -5,7 +5,8 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from devflow.cli.commands.open_command import _extract_repository_from_issue_key, _prompt_for_working_directory
+from devflow.cli.utils import extract_repository_from_issue_key as _extract_repository_from_issue_key
+from devflow.cli.commands.open_command import _prompt_for_working_directory
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
 

--- a/tests/test_investigate_command.py
+++ b/tests/test_investigate_command.py
@@ -426,9 +426,13 @@ class TestMultiProjectInvestigation:
         project2.mkdir(exist_ok=True)
 
         # Mock the repository selection to return multiple projects
-        with patch("devflow.cli.utils.prompt_repository_selection_with_multiproject") as mock_prompt, \
+        with patch("devflow.cli.commands.investigate_command.unified_project_selection") as mock_select, \
+             patch("devflow.cli.commands.investigate_command.select_workspace") as mock_ws, \
+             patch("devflow.cli.commands.investigate_command.scan_workspace_repositories") as mock_scan, \
              patch("devflow.cli.commands.investigate_command.should_launch_claude_code") as mock_launch:
-            mock_prompt.return_value = ([str(project1), str(project2)], "default")
+            mock_ws.return_value = "default"
+            mock_scan.return_value = ["backend-api", "frontend-app"]
+            mock_select.return_value = ([str(project1), str(project2)], True)
             mock_launch.return_value = False  # Don't launch Claude in tests
 
             runner = CliRunner()
@@ -493,9 +497,13 @@ class TestMultiProjectInvestigation:
         project2.mkdir(exist_ok=True)
 
         # Mock the repository selection to return multiple projects
-        with patch("devflow.cli.utils.prompt_repository_selection_with_multiproject") as mock_prompt, \
+        with patch("devflow.cli.commands.investigate_command.unified_project_selection") as mock_select, \
+             patch("devflow.cli.commands.investigate_command.select_workspace") as mock_ws, \
+             patch("devflow.cli.commands.investigate_command.scan_workspace_repositories") as mock_scan, \
              patch("devflow.cli.commands.investigate_command.should_launch_claude_code") as mock_launch:
-            mock_prompt.return_value = ([str(project1), str(project2)], "default")
+            mock_ws.return_value = "default"
+            mock_scan.return_value = ["backend-api", "frontend-app"]
+            mock_select.return_value = ([str(project1), str(project2)], True)
             mock_launch.return_value = False  # Don't launch Claude in tests
 
             runner = CliRunner()
@@ -546,8 +554,12 @@ class TestMultiProjectInvestigation:
         project1.mkdir(exist_ok=True)
 
         # Mock the repository selection to return single project
-        with patch("devflow.cli.utils.prompt_repository_selection_with_multiproject") as mock_prompt:
-            mock_prompt.return_value = ([str(project1)], "default")
+        with patch("devflow.cli.commands.investigate_command.unified_project_selection") as mock_select, \
+             patch("devflow.cli.commands.investigate_command.select_workspace") as mock_ws, \
+             patch("devflow.cli.commands.investigate_command.scan_workspace_repositories") as mock_scan:
+            mock_ws.return_value = "default"
+            mock_scan.return_value = ["backend-api"]
+            mock_select.return_value = ([str(project1)], False)
 
             runner = CliRunner()
             result = runner.invoke(cli, [

--- a/tests/test_jira_new_command.py
+++ b/tests/test_jira_new_command.py
@@ -158,12 +158,17 @@ class TestCreateJiraTicketSession:
         # Setup mocks
         mock_confirm.return_value = False  # Don't launch Claude
 
-        # Call the function
+        # Create test project directory
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
+
+        # Call the function (provide path to skip interactive project selection)
         create_jira_ticket_session(
             issue_type="story",
             parent="PROJ-59038",
             goal="Add retry logic to subscription API",
-            name=None  # Auto-generate name
+            name=None,  # Auto-generate name
+            path=str(test_project),
         )
 
         # Session is created with auto-generated name (from goal slug + random suffix)
@@ -199,12 +204,17 @@ class TestCreateJiraTicketSession:
         # Setup mocks
         mock_confirm.return_value = False  # Don't launch Claude
 
-        # Call the function
+        # Create test project directory
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
+
+        # Call the function (provide path to skip interactive project selection)
         create_jira_ticket_session(
             issue_type="bug",
             parent="PROJ-60000",
             goal="Fix timeout in backup operation",
-            name="custom-session-name"
+            name="custom-session-name",
+            path=str(test_project),
         )
 
         # Session keeps custom name (renaming only happens in mock mode or when Claude creates a ticket)
@@ -244,12 +254,17 @@ class TestCreateJiraTicketSession:
         mock_confirm.return_value = True  # Launch Claude
         mock_should_launch.return_value = True  # Override mock mode check
 
+        # Create test project directory
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
+
         # Call the function
         create_jira_ticket_session(
             issue_type="task",
             parent="PROJ-59038",
             goal="Update documentation",
-            name="doc-update"
+            name="doc-update",
+            path=str(test_project),
         )
 
         # Verify Claude was launched
@@ -291,12 +306,17 @@ class TestCreateJiraTicketSession:
         # Setup mocks
         mock_confirm.return_value = False  # Don't launch Claude
 
+        # Create test project directory
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
+
         # Create session
         create_jira_ticket_session(
             issue_type="story",
             parent="PROJ-59038",
             goal="Test goal",
-            name="test-session"
+            name="test-session",
+            path=str(test_project),
         )
 
         # After PROJ-60665, sessions are renamed to creation-{ISSUE_KEY}
@@ -339,12 +359,16 @@ class TestCreateJiraTicketSession:
 
         # After PROJ-60665, sessions are renamed to creation-{ISSUE_KEY}
         # Don't assume ticket numbers - find sessions by goal instead
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
+
         for issue_type in issue_types:
             create_jira_ticket_session(
                 issue_type=issue_type,
                 parent="PROJ-59038",
                 goal=f"Test {issue_type}",
-                name=f"test-{issue_type}"
+                name=f"test-{issue_type}",
+                path=str(test_project),
             )
 
             session_manager = SessionManager(config_loader=ConfigLoader())
@@ -427,11 +451,16 @@ class TestJiraNewCommandInteractivePrompts:
 
         runner = CliRunner()
 
+        # Create test project dir
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
+
         # Run command without --goal, providing goal through prompt
         # Input: goal description + no to temp clone prompt
         result = runner.invoke(cli, [
             "jira", "new", "story",
-            "--parent", "PROJ-59038"
+            "--parent", "PROJ-59038",
+            "--path", str(test_project),
         ], input="Add retry logic to subscription API\nn\n")
 
         # Verify command succeeded
@@ -462,12 +491,17 @@ class TestJiraNewCommandInteractivePrompts:
 
         runner = CliRunner()
 
+        # Create test project dir
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
+
         # Run command with --goal
         # Input: no to temp clone prompt
         result = runner.invoke(cli, [
             "jira", "new", "bug",
             "--parent", "PROJ-60000",
-            "--goal", "Fix timeout in backup operation"
+            "--goal", "Fix timeout in backup operation",
+            "--path", str(test_project),
         ], input="n\n")
 
         # Verify command succeeded
@@ -498,12 +532,17 @@ class TestJiraNewCommandInteractivePrompts:
 
         runner = CliRunner()
 
+        # Create test project dir
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
+
         # Run command with --name but without --goal
         # Input: goal description + no to temp clone prompt
         result = runner.invoke(cli, [
             "jira", "new", "task",
             "--parent", "PROJ-59038",
-            "--name", "my-custom-task"
+            "--name", "my-custom-task",
+            "--path", str(test_project),
         ], input="Update documentation for new feature\nn\n")
 
         # Verify command succeeded
@@ -528,6 +567,12 @@ class TestJiraNewCommandInteractivePrompts:
 class TestJiraNewMockMode:
     """Test daf jira new command in mock mode."""
 
+    @pytest.fixture(autouse=True)
+    def create_test_project_dir(self, temp_daf_home):
+        """Create test project directory for all tests in this class."""
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
+
     @patch.dict("os.environ", {"DAF_MOCK_MODE": "1"})
     def test_mock_mode_creates_ticket_story(self, temp_daf_home):
         """Test that mock mode creates a mock JIRA story ticket."""
@@ -544,7 +589,8 @@ class TestJiraNewMockMode:
         result = runner.invoke(cli, [
             "jira", "new", "story",
             "--parent", "PROJ-59038",
-            "--goal", "Add retry logic to subscription API"
+            "--goal", "Add retry logic to subscription API",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         # Verify command succeeded
@@ -585,7 +631,8 @@ class TestJiraNewMockMode:
         result = runner.invoke(cli, [
             "jira", "new", "bug",
             "--parent", "PROJ-60000",
-            "--goal", "Fix timeout in backup operation"
+            "--goal", "Fix timeout in backup operation",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         # Verify command succeeded
@@ -612,7 +659,8 @@ class TestJiraNewMockMode:
         result = runner.invoke(cli, [
             "jira", "new", "task",
             "--parent", "PROJ-59038",
-            "--goal", "Update documentation"
+            "--goal", "Update documentation",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         # Verify command succeeded
@@ -639,7 +687,8 @@ class TestJiraNewMockMode:
         result = runner.invoke(cli, [
             "jira", "new", "epic",
             "--parent", "PROJ-50000",
-            "--goal", "Implement new backup feature"
+            "--goal", "Implement new backup feature",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         # Verify command succeeded
@@ -668,7 +717,8 @@ class TestJiraNewMockMode:
         result = runner.invoke(cli, [
             "jira", "new", "story",
             "--parent", "PROJ-59038",
-            "--goal", "Test persistence"
+            "--goal", "Test persistence",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         assert result.exit_code == 0
@@ -707,7 +757,8 @@ class TestJiraNewMockMode:
         result = runner.invoke(cli, [
             "jira", "new", "story",
             "--parent", "CUSTOM-1000",
-            "--goal", "Test custom project"
+            "--goal", "Test custom project",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         assert result.exit_code == 0, f"Command failed: {result.output}"
@@ -744,7 +795,8 @@ class TestJiraNewMockMode:
         result = runner.invoke(cli, [
             "jira", "new", "story",
             "--parent", "PROJ-59038",
-            "--goal", "Test Claude session"
+            "--goal", "Test Claude session",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         assert result.exit_code == 0, f"Command failed: {result.output}"
@@ -800,7 +852,8 @@ class TestJiraNewMockMode:
         result = runner.invoke(cli, [
             "jira", "new", "story",
             "--parent", "PROJ-59038",
-            "--goal", "Test JIRA metadata"
+            "--goal", "Test JIRA metadata",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         assert result.exit_code == 0, f"Command failed: {result.output}"
@@ -837,6 +890,12 @@ class TestJiraNewMockMode:
 
 class TestJiraNewPathFlag:
     """Test the --path flag for daf jira new command."""
+
+    @pytest.fixture(autouse=True)
+    def create_test_project_dir(self, temp_daf_home):
+        """Create test project directory for all tests in this class."""
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
 
     @patch.dict("os.environ", {"DAF_MOCK_MODE": "1"})
     def test_path_flag_with_valid_path(self, temp_daf_home, tmp_path):
@@ -962,7 +1021,8 @@ class TestJiraNewPathFlag:
         result = runner.invoke(cli, [
             "jira", "new", "task",
             "--parent", "PROJ-59038",
-            "--goal", "Test without path flag"
+            "--goal", "Test without path flag",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         # Verify command succeeded (mock mode handles the fallback)
@@ -1095,6 +1155,12 @@ class TestJiraNewPathFlag:
 class TestJiraNewWithGoalFromFile:
     """Test daf jira new command with goal from file:// path."""
 
+    @pytest.fixture(autouse=True)
+    def create_test_project_dir(self, temp_daf_home):
+        """Create test project directory for all tests in this class."""
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
+
     @patch.dict("os.environ", {"DAF_MOCK_MODE": "1"})
     def test_jira_new_with_file_goal(self, temp_daf_home, tmp_path):
         """Test daf jira new with --goal pointing to a file."""
@@ -1117,7 +1183,8 @@ class TestJiraNewWithGoalFromFile:
             "jira", "new", "story",
             "--parent", "PROJ-59038",
             "--goal", f"file://{requirements_file}",
-            "--name", "file-goal-test"
+            "--name", "file-goal-test",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         # Verify command succeeded
@@ -1164,7 +1231,8 @@ class TestJiraNewWithGoalFromFile:
             "jira", "new", "task",
             "--parent", "PROJ-59038",
             "--goal", "http://docs.example.com/spec.txt",
-            "--name", "url-goal-test"
+            "--name", "url-goal-test",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         # Verify command succeeded
@@ -1196,7 +1264,8 @@ class TestJiraNewWithGoalFromFile:
         result = runner.invoke(cli, [
             "jira", "new", "bug",
             "--parent", "PROJ-60000",
-            "--goal", "file:///path/that/does/not/exist.txt"
+            "--goal", "file:///path/that/does/not/exist.txt",
+            "--path", str(Path(temp_daf_home) / "test-project"),
         ])
 
         # Verify command failed with appropriate error
@@ -1206,6 +1275,12 @@ class TestJiraNewWithGoalFromFile:
 
 class TestExceptionHandlingInCleanup:
     """Tests for PROJ-61150: Proper exception handling in cleanup code."""
+
+    @pytest.fixture(autouse=True)
+    def create_test_project_dir(self, temp_daf_home):
+        """Create test project directory for all tests in this class."""
+        test_project = Path(temp_daf_home) / "test-project"
+        test_project.mkdir(exist_ok=True)
 
     @patch.dict("os.environ", {"DAF_MOCK_MODE": "1"})
     def test_cleanup_finally_block_allows_value_error_from_end_work_session(self, temp_daf_home):

--- a/tests/test_jira_new_multiproject.py
+++ b/tests/test_jira_new_multiproject.py
@@ -17,7 +17,6 @@ def mock_workspace_with_multiple_repos(tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
-    # Create three mock git repos
     for repo_name in ["backend-api", "frontend-app", "database"]:
         repo_path = workspace / repo_name
         repo_path.mkdir()
@@ -45,18 +44,18 @@ class TestJiraNewMultiProjectSelection:
     @patch("devflow.cli.commands.jira_new_command.should_launch_claude_code", return_value=False)
     @patch("devflow.session.manager.SessionManager")
     @patch("devflow.config.loader.ConfigLoader")
-    @patch("rich.prompt.Confirm.ask")
-    @patch("rich.prompt.Prompt.ask")
-    @patch("devflow.cli.utils.select_workspace")
-    @patch("devflow.cli.utils.scan_workspace_repositories")
+    @patch("devflow.cli.commands.jira_new_command.unified_project_selection")
+    @patch("devflow.cli.commands.jira_new_command.scan_workspace_repositories")
+    @patch("devflow.cli.commands.jira_new_command.select_workspace")
+    @patch("devflow.cli.commands.jira_new_command.get_workspace_path")
     @patch("devflow.utils.is_mock_mode", return_value=True)
     def test_jira_new_with_multiproject_selection(
         self,
         mock_is_mock_mode,
-        mock_scan_repos,
+        mock_get_ws_path,
         mock_select_workspace,
-        mock_prompt_ask,
-        mock_confirm_ask,
+        mock_scan_repos,
+        mock_unified_select,
         mock_config_loader,
         mock_session_manager,
         mock_should_launch,
@@ -64,13 +63,15 @@ class TestJiraNewMultiProjectSelection:
         config_with_workspace,
     ):
         """Test that daf jira new supports multi-project selection."""
-        # Setup mocks
         mock_select_workspace.return_value = "test-workspace"
+        mock_get_ws_path.return_value = str(mock_workspace_with_multiple_repos)
         mock_scan_repos.return_value = ["backend-api", "frontend-app", "database"]
 
-        # User selects multi-project mode and chooses projects 1,2
-        mock_confirm_ask.return_value = True  # Accept multi-project mode
-        mock_prompt_ask.return_value = "1,2"  # Select backend-api and frontend-app
+        mock_unified_select.return_value = (
+            [str(mock_workspace_with_multiple_repos / "backend-api"),
+             str(mock_workspace_with_multiple_repos / "frontend-app")],
+            True
+        )
 
         mock_config_loader.return_value.load_config.return_value = config_with_workspace
 
@@ -78,55 +79,48 @@ class TestJiraNewMultiProjectSelection:
         mock_session.name = "test-session"
         mock_session_manager.return_value.create_session.return_value = mock_session
 
-        # Call the function
         create_jira_ticket_session(
             goal="Add Redis caching",
             issue_type="story",
             parent="PROJ-1234",
             name="test-session",
-            path=None,  # Use interactive selection
+            path=None,
             branch=None,
             workspace="test-workspace",
             affects_versions=None,
         )
 
-        # Verify multi-project selection was offered
-        mock_confirm_ask.assert_called_once()
-        call_args = str(mock_confirm_ask.call_args)
-        assert "multi-project" in call_args.lower()
-
-        # Verify selection prompt was shown
-        mock_prompt_ask.assert_called_once()
+        mock_unified_select.assert_called_once()
 
 
     @patch("devflow.session.manager.SessionManager")
     @patch("devflow.config.loader.ConfigLoader")
-    @patch("rich.prompt.Confirm.ask")
-    @patch("rich.prompt.Prompt.ask")
-    @patch("devflow.cli.utils.select_workspace")
-    @patch("devflow.cli.utils.scan_workspace_repositories")
+    @patch("devflow.cli.commands.jira_new_command.unified_project_selection")
+    @patch("devflow.cli.commands.jira_new_command.scan_workspace_repositories")
+    @patch("devflow.cli.commands.jira_new_command.select_workspace")
+    @patch("devflow.cli.commands.jira_new_command.get_workspace_path")
     @patch("devflow.utils.is_mock_mode", return_value=True)
     def test_jira_new_single_project_fallback(
         self,
         mock_is_mock_mode,
-        mock_scan_repos,
+        mock_get_ws_path,
         mock_select_workspace,
-        mock_prompt_ask,
-        mock_confirm_ask,
+        mock_scan_repos,
+        mock_unified_select,
         mock_config_loader,
         mock_session_manager,
         mock_workspace_with_multiple_repos,
         config_with_workspace,
     ):
         """Test that declining multi-project mode falls back to single-project."""
-        # Setup mocks
         mock_select_workspace.return_value = "test-workspace"
+        mock_get_ws_path.return_value = str(mock_workspace_with_multiple_repos)
         mock_scan_repos.return_value = ["backend-api", "frontend-app", "database"]
 
-        # User declines multi-project mode
-        mock_confirm_ask.return_value = False
-        # Then selects single project
-        mock_prompt_ask.side_effect = ["1"]  # Select backend-api
+        mock_unified_select.return_value = (
+            [str(mock_workspace_with_multiple_repos / "backend-api")],
+            False
+        )
 
         mock_config_loader.return_value.load_config.return_value = config_with_workspace
 
@@ -134,7 +128,6 @@ class TestJiraNewMultiProjectSelection:
         mock_session.name = "test-session"
         mock_session_manager.return_value.create_session.return_value = mock_session
 
-        # Call the function
         create_jira_ticket_session(
             goal="Fix bug",
             issue_type="bug",
@@ -146,10 +139,7 @@ class TestJiraNewMultiProjectSelection:
             affects_versions=None,
         )
 
-        # Verify multi-project was offered but declined
-        mock_confirm_ask.assert_called_once()
-
-        # Should still create a session (single-project mode)
+        mock_unified_select.assert_called_once()
         mock_session_manager.return_value.create_session.assert_called()
 
 
@@ -162,7 +152,6 @@ class TestMultiProjectTicketCreationSession:
             create_multi_project_ticket_creation_session,
         )
 
-        # Create mock repos
         workspace = tmp_path / "workspace"
         workspace.mkdir()
 
@@ -174,7 +163,6 @@ class TestMultiProjectTicketCreationSession:
             git_dir.mkdir()
             project_paths.append(str(repo_path))
 
-        # Create mock config and session manager
         mock_config = MagicMock()
         mock_session_manager = MagicMock()
 
@@ -182,7 +170,6 @@ class TestMultiProjectTicketCreationSession:
         mock_session.name = "test-session"
         mock_session_manager.create_session.return_value = mock_session
 
-        # Create multi-project ticket creation session
         session, ai_agent_session_id = create_multi_project_ticket_creation_session(
             session_manager=mock_session_manager,
             config=mock_config,
@@ -195,14 +182,9 @@ class TestMultiProjectTicketCreationSession:
             issue_type="story",
         )
 
-        # Verify session was created
         assert session == mock_session
         assert ai_agent_session_id is not None
-
-        # Verify session_type was set
         assert session.session_type == "ticket_creation"
-
-        # Verify add_multi_project_conversation was called
         session.add_multi_project_conversation.assert_called_once()
 
 
@@ -215,7 +197,6 @@ class TestMultiProjectPromptBuilder:
             _build_multiproject_ticket_creation_prompt,
         )
 
-        # Create mock project paths
         workspace = tmp_path / "workspace"
         workspace.mkdir()
 
@@ -225,12 +206,10 @@ class TestMultiProjectPromptBuilder:
             repo_path.mkdir()
             project_paths.append(str(repo_path))
 
-        # Create mock config
         mock_config = MagicMock()
         mock_config.jira.project = "PROJ"
         mock_config.jira.custom_field_defaults = {}
 
-        # Build prompt
         prompt = _build_multiproject_ticket_creation_prompt(
             issue_type="story",
             goal="Add Redis caching",
@@ -242,15 +221,10 @@ class TestMultiProjectPromptBuilder:
             affects_versions=None,
         )
 
-        # Verify prompt mentions all projects
         assert "backend-api" in prompt
         assert "frontend-app" in prompt
         assert "database" in prompt
-
-        # Verify prompt indicates it's multi-project
         assert "MULTI-PROJECT" in prompt or "multi-project" in prompt
-
-        # Verify prompt has read-only constraints
         assert "READ-ONLY" in prompt
         assert "Do NOT modify" in prompt or "DO NOT modify" in prompt
 

--- a/tests/test_open_multiproject_selection.py
+++ b/tests/test_open_multiproject_selection.py
@@ -1,8 +1,9 @@
-"""Test multi-project selection in daf open for synced sessions (Issue #177)."""
+"""Tests for multi-project selection in daf open _prompt_for_working_directory (Issue #177)."""
 
 import subprocess
+import json
 from pathlib import Path
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -11,115 +12,13 @@ from devflow.session.manager import SessionManager
 
 
 def test_prompt_for_working_directory_offers_multiproject_selection(temp_daf_home, tmp_path):
-    """Test that _prompt_for_working_directory offers multi-project selection when multiple repos exist.
-
-    This verifies Issue #177: when opening a synced session without conversations,
-    users should be able to select multiple projects interactively.
-    """
+    """Test that _prompt_for_working_directory offers multi-project selection via unified_project_selection."""
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)
 
-    # Setup workspace in config
     workspace_path = tmp_path / "test-workspace"
     workspace_path.mkdir()
 
-    # Create three test projects
-    project1 = workspace_path / "backend-api"
-    project2 = workspace_path / "frontend-app"
-    project3 = workspace_path / "shared-lib"
-
-    for proj in [project1, project2, project3]:
-        proj.mkdir()
-        subprocess.run(["git", "init"], cwd=proj, capture_output=True)
-        subprocess.run(["git", "config", "user.name", "Test"], cwd=proj, capture_output=True)
-        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=proj, capture_output=True)
-        (proj / "README.md").write_text("test")
-        subprocess.run(["git", "add", "."], cwd=proj, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "initial"], cwd=proj, capture_output=True)
-
-    # Create config with workspace
-    import json
-    config_file = Path.home() / ".daf-sessions" / "config.json"
-    config_data = {
-        "repos": {
-            "workspaces": [
-                {
-                    "name": "test-workspace",
-                    "path": str(workspace_path)
-                }
-            ]
-        }
-    }
-    config_file.write_text(json.dumps(config_data, indent=2))
-
-    # Create a synced session without conversations (simulating daf sync)
-    session = session_manager.create_session(
-        name="PROJ-123",
-        issue_key="PROJ-123",
-        goal="Test synced session",
-        working_directory=None,
-        project_path=None,
-    )
-
-    # Mock user interactions
-    # 1. User chooses multi-project mode: Yes
-    # 2. User selects projects: "1,2" (backend-api and frontend-app)
-    # 3. User accepts default branch name
-    # 4. User selects base branch for each project
-    mock_confirm = MagicMock()
-    mock_confirm.ask.side_effect = [
-        True,  # Create multi-project session? Yes
-    ]
-
-    mock_prompt = MagicMock()
-    mock_prompt.ask.side_effect = [
-        "1,2",  # Select projects: backend-api,frontend-app
-        "PROJ-123",  # Branch name (accept default)
-        "main",  # Base branch for backend-api
-        "main",  # Base branch for frontend-app
-    ]
-
-    with patch('rich.prompt.Confirm.ask', mock_confirm.ask), \
-         patch('rich.prompt.Prompt.ask', mock_prompt.ask), \
-         patch('devflow.cli.commands.new_command._prompt_for_source_branch', return_value="main"):
-
-        from devflow.cli.commands.open_command import _prompt_for_working_directory
-
-        # Call the function
-        result = _prompt_for_working_directory(
-            session=session,
-            config_loader=config_loader,
-            session_manager=session_manager,
-            selected_workspace_name="test-workspace",
-        )
-
-        # Verify success
-        assert result is True
-
-        # Verify session was updated with multi-project conversation
-        assert len(session.conversations) == 1
-
-        # Get the conversation
-        conv_key = list(session.conversations.keys())[0]
-        conv = session.conversations[conv_key]
-
-        # Verify it's a multi-project conversation
-        assert conv.active_session.is_multi_project is True
-        assert len(conv.active_session.projects) == 2
-        assert "backend-api" in conv.active_session.projects
-        assert "frontend-app" in conv.active_session.projects
-
-
-def test_prompt_for_working_directory_single_project_when_only_one_selected(temp_daf_home, tmp_path):
-    """Test that selecting only one project in multi-project mode falls back to single-project."""
-    config_loader = ConfigLoader()
-    session_manager = SessionManager(config_loader)
-
-    # Setup workspace in config
-    workspace_path = tmp_path / "test-workspace"
-    workspace_path.mkdir()
-
-    # Create two test projects
     project1 = workspace_path / "backend-api"
     project2 = workspace_path / "frontend-app"
 
@@ -132,25 +31,76 @@ def test_prompt_for_working_directory_single_project_when_only_one_selected(temp
         subprocess.run(["git", "add", "."], cwd=proj, capture_output=True)
         subprocess.run(["git", "commit", "-m", "initial"], cwd=proj, capture_output=True)
 
-    # Create config with workspace
-    import json
     config_file = Path.home() / ".daf-sessions" / "config.json"
     config_data = {
         "repos": {
             "workspaces": [
-                {
-                    "name": "test-workspace",
-                    "path": str(workspace_path)
-                }
+                {"name": "test-workspace", "path": str(workspace_path)}
             ]
         },
-        "templates": {
-            "auto_create": False  # Disable auto-create for this test
-        }
+        "templates": {"auto_create": False}
     }
     config_file.write_text(json.dumps(config_data, indent=2))
 
-    # Create a synced session without conversations
+    session = session_manager.create_session(
+        name="PROJ-123",
+        issue_key="PROJ-123",
+        goal="Test multi-project selection",
+        working_directory=None,
+        project_path=None,
+    )
+
+    with patch("devflow.cli.commands.open_command.unified_project_selection") as mock_unified:
+        mock_unified.return_value = ([str(project1), str(project2)], True)
+
+        with patch("devflow.cli.commands.open_command._create_multi_project_conversation_for_open") as mock_multi:
+            mock_multi.return_value = True
+
+            from devflow.cli.commands.open_command import _prompt_for_working_directory
+
+            result = _prompt_for_working_directory(
+                session=session,
+                config_loader=config_loader,
+                session_manager=session_manager,
+                selected_workspace_name="test-workspace",
+            )
+
+            assert result is True
+            mock_unified.assert_called_once()
+            mock_multi.assert_called_once()
+
+
+def test_prompt_for_working_directory_single_project_when_only_one_selected(temp_daf_home, tmp_path):
+    """Test that selecting only one project continues with single-project mode."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    workspace_path = tmp_path / "test-workspace"
+    workspace_path.mkdir()
+
+    project1 = workspace_path / "backend-api"
+    project2 = workspace_path / "frontend-app"
+
+    for proj in [project1, project2]:
+        proj.mkdir()
+        subprocess.run(["git", "init"], cwd=proj, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=proj, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=proj, capture_output=True)
+        (proj / "README.md").write_text("test")
+        subprocess.run(["git", "add", "."], cwd=proj, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=proj, capture_output=True)
+
+    config_file = Path.home() / ".daf-sessions" / "config.json"
+    config_data = {
+        "repos": {
+            "workspaces": [
+                {"name": "test-workspace", "path": str(workspace_path)}
+            ]
+        },
+        "templates": {"auto_create": False}
+    }
+    config_file.write_text(json.dumps(config_data, indent=2))
+
     session = session_manager.create_session(
         name="PROJ-124",
         issue_key="PROJ-124",
@@ -159,28 +109,11 @@ def test_prompt_for_working_directory_single_project_when_only_one_selected(temp
         project_path=None,
     )
 
-    # Mock user interactions
-    # 1. User chooses multi-project mode: Yes
-    # 2. User selects only one project: "1"
-    # 3. System falls back to single-project mode
-    # 4. User confirms the single selection
-    mock_confirm = MagicMock()
-    mock_confirm.ask.side_effect = [
-        True,  # Create multi-project session? Yes
-    ]
-
-    mock_prompt = MagicMock()
-    mock_prompt.ask.side_effect = [
-        "1",  # Select only project 1
-        "1",  # Confirm single-project selection
-    ]
-
-    with patch('rich.prompt.Confirm.ask', mock_confirm.ask), \
-         patch('rich.prompt.Prompt.ask', mock_prompt.ask):
+    with patch("devflow.cli.commands.open_command.unified_project_selection") as mock_unified:
+        mock_unified.return_value = ([str(project1)], False)
 
         from devflow.cli.commands.open_command import _prompt_for_working_directory
 
-        # Call the function
         result = _prompt_for_working_directory(
             session=session,
             config_loader=config_loader,
@@ -188,28 +121,21 @@ def test_prompt_for_working_directory_single_project_when_only_one_selected(temp
             selected_workspace_name="test-workspace",
         )
 
-        # Verify success
         assert result is True
-
-        # Verify session has a single-project conversation
         assert len(session.conversations) == 1
         conv_key = list(session.conversations.keys())[0]
         conv = session.conversations[conv_key]
-
-        # Verify it's NOT a multi-project conversation
         assert conv.active_session.is_multi_project is False
 
 
 def test_prompt_for_working_directory_no_multiproject_when_user_declines(temp_daf_home, tmp_path):
-    """Test that declining multi-project mode continues with single-project selection."""
+    """Test that declining multi-project still selects single project."""
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)
 
-    # Setup workspace in config
     workspace_path = tmp_path / "test-workspace"
     workspace_path.mkdir()
 
-    # Create two test projects
     project1 = workspace_path / "backend-api"
     project2 = workspace_path / "frontend-app"
 
@@ -222,52 +148,30 @@ def test_prompt_for_working_directory_no_multiproject_when_user_declines(temp_da
         subprocess.run(["git", "add", "."], cwd=proj, capture_output=True)
         subprocess.run(["git", "commit", "-m", "initial"], cwd=proj, capture_output=True)
 
-    # Create config with workspace
-    import json
     config_file = Path.home() / ".daf-sessions" / "config.json"
     config_data = {
         "repos": {
             "workspaces": [
-                {
-                    "name": "test-workspace",
-                    "path": str(workspace_path)
-                }
+                {"name": "test-workspace", "path": str(workspace_path)}
             ]
         },
-        "templates": {
-            "auto_create": False  # Disable auto-create for this test
-        }
+        "templates": {"auto_create": False}
     }
     config_file.write_text(json.dumps(config_data, indent=2))
 
-    # Create a synced session without conversations
     session = session_manager.create_session(
         name="PROJ-125",
         issue_key="PROJ-125",
-        goal="Test declining multi-project",
+        goal="Test decline multi-project",
         working_directory=None,
         project_path=None,
     )
 
-    # Mock user interactions
-    # 1. User declines multi-project mode: No
-    # 2. User selects a single project: "1"
-    mock_confirm = MagicMock()
-    mock_confirm.ask.side_effect = [
-        False,  # Create multi-project session? No
-    ]
-
-    mock_prompt = MagicMock()
-    mock_prompt.ask.side_effect = [
-        "1",  # Select single project
-    ]
-
-    with patch('rich.prompt.Confirm.ask', mock_confirm.ask), \
-         patch('rich.prompt.Prompt.ask', mock_prompt.ask):
+    with patch("devflow.cli.commands.open_command.unified_project_selection") as mock_unified:
+        mock_unified.return_value = ([str(project1)], False)
 
         from devflow.cli.commands.open_command import _prompt_for_working_directory
 
-        # Call the function
         result = _prompt_for_working_directory(
             session=session,
             config_loader=config_loader,
@@ -275,13 +179,5 @@ def test_prompt_for_working_directory_no_multiproject_when_user_declines(temp_da
             selected_workspace_name="test-workspace",
         )
 
-        # Verify success
         assert result is True
-
-        # Verify session has a single-project conversation
         assert len(session.conversations) == 1
-        conv_key = list(session.conversations.keys())[0]
-        conv = session.conversations[conv_key]
-
-        # Verify it's NOT a multi-project conversation
-        assert conv.active_session.is_multi_project is False

--- a/tests/test_repository_selection.py
+++ b/tests/test_repository_selection.py
@@ -17,7 +17,6 @@ def mock_workspace(tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
-    # Create test repositories as git repos
     for repo_name in ["repo1", "repo2", "repo3"]:
         repo_path = workspace / repo_name
         repo_path.mkdir()
@@ -44,37 +43,42 @@ def mock_config_loader(mock_workspace, temp_daf_home):
     return config_loader
 
 
+def _get_path(result):
+    """Extract path from _suggest_and_select_repository result (now returns tuple)."""
+    if result is None:
+        return None
+    paths, is_multi = result
+    if paths is None:
+        return None
+    return paths[0] if paths else None
+
+
 def test_empty_input_uses_default(mock_workspace, mock_config_loader, monkeypatch):
     """Test that pressing Enter without input uses the default selection (first repository)."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate empty input (pressing Enter) - returns default
     def mock_ask(prompt, **kwargs):
-        # When user presses Enter, Prompt.ask returns the default value
         return kwargs.get('default', '')
 
     monkeypatch.setattr(Prompt, "ask", mock_ask)
 
-    # Call the function
     result = _suggest_and_select_repository(
         config_loader=mock_config_loader,
         issue_key=None,
         issue_metadata_dict=None,
     )
 
-    # Verify: Returns path to first repository (default is "1")
-    assert result is not None
-    assert "repo1" in result or "repo2" in result or "repo3" in result
+    path = _get_path(result)
+    assert path is not None
+    assert "repo1" in path or "repo2" in path or "repo3" in path
 
 
 def test_whitespace_input_returns_none_with_error(mock_workspace, mock_config_loader, monkeypatch):
     """Test that entering only whitespace shows error and returns None (PROJ-61069)."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate whitespace input (user explicitly types spaces)
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "   ")
 
-    # Mock console to capture output
     console_output = []
     original_print = Console.print
 
@@ -85,17 +89,15 @@ def test_whitespace_input_returns_none_with_error(mock_workspace, mock_config_lo
 
     monkeypatch.setattr(Console, "print", mock_print)
 
-    # Call the function
     result = _suggest_and_select_repository(
         config_loader=mock_config_loader,
         issue_key=None,
         issue_metadata_dict=None,
     )
 
-    # Verify: Returns None
-    assert result is None
+    path = _get_path(result)
+    assert path is None
 
-    # Verify: Error message was shown
     error_messages = [msg for msg in console_output if "Empty selection not allowed" in msg]
     assert len(error_messages) > 0
 
@@ -104,65 +106,57 @@ def test_valid_number_selection_succeeds(mock_workspace, mock_config_loader, mon
     """Test that selecting a valid number returns the correct repository."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate selecting first repository
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "1")
 
-    # Call the function
     result = _suggest_and_select_repository(
         config_loader=mock_config_loader,
         issue_key=None,
         issue_metadata_dict=None,
     )
 
-    # Verify: Returns path to first repository
-    assert result is not None
-    assert "repo1" in result or "repo2" in result or "repo3" in result
+    path = _get_path(result)
+    assert path is not None
+    assert "repo1" in path or "repo2" in path or "repo3" in path
 
 
 def test_cancel_returns_none(mock_workspace, mock_config_loader, monkeypatch):
     """Test that entering 'cancel' returns None."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate cancel
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "cancel")
 
-    # Call the function
     result = _suggest_and_select_repository(
         config_loader=mock_config_loader,
         issue_key=None,
         issue_metadata_dict=None,
     )
 
-    # Verify: Returns None (use current directory)
-    assert result is None
+    path = _get_path(result)
+    assert path is None
 
 
 def test_q_returns_none(mock_workspace, mock_config_loader, monkeypatch):
     """Test that entering 'q' returns None (alias for cancel)."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate 'q'
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "q")
 
-    # Call the function
     result = _suggest_and_select_repository(
         config_loader=mock_config_loader,
         issue_key=None,
         issue_metadata_dict=None,
     )
 
-    # Verify: Returns None (use current directory)
-    assert result is None
+    path = _get_path(result)
+    assert path is None
 
 
 def test_invalid_number_returns_none(mock_workspace, mock_config_loader, monkeypatch):
     """Test that selecting an invalid number shows error and returns None."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate invalid number (out of range)
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "999")
 
-    # Mock console to capture output
     console_output = []
     original_print = Console.print
 
@@ -173,17 +167,15 @@ def test_invalid_number_returns_none(mock_workspace, mock_config_loader, monkeyp
 
     monkeypatch.setattr(Console, "print", mock_print)
 
-    # Call the function
     result = _suggest_and_select_repository(
         config_loader=mock_config_loader,
         issue_key=None,
         issue_metadata_dict=None,
     )
 
-    # Verify: Returns None
-    assert result is None
+    path = _get_path(result)
+    assert path is None
 
-    # Verify: Error message was shown
     error_messages = [msg for msg in console_output if "Invalid selection" in msg]
     assert len(error_messages) > 0
 
@@ -192,76 +184,63 @@ def test_valid_repo_name_succeeds(mock_workspace, mock_config_loader, monkeypatc
     """Test that entering a valid repository name returns the correct path."""
     from rich.prompt import Prompt, Confirm
 
-    # Mock Prompt.ask to simulate entering repository name
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "repo2")
-
-    # Mock Confirm.ask to always return True (use the path)
     monkeypatch.setattr(Confirm, "ask", lambda prompt, default=False: True)
 
-    # Call the function
     result = _suggest_and_select_repository(
         config_loader=mock_config_loader,
         issue_key=None,
         issue_metadata_dict=None,
     )
 
-    # Verify: Returns path to repo2
-    assert result is not None
-    assert "repo2" in result
+    path = _get_path(result)
+    assert path is not None
+    assert "repo2" in path
 
 
 def test_absolute_path_succeeds(mock_workspace, mock_config_loader, monkeypatch, tmp_path):
     """Test that entering an absolute path works correctly."""
     from rich.prompt import Prompt
 
-    # Create a test directory
     test_path = tmp_path / "custom-repo"
     test_path.mkdir()
 
-    # Mock Prompt.ask to simulate entering absolute path
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: str(test_path))
 
-    # Call the function
     result = _suggest_and_select_repository(
         config_loader=mock_config_loader,
         issue_key=None,
         issue_metadata_dict=None,
     )
 
-    # Verify: Returns the absolute path
-    assert result == str(test_path)
+    path = _get_path(result)
+    assert path == str(test_path)
 
 
 def test_tilde_path_succeeds(mock_workspace, mock_config_loader, monkeypatch, tmp_path):
     """Test that entering a path with tilde (~) works correctly."""
     from rich.prompt import Prompt, Confirm
 
-    # Mock Prompt.ask to simulate entering tilde path
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "~/test-repo")
-
-    # Mock Confirm.ask to return True if path doesn't exist
     monkeypatch.setattr(Confirm, "ask", lambda prompt, default=False: True)
 
-    # Call the function
     result = _suggest_and_select_repository(
         config_loader=mock_config_loader,
         issue_key=None,
         issue_metadata_dict=None,
     )
 
-    # Verify: Returns expanded path (not None)
-    assert result is not None
-    assert "~" not in result  # Tilde should be expanded
+    path = _get_path(result)
+    assert path is not None
+    assert "~" not in path
 
 
 def test_empty_input_error_message_includes_valid_options(mock_workspace, mock_config_loader, monkeypatch):
     """Test that error message for empty input includes all valid selection options (PROJ-61069)."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate empty input
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "")
 
-    # Mock console to capture output
     console_output = []
     original_print = Console.print
 
@@ -272,21 +251,18 @@ def test_empty_input_error_message_includes_valid_options(mock_workspace, mock_c
 
     monkeypatch.setattr(Console, "print", mock_print)
 
-    # Call the function
     result = _suggest_and_select_repository(
         config_loader=mock_config_loader,
         issue_key=None,
         issue_metadata_dict=None,
     )
 
-    # Verify: Returns None
-    assert result is None
+    path = _get_path(result)
+    assert path is None
 
-    # Verify: Error message includes all valid options
     error_messages = [msg for msg in console_output if "Empty selection not allowed" in msg]
     assert len(error_messages) > 0
 
-    # Check that error message mentions valid options
     error_msg = error_messages[0]
     assert "number" in error_msg.lower()
     assert "repository name" in error_msg.lower() or "path" in error_msg.lower()
@@ -294,29 +270,25 @@ def test_empty_input_error_message_includes_valid_options(mock_workspace, mock_c
 
 
 def test_default_selection_displayed_and_used(mock_workspace, mock_config_loader, monkeypatch):
-    """Test that default selection is shown in prompt and used when Enter is pressed (itdove/devaiflow#280)."""
+    """Test that default selection is shown in prompt and used when Enter is pressed."""
     from rich.prompt import Prompt
 
-    # Track what default value was passed to Prompt.ask
     captured_default = {}
 
     def mock_ask(prompt, **kwargs):
         captured_default['value'] = kwargs.get('default')
-        # Simulate user pressing Enter (returns the default)
         return kwargs.get('default', '')
 
     monkeypatch.setattr(Prompt, "ask", mock_ask)
 
-    # Call the function
     result = _suggest_and_select_repository(
         config_loader=mock_config_loader,
         issue_key=None,
         issue_metadata_dict=None,
     )
 
-    # Verify: Default was set to "1" (first repository)
     assert captured_default.get('value') == "1"
 
-    # Verify: Returns path to first repository
-    assert result is not None
-    assert "repo1" in result or "repo2" in result or "repo3" in result
+    path = _get_path(result)
+    assert path is not None
+    assert "repo1" in path or "repo2" in path or "repo3" in path

--- a/tests/test_repository_selection_jira_new.py
+++ b/tests/test_repository_selection_jira_new.py
@@ -1,4 +1,4 @@
-"""Tests for repository selection in 'daf jira new' command (PROJ-61069)."""
+"""Tests for unified project selection used by 'daf jira new' and other commands."""
 
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from rich.console import Console
 
-from devflow.cli.commands.jira_new_command import _prompt_for_repository_selection
+from devflow.cli.utils import unified_project_selection
 from devflow.config.loader import ConfigLoader
 
 
@@ -17,7 +17,6 @@ def mock_workspace(tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
-    # Create test repositories as git repos
     for repo_name in ["repo1", "repo2", "repo3"]:
         repo_path = workspace / repo_name
         repo_path.mkdir()
@@ -26,54 +25,29 @@ def mock_workspace(tmp_path):
     return workspace
 
 
-@pytest.fixture
-def mock_config(mock_workspace, temp_daf_home):
-    """Create a mock config with workspace path."""
-    from devflow.config.models import WorkspaceDefinition
-
-    config_loader = ConfigLoader()
-    config_loader.create_default_config()
-
-    config = config_loader.load_config()
-    # Use new workspaces list instead of old workspace field
-    config.repos.workspaces = [
-        WorkspaceDefinition(name="default", path=str(mock_workspace))
-    ]
-    # Set last-used workspace for the selection system
-    config.repos.last_used_workspace = "default"
-    config_loader.save_config(config)
-
-    return config
-
-
-def test_empty_input_uses_default(mock_workspace, mock_config, monkeypatch):
+def test_empty_input_uses_default(mock_workspace, monkeypatch):
     """Test that pressing Enter without input uses the default selection (first repository)."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate empty input (pressing Enter) - returns default
-    def mock_ask(prompt, **kwargs):
-        # When user presses Enter, Prompt.ask returns the default value
-        return kwargs.get('default', '')
+    monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: kwargs.get('default', ''))
 
-    monkeypatch.setattr(Prompt, "ask", mock_ask)
+    result, is_multi = unified_project_selection(
+        workspace_path=str(mock_workspace),
+        repo_options=["repo1", "repo2", "repo3"],
+    )
 
-    # Call the function
-    result = _prompt_for_repository_selection(config=mock_config)
-
-    # Verify: Returns tuple with path to first repository (default is "1")
     assert result is not None
-    assert result[0] is not None
-    assert "repo1" in result[0] or "repo2" in result[0] or "repo3" in result[0]
+    assert len(result) == 1
+    assert "repo1" in result[0]
+    assert is_multi is False
 
 
-def test_whitespace_input_returns_none_with_error(mock_workspace, mock_config, monkeypatch):
-    """Test that entering only whitespace shows error and returns None (PROJ-61069)."""
+def test_whitespace_input_returns_none_with_error(mock_workspace, monkeypatch):
+    """Test that entering only whitespace shows error and returns None."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate whitespace input
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "   ")
 
-    # Mock console to capture output
     console_output = []
     original_print = Console.print
 
@@ -84,74 +58,68 @@ def test_whitespace_input_returns_none_with_error(mock_workspace, mock_config, m
 
     monkeypatch.setattr(Console, "print", mock_print)
 
-    # Call the function
-    result = _prompt_for_repository_selection(config=mock_config)
+    result, is_multi = unified_project_selection(
+        workspace_path=str(mock_workspace),
+        repo_options=["repo1", "repo2", "repo3"],
+    )
 
-    # Verify: Returns (None, None)
-    assert result == (None, None)
-
-    # Verify: Error message was shown
+    assert result is None
     error_messages = [msg for msg in console_output if "Empty selection not allowed" in msg]
     assert len(error_messages) > 0
 
 
-def test_valid_number_selection_succeeds(mock_workspace, mock_config, monkeypatch):
+def test_valid_number_selection_succeeds(mock_workspace, monkeypatch):
     """Test that selecting a valid number returns the correct repository path."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate selecting first repository
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "1")
 
-    # Call the function
-    result = _prompt_for_repository_selection(config=mock_config)
+    result, is_multi = unified_project_selection(
+        workspace_path=str(mock_workspace),
+        repo_options=["repo1", "repo2", "repo3"],
+    )
 
-    # Verify: Returns tuple with path to first repository
     assert result is not None
-    assert result[0] is not None
-    assert "repo1" in result[0] or "repo2" in result[0] or "repo3" in result[0]
+    assert len(result) == 1
+    assert "repo1" in result[0]
 
 
-def test_cancel_returns_none(mock_workspace, mock_config, monkeypatch):
+def test_cancel_returns_none(mock_workspace, monkeypatch):
     """Test that entering 'cancel' returns None."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate cancel
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "cancel")
 
-    # Call the function
-    result = _prompt_for_repository_selection(config=mock_config)
+    result, is_multi = unified_project_selection(
+        workspace_path=str(mock_workspace),
+        repo_options=["repo1", "repo2", "repo3"],
+    )
 
-    # Verify: Returns (None, None) (user cancelled)
-    assert result == (None, None)
+    assert result is None
 
 
-def test_valid_repo_name_succeeds(mock_workspace, mock_config, monkeypatch):
+def test_valid_repo_name_succeeds(mock_workspace, monkeypatch):
     """Test that entering a valid repository name returns the correct path."""
     from rich.prompt import Prompt, Confirm
 
-    # Mock Prompt.ask to simulate entering repository name
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "repo2")
-
-    # Mock Confirm.ask to always return True (use the path)
     monkeypatch.setattr(Confirm, "ask", lambda prompt, default=False: True)
 
-    # Call the function
-    result = _prompt_for_repository_selection(config=mock_config)
+    result, is_multi = unified_project_selection(
+        workspace_path=str(mock_workspace),
+        repo_options=["repo1", "repo2", "repo3"],
+    )
 
-    # Verify: Returns tuple with path to repo2
     assert result is not None
-    assert result[0] is not None
     assert "repo2" in result[0]
 
 
-def test_invalid_number_returns_none(mock_workspace, mock_config, monkeypatch):
+def test_invalid_number_returns_none(mock_workspace, monkeypatch):
     """Test that selecting an invalid number shows error and returns None."""
     from rich.prompt import Prompt
 
-    # Mock Prompt.ask to simulate invalid number (out of range)
     monkeypatch.setattr(Prompt, "ask", lambda prompt, **kwargs: "999")
 
-    # Mock console to capture output
     console_output = []
     original_print = Console.print
 
@@ -162,12 +130,11 @@ def test_invalid_number_returns_none(mock_workspace, mock_config, monkeypatch):
 
     monkeypatch.setattr(Console, "print", mock_print)
 
-    # Call the function
-    result = _prompt_for_repository_selection(config=mock_config)
+    result, is_multi = unified_project_selection(
+        workspace_path=str(mock_workspace),
+        repo_options=["repo1", "repo2", "repo3"],
+    )
 
-    # Verify: Returns (None, None)
-    assert result == (None, None)
-
-    # Verify: Error message was shown
+    assert result is None
     error_messages = [msg for msg in console_output if "Invalid selection" in msg]
     assert len(error_messages) > 0

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -432,13 +432,16 @@ def test_new_command_w_flag_uses_correct_workspace(monkeypatch, tmp_path):
     monkeypatch.setattr(Prompt, 'ask', lambda *args, **kwargs: "1")
 
     # Test repository discovery with ai workspace
-    selected_path = _suggest_and_select_repository(
+    result = _suggest_and_select_repository(
         config_loader,
         workspace_name="ai"
     )
 
     # Verify the selected path is from ai workspace, not primary
-    assert selected_path is not None
+    assert result is not None
+    selected_paths, is_multi = result
+    assert selected_paths is not None
+    selected_path = selected_paths[0]
     assert "devaiflow" in selected_path or "ml-models" in selected_path
     assert str(ai_ws) in selected_path
     assert str(primary_ws) not in selected_path

--- a/tests/test_workspace_selection_bug.py
+++ b/tests/test_workspace_selection_bug.py
@@ -6,8 +6,9 @@ workspace when scanning for repositories, instead of always using the default wo
 
 import pytest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 from devflow.cli.commands.open_command import _prompt_for_working_directory
+from devflow.cli.utils import unified_project_selection
 from devflow.config.loader import ConfigLoader
 from devflow.config.models import WorkspaceDefinition
 from devflow.session.manager import SessionManager
@@ -16,15 +17,13 @@ from devflow.session.manager import SessionManager
 @pytest.fixture
 def mock_config_multi_workspace():
     """Create a mock config with multiple workspaces."""
-    # Create mock repos object
     mock_repos = MagicMock()
     mock_repos.workspaces = [
         WorkspaceDefinition(name="ai", path="/Users/test/development/ai"),
         WorkspaceDefinition(name="project-b", path="/Users/test/development/project-b"),
     ]
-    mock_repos.last_used_workspace = "project-b"  # Default is project-b
+    mock_repos.last_used_workspace = "project-b"
 
-    # Mock get_workspace_by_name method
     def get_workspace_by_name(name):
         for ws in mock_repos.workspaces:
             if ws.name == name:
@@ -32,7 +31,6 @@ def mock_config_multi_workspace():
         return None
     mock_repos.get_workspace_by_name = get_workspace_by_name
 
-    # Mock get_default_workspace_path method
     def get_default_workspace_path():
         if mock_repos.last_used_workspace:
             ws = get_workspace_by_name(mock_repos.last_used_workspace)
@@ -40,7 +38,6 @@ def mock_config_multi_workspace():
         return None
     mock_repos.get_default_workspace_path = get_default_workspace_path
 
-    # Create mock config object
     mock_config = MagicMock()
     mock_config.repos = mock_repos
 
@@ -53,7 +50,6 @@ def mock_config_loader(mock_config_multi_workspace, tmp_path):
     config_loader = MagicMock(spec=ConfigLoader)
     config_loader.load_config.return_value = mock_config_multi_workspace
 
-    # Use real Path objects for file system paths to avoid JSON serialization errors
     sessions_dir = tmp_path / "sessions"
     sessions_dir.mkdir(parents=True, exist_ok=True)
     config_loader.sessions_dir = sessions_dir
@@ -65,7 +61,6 @@ def mock_config_loader(mock_config_multi_workspace, tmp_path):
 @pytest.fixture
 def mock_session(mock_config_loader):
     """Create a mock session."""
-    # Mock audit logging to avoid JSON serialization errors with MagicMock
     with patch("devflow.utils.audit_log.log_model_provider_usage"):
         session_manager = SessionManager(mock_config_loader)
         session = session_manager.create_session(
@@ -82,60 +77,25 @@ def test_prompt_for_working_directory_uses_selected_workspace(
     mock_config_multi_workspace,
     monkeypatch,
 ):
-    """Test that _prompt_for_working_directory uses the selected workspace from -w flag.
-    
-    Bug: When user runs 'daf open AAP-12345 -w ai', the function should scan
-    /Users/test/development/ai, not the default workspace /Users/test/development/project-b.
-    """
-    # Create session manager
+    """Test that _prompt_for_working_directory uses the selected workspace from -w flag."""
     session_manager = SessionManager(mock_config_loader)
-    
-    # Mock Path to avoid filesystem operations
-    mock_ai_workspace = MagicMock(spec=Path)
-    mock_ai_workspace.expanduser.return_value = mock_ai_workspace
-    mock_ai_workspace.exists.return_value = True
-    mock_ai_workspace.is_dir.return_value = True
-    mock_ai_workspace.__str__.return_value = "/Users/test/development/ai"
-    
-    # Mock iterdir to return empty list (no repos for simplicity)
-    mock_ai_workspace.iterdir.return_value = []
-    
-    # Mock Path constructor to return our mock workspace
-    def mock_path_constructor(path_str):
-        if str(path_str) == "/Users/test/development/ai":
-            return mock_ai_workspace
-        return MagicMock(spec=Path)
-    
-    # Mock Prompt to simulate user input
-    mock_prompt = MagicMock()
-    mock_prompt.ask.return_value = "cancel"  # User cancels after seeing the prompt
-    
-    with patch('devflow.cli.commands.open_command.Path', side_effect=mock_path_constructor), \
-         patch('rich.prompt.Prompt', mock_prompt), \
-         patch('devflow.cli.commands.open_command.console') as mock_console:
-        
-        # Call the function with selected_workspace_name="ai"
+
+    with patch("devflow.cli.commands.open_command.get_workspace_path") as mock_get_ws, \
+         patch("devflow.cli.commands.open_command.scan_workspace_repositories") as mock_scan, \
+         patch("devflow.cli.commands.open_command.unified_project_selection") as mock_unified:
+        mock_get_ws.return_value = "/Users/test/development/ai"
+        mock_scan.return_value = ["repo-a", "repo-b"]
+        mock_unified.return_value = (None, False)
+
         result = _prompt_for_working_directory(
             session=mock_session,
             config_loader=mock_config_loader,
             session_manager=session_manager,
-            selected_workspace_name="ai"  # User specified -w ai
+            selected_workspace_name="ai"
         )
-        
-        # Verify that the correct workspace path was used for scanning
-        # Find the console.print call that shows "Scanning workspace:"
-        scanning_calls = [
-            call for call in mock_console.print.call_args_list
-            if len(call[0]) > 0 and "Scanning workspace:" in str(call[0][0])
-        ]
-        
-        # Should have printed the AI workspace path, not project-b
-        assert len(scanning_calls) > 0, "Should have printed 'Scanning workspace:' message"
-        scanning_message = str(scanning_calls[0][0][0])
-        assert "/Users/test/development/ai" in scanning_message, \
-            f"Should scan AI workspace, but got: {scanning_message}"
-        assert "/Users/test/development/project-b" not in scanning_message, \
-            f"Should NOT scan project-b workspace, but got: {scanning_message}"
+
+        mock_get_ws.assert_called_once_with(mock_config_multi_workspace, "ai")
+        mock_scan.assert_called_once_with("/Users/test/development/ai")
 
 
 def test_prompt_for_working_directory_uses_default_when_no_selection(
@@ -144,53 +104,20 @@ def test_prompt_for_working_directory_uses_default_when_no_selection(
     mock_config_multi_workspace,
     monkeypatch,
 ):
-    """Test that _prompt_for_working_directory uses default workspace when no -w flag provided.
-    
-    This verifies backward compatibility - when no workspace is selected,
-    the function should use the default workspace (last_used_workspace).
-    """
-    # Create session manager
+    """Test that _prompt_for_working_directory uses default workspace when no -w flag provided."""
     session_manager = SessionManager(mock_config_loader)
-    
-    # Mock Path to avoid filesystem operations
-    mock_default_workspace = MagicMock(spec=Path)
-    mock_default_workspace.expanduser.return_value = mock_default_workspace
-    mock_default_workspace.exists.return_value = True
-    mock_default_workspace.is_dir.return_value = True
-    mock_default_workspace.__str__.return_value = "/Users/test/development/project-b"
-    
-    # Mock iterdir to return empty list
-    mock_default_workspace.iterdir.return_value = []
-    
-    # Mock Path constructor
-    def mock_path_constructor(path_str):
-        if str(path_str) == "/Users/test/development/project-b":
-            return mock_default_workspace
-        return MagicMock(spec=Path)
-    
-    # Mock Prompt to simulate user input
-    mock_prompt = MagicMock()
-    mock_prompt.ask.return_value = "cancel"
-    
-    with patch('devflow.cli.commands.open_command.Path', side_effect=mock_path_constructor), \
-         patch('rich.prompt.Prompt', mock_prompt), \
-         patch('devflow.cli.commands.open_command.console') as mock_console:
-        
-        # Call the function WITHOUT selected_workspace_name (backward compatibility)
+
+    with patch("devflow.cli.commands.open_command.get_workspace_path") as mock_get_ws, \
+         patch("devflow.cli.commands.open_command.scan_workspace_repositories") as mock_scan, \
+         patch("devflow.cli.commands.open_command.unified_project_selection") as mock_unified:
+        mock_get_ws.return_value = "/Users/test/development/project-b"
+        mock_scan.return_value = ["repo-x"]
+        mock_unified.return_value = (None, False)
+
         result = _prompt_for_working_directory(
             session=mock_session,
             config_loader=mock_config_loader,
-            session_manager=session_manager
-            # selected_workspace_name NOT provided
+            session_manager=session_manager,
         )
-        
-        # Verify that the default workspace was used
-        scanning_calls = [
-            call for call in mock_console.print.call_args_list
-            if len(call[0]) > 0 and "Scanning workspace:" in str(call[0][0])
-        ]
-        
-        assert len(scanning_calls) > 0, "Should have printed 'Scanning workspace:' message"
-        scanning_message = str(scanning_calls[0][0][0])
-        assert "/Users/test/development/project-b" in scanning_message, \
-            f"Should scan default (project-b) workspace, but got: {scanning_message}"
+
+        mock_scan.assert_called_once_with("/Users/test/development/project-b")


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->

## Description

Unifies the project selection UX across all daf commands (`investigate`, `open`, `new`, `git new`, `jira new`) so they behave consistently. Previously, each command had its own project selection flow, leading to an inconsistent user experience. The `daf open` command had the preferred selection UX, so this refactor extracts that pattern into shared utilities and applies it across all commands.

Key changes:
- Extracted common project selection logic into `devflow/cli/utils.py`
- Updated `investigate_command.py`, `new_command.py`, `git_new_command.py`, `jira_new_command.py`, and `open_command.py` to use the shared selection flow
- Updated and added tests to verify consistent behavior across all commands

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `daf open` and note the project selection experience
3. Run `daf new` and verify the project selection matches `daf open`
4. Run `daf investigate` and verify the project selection matches `daf open`
5. Run `daf git new` and verify the project selection matches `daf open`
6. Run `daf jira new` and verify the project selection matches `daf open`
7. Run the test suite: `pytest tests/test_open_multiproject_selection.py tests/test_investigate_command.py tests/test_git_new_multiproject.py tests/test_jira_new_multiproject.py tests/test_jira_new_command.py tests/test_repository_selection.py tests/test_repository_selection_jira_new.py tests/test_workspace.py tests/test_workspace_selection_bug.py tests/test_github_repo_suggestion.py`

### Scenarios tested
- Project selection in single-project sessions
- Project selection in multi-project sessions across all commands
- Workspace selection behavior
- Repository suggestion flow

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: