### PR TITLE
feat: default conversation selection to most recently active

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,6 +1,6 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-05-30T17:58:11.475Z
+> Auto-maintained by OpenWolf. Last scanned: 2026-05-30T18:53:02.445Z
 > Files: 518 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../../../.claude/plans/
@@ -167,7 +167,7 @@
 - `new_command_multiproject.py` — Multi-project session creation logic for DevAIFlow (Issue #149). (~4292 tok)
 - `new_command.py` — Implementation of 'daf new' command. (~24904 tok)
 - `note_command.py` — Implementation of 'daf note' and 'daf notes' commands. (~1903 tok)
-- `open_command.py` — Implementation of 'daf open' command. (~48238 tok)
+- `open_command.py` — Implementation of 'daf open' command. (~48391 tok)
 - `pause_command.py` — Implementation of 'daf pause' command. (~619 tok)
 - `provider_commands.py` — Implementation of 'daf model' commands for managing model provider profiles. (~6464 tok)
 - `rebuild_index_command.py` — Implementation of 'daf rebuild-index' command. (~2992 tok)

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -1,6 +1,6 @@
 {
-  "session_id": "session-2026-05-30-1405",
-  "started": "2026-05-30T18:05:06.902Z",
+  "session_id": "session-2026-05-30-1456",
+  "started": "2026-05-30T18:56:55.313Z",
   "files_read": {},
   "files_written": [],
   "edit_counts": {},
@@ -8,5 +8,5 @@
   "anatomy_misses": 0,
   "repeated_reads_warned": 0,
   "cerebrum_warnings": 0,
-  "stop_count": 0
+  "stop_count": 3
 }

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -603,3 +603,25 @@
 
 | Time | Action | File(s) | Outcome | ~Tokens |
 |------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 14:51
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 14:53 | Edited devflow/cli/commands/open_command.py | expanded (+11 lines) | ~254 |
+
+## Session: 2026-05-30 14:55
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 14:56
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-30 14:56
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 2026-05-30 | Changed conversation selection default from "n" (new) to most recently active conversation number | devflow/cli/commands/open_command.py | 3609 tests pass | ~500 |

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -5,7 +5,7 @@
     "total_tokens_estimated": 893722,
     "total_reads": 101,
     "total_writes": 91,
-    "total_sessions": 83,
+    "total_sessions": 87,
     "anatomy_hits": 67,
     "anatomy_misses": 29,
     "repeated_reads_blocked": 58,

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -2174,12 +2174,23 @@ def _handle_conversation_selection(
         console.print(f"\n[dim]Mock mode: Auto-selecting the existing conversation[/dim]")
         choice = "1"
     else:
+        # Default to the most recently active conversation
+        most_recent_idx = 1
+        if len(session.conversations) > 1:
+            most_recent_time = None
+            for i, (_, conv) in enumerate(session.conversations.items(), 1):
+                conv_time = conv.active_session.last_active
+                if most_recent_time is None or conv_time > most_recent_time:
+                    most_recent_time = conv_time
+                    most_recent_idx = i
+        default_selection = str(most_recent_idx)
+
         console.print(f"\n[bold]Options:[/bold]")
         console.print(f"  [cyan]n[/cyan] - Create new conversation for '{detected_repo_name}'")
         console.print(f"  [cyan]1-{len(session.conversations)}[/cyan] - Select existing conversation")
         console.print(f"  [cyan]c[/cyan] - Cancel")
 
-        choice = Prompt.ask("Selection", default="n")
+        choice = Prompt.ask("Selection", default=default_selection)
 
     if choice.lower() == "c":
         console.print(f"\n[yellow]Cancelled[/yellow] - session not opened")


### PR DESCRIPTION
Here's the filled PR template:

---

Jira Issue: <!-- This PR does not need a corresponding Jira item. -->

## Description

When reopening a session, the conversation list now defaults to selecting the most recently active conversation instead of requiring the user to manually find and select it. This improves the workflow by immediately surfacing the context the user was last working in.

The change modifies the `open_command.py` to sort or select conversations by their last activity timestamp, so the default selection reflects the most recent work.

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Create or open multiple sessions with different conversations
3. Close the session
4. Reopen the session using the open command
5. Verify that the most recently active conversation is selected by default
6. Switch to a different conversation, close, and reopen — confirm the newly active conversation is now the default selection

### Scenarios tested
- Reopening a session with multiple conversations confirms the last-active conversation is pre-selected
- Reopening a session with a single conversation still works correctly
- New sessions without prior activity behave as expected (no regression)

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: