### PR TITLE
feat: Add CLI parameters for all interactive prompts (#278)

### DIFF
--- a/devflow/cli/commands/complete_command.py
+++ b/devflow/cli/commands/complete_command.py
@@ -9,7 +9,7 @@ import urllib.request
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
-from devflow.cli.utils import add_jira_comment, get_session_with_prompt, get_status_display, require_outside_claude
+from devflow.cli.utils import add_jira_comment, get_session_with_prompt, get_status_display, is_non_interactive, require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.exceptions import ToolNotFoundError
 from devflow.export.manager import ExportManager
@@ -113,7 +113,12 @@ def complete_session(
     latest: bool = False,
     no_commit: bool = False,
     no_pr: bool = False,
-    no_issue_update: bool = False
+    no_issue_update: bool = False,
+    yes: bool = False,
+    commit_message: Optional[str] = None,
+    export_commit: Optional[bool] = None,
+    pr_template_url: Optional[str] = None,
+    no_retry: bool = False,
 ) -> None:
     """Mark a session as complete.
 
@@ -125,6 +130,11 @@ def complete_session(
         no_commit: If True, skip git commit prompt
         no_pr: If True, skip PR/MR creation prompt
         no_issue_update: If True, skip JIRA update prompt
+        yes: If True, skip all confirmation prompts (use defaults)
+        commit_message: Commit message to use directly (skip prompt)
+        export_commit: If set, control commit before export (True/False)
+        pr_template_url: PR/MR template URL (skip template discovery prompt)
+        no_retry: If True, don't retry on PR/MR creation failure
     """
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)
@@ -153,9 +163,10 @@ def complete_session(
             console.print(f"  Goal: {session.goal}")
         console.print(f"  Last active: {session.last_active.strftime('%Y-%m-%d %H:%M:%S')}")
 
-        if not Confirm.ask("\nContinue?", default=True):
-            console.print("[dim]Cancelled[/dim]")
-            return
+        if not yes and not is_non_interactive():
+            if not Confirm.ask("\nContinue?", default=True):
+                console.print("[dim]Cancelled[/dim]")
+                return
     else:
         # Require identifier if --latest not specified
         if not identifier:
@@ -305,6 +316,8 @@ def complete_session(
                 should_commit = True
                 if no_commit:
                     should_commit = False
+                elif yes or is_non_interactive():
+                    should_commit = True
                 elif config and config.prompts and config.prompts.auto_commit_on_complete is not None:
                     should_commit = config.prompts.auto_commit_on_complete
                 else:
@@ -314,7 +327,7 @@ def complete_session(
                     auto_message = f"{session.issue_key}: {session.goal} ({proj_name})" if session.issue_key else f"{session.goal} ({proj_name})"
 
                     # Display commit message and prompt for confirmation
-                    commit_message_short = _prompt_for_commit_message(auto_message, config)
+                    commit_message_short = _prompt_for_commit_message(auto_message, config, commit_message=commit_message)
 
                     if commit_message_short:
                         co_authored_by = get_co_authored_by_line(config, session.model_profile)
@@ -337,7 +350,9 @@ def complete_session(
                         # Push to remote
                         if GitUtils.has_unpushed_commits(working_dir, proj_info.branch):
                             should_push = True
-                            if config and config.prompts and config.prompts.auto_push_to_remote is not None:
+                            if yes or is_non_interactive():
+                                should_push = True
+                            elif config and config.prompts and config.prompts.auto_push_to_remote is not None:
                                 should_push = config.prompts.auto_push_to_remote
                             else:
                                 should_push = Confirm.ask(f"  Push to remote?", default=True)
@@ -361,7 +376,9 @@ def complete_session(
                 # Push unpushed commits if any
                 if GitUtils.has_unpushed_commits(working_dir, proj_info.branch):
                     should_push = not no_pr
-                    if should_push and config and config.prompts and config.prompts.auto_push_to_remote is not None:
+                    if should_push and (yes or is_non_interactive()):
+                        should_push = True
+                    elif should_push and config and config.prompts and config.prompts.auto_push_to_remote is not None:
                         should_push = config.prompts.auto_push_to_remote
                     elif should_push:
                         should_push = Confirm.ask(f"  Push latest commits to update PR/MR?", default=True)
@@ -397,7 +414,9 @@ def complete_session(
 
                 if changed_files:
                     should_create = not no_pr
-                    if should_create and config and config.prompts and config.prompts.auto_create_pr_on_complete is not None:
+                    if should_create and (yes or is_non_interactive()):
+                        should_create = True
+                    elif should_create and config and config.prompts and config.prompts.auto_create_pr_on_complete is not None:
                         should_create = config.prompts.auto_create_pr_on_complete
                     elif should_create:
                         should_create = Confirm.ask(f"  Create PR/MR for {proj_name}?", default=True)
@@ -472,6 +491,8 @@ def complete_session(
                 should_commit = True
                 if no_commit:
                     should_commit = False
+                elif yes or is_non_interactive():
+                    should_commit = True
                 elif config and config.prompts and config.prompts.auto_commit_on_complete is not None:
                     should_commit = config.prompts.auto_commit_on_complete
                 else:
@@ -481,7 +502,7 @@ def complete_session(
                     auto_message = f"{session.issue_key}: {session.goal} ({working_dir_name})" if session.issue_key else f"{session.goal} ({working_dir_name})"
 
                     # Display commit message and prompt for confirmation
-                    commit_message_short = _prompt_for_commit_message(auto_message, config)
+                    commit_message_short = _prompt_for_commit_message(auto_message, config, commit_message=commit_message)
 
                     if commit_message_short:
                         co_authored_by = get_co_authored_by_line(config, session.model_profile)
@@ -504,7 +525,9 @@ def complete_session(
                         # Push to remote
                         if GitUtils.has_unpushed_commits(working_dir, conv.branch):
                             should_push = True
-                            if config and config.prompts and config.prompts.auto_push_to_remote is not None:
+                            if yes or is_non_interactive():
+                                should_push = True
+                            elif config and config.prompts and config.prompts.auto_push_to_remote is not None:
                                 should_push = config.prompts.auto_push_to_remote
                             else:
                                 should_push = Confirm.ask(f"  Push to remote?", default=True)
@@ -528,7 +551,9 @@ def complete_session(
                 # Push unpushed commits if any
                 if GitUtils.has_unpushed_commits(working_dir, conv.branch):
                     should_push = not no_pr
-                    if should_push and config and config.prompts and config.prompts.auto_push_to_remote is not None:
+                    if should_push and (yes or is_non_interactive()):
+                        should_push = True
+                    elif should_push and config and config.prompts and config.prompts.auto_push_to_remote is not None:
                         should_push = config.prompts.auto_push_to_remote
                     elif should_push:
                         should_push = Confirm.ask(f"  Push latest commits to update PR/MR?", default=True)
@@ -564,7 +589,9 @@ def complete_session(
 
                 if changed_files:
                     should_create = not no_pr
-                    if should_create and config and config.prompts and config.prompts.auto_create_pr_on_complete is not None:
+                    if should_create and (yes or is_non_interactive()):
+                        should_create = True
+                    elif should_create and config and config.prompts and config.prompts.auto_create_pr_on_complete is not None:
                         should_create = config.prompts.auto_create_pr_on_complete
                     elif should_create:
                         should_create = Confirm.ask(f"  Create PR/MR for {working_dir_name}?", default=True)
@@ -607,6 +634,8 @@ def complete_session(
             if no_commit:
                 should_commit = False
                 console.print("\n[dim]Skipping commit (--no-commit flag)[/dim]")
+            elif yes or is_non_interactive():
+                should_commit = True
             elif config and config.prompts and config.prompts.auto_commit_on_complete is not None:
                 should_commit = config.prompts.auto_commit_on_complete
                 if should_commit:
@@ -619,7 +648,7 @@ def complete_session(
                 auto_message = _generate_commit_message(session)
 
                 # Display commit message and prompt for confirmation
-                commit_message_short = _prompt_for_commit_message(auto_message, config)
+                commit_message_short = _prompt_for_commit_message(auto_message, config, commit_message=commit_message)
 
                 if commit_message_short:
                     # Create commit with standard format
@@ -649,7 +678,9 @@ def complete_session(
                     if success and GitUtils.has_unpushed_commits(working_dir, active_conv.branch):
                         # Check if auto_push_to_remote is configured
                         should_push = True
-                        if config and config.prompts and config.prompts.auto_push_to_remote is not None:
+                        if yes or is_non_interactive():
+                            should_push = True
+                        elif config and config.prompts and config.prompts.auto_push_to_remote is not None:
                             should_push = config.prompts.auto_push_to_remote
                             if should_push:
                                 console.print("\n[dim]Automatically pushing to remote (configured in prompts)[/dim]")
@@ -709,6 +740,8 @@ def complete_session(
                         if no_pr:
                             should_push = False
                             console.print("\n[dim]Skipping PR update (--no-pr flag)[/dim]")
+                        elif yes or is_non_interactive():
+                            should_push = True
                         elif config and config.prompts and config.prompts.auto_push_to_remote is not None:
                             should_push = config.prompts.auto_push_to_remote
                             if should_push:
@@ -752,6 +785,8 @@ def complete_session(
                         if no_pr:
                             should_create_pr = False
                             console.print("[dim]Skipping PR creation (--no-pr flag)[/dim]")
+                        elif yes or is_non_interactive():
+                            should_create_pr = True
                         elif config and config.prompts and config.prompts.auto_create_pr_on_complete is not None:
                             should_create_pr = config.prompts.auto_create_pr_on_complete
                             if should_create_pr:
@@ -760,7 +795,7 @@ def complete_session(
                             should_create_pr = Confirm.ask("Create a new PR/MR?", default=True)
 
                         if should_create_pr:
-                            pr_url = _create_pr_mr(session, working_dir, session_manager)
+                            pr_url = _create_pr_mr(session, working_dir, session_manager, yes=yes, pr_template_url=pr_template_url, no_retry=no_retry)
 
                             # Update issue tracker ticket with PR URL if created successfully
                             if pr_url and session.issue_key:
@@ -794,6 +829,8 @@ def complete_session(
                         if no_pr:
                             should_create_pr = False
                             console.print("[dim]Skipping PR creation (--no-pr flag)[/dim]")
+                        elif yes or is_non_interactive():
+                            should_create_pr = True
                         elif config and config.prompts and config.prompts.auto_create_pr_on_complete is not None:
                             should_create_pr = config.prompts.auto_create_pr_on_complete
                             if should_create_pr:
@@ -802,7 +839,7 @@ def complete_session(
                             should_create_pr = Confirm.ask("Create a PR/MR now?", default=True)
 
                         if should_create_pr:
-                            pr_url = _create_pr_mr(session, working_dir, session_manager)
+                            pr_url = _create_pr_mr(session, working_dir, session_manager, yes=yes, pr_template_url=pr_template_url, no_retry=no_retry)
 
                             # Update issue tracker ticket with PR URL if created successfully
                             if pr_url and session.issue_key:
@@ -836,6 +873,8 @@ def complete_session(
             if no_issue_update:
                 should_add_summary = False
                 console.print(f"\n[dim]Skipping {backend_name} update (--no-issue-update flag)[/dim]")
+            elif yes or is_non_interactive():
+                should_add_summary = True
             elif config and config.prompts and config.prompts.auto_add_issue_summary is not None:
                 should_add_summary = config.prompts.auto_add_issue_summary
                 if should_add_summary:
@@ -853,7 +892,7 @@ def complete_session(
     # Export and attach to issue tracker if requested
     if attach_to_issue:
         if session.issue_key:
-            _export_and_attach_to_issue(session, config, session.name, config_loader)
+            _export_and_attach_to_issue(session, config, session.name, config_loader, yes=yes, export_commit=export_commit)
         else:
             console.print(f"[yellow]⚠[/yellow] Cannot attach to issue tracker - session has no issue key")
 
@@ -1284,7 +1323,7 @@ _Generated by DevAIFlow_"""
         console.print(f"[yellow]⚠[/yellow] Failed to generate session summary: {e}")
 
 
-def _sync_branch_for_export(session, issue_key: str, config_loader) -> None:
+def _sync_branch_for_export(session, issue_key: str, config_loader, yes: bool = False, export_commit: Optional[bool] = None) -> None:
     """Sync branch before export for team handoff.
 
     Commits any uncommitted changes and pushes branch to remote.
@@ -1293,6 +1332,8 @@ def _sync_branch_for_export(session, issue_key: str, config_loader) -> None:
         session: Session object with project_path and branch
         issue_key: issue tracker key for commit message
         config_loader: ConfigLoader instance for accessing configuration
+        yes: Skip all confirmation prompts
+        export_commit: If set, control commit before export (True/False)
     """
     # Get active conversation for accessing conversation-specific fields
     active_conv = session.active_conversation
@@ -1319,7 +1360,15 @@ def _sync_branch_for_export(session, issue_key: str, config_loader) -> None:
             for line in status_summary.split('\n'):
                 console.print(f"  {line}")
 
-        if not Confirm.ask("\nCommit all changes before export for teammate handoff?", default=True):
+        should_export_commit = True
+        if export_commit is not None:
+            should_export_commit = export_commit
+        elif yes or is_non_interactive():
+            should_export_commit = True
+        else:
+            should_export_commit = Confirm.ask("\nCommit all changes before export for teammate handoff?", default=True)
+
+        if not should_export_commit:
             console.print(f"[dim]Skipping commit - changes will not be included in export[/dim]")
         else:
             # Create WIP commit
@@ -1347,7 +1396,9 @@ def _sync_branch_for_export(session, issue_key: str, config_loader) -> None:
 
         # Check if auto_push_to_remote is configured
         should_push = True
-        if config and config.prompts and config.prompts.auto_push_to_remote is not None:
+        if yes or is_non_interactive():
+            should_push = True
+        elif config and config.prompts and config.prompts.auto_push_to_remote is not None:
             should_push = config.prompts.auto_push_to_remote
             if should_push:
                 console.print(f"[dim]Automatically pushing to remote (configured in prompts)[/dim]")
@@ -1379,7 +1430,7 @@ def _sync_branch_for_export(session, issue_key: str, config_loader) -> None:
             console.print(f"[yellow]Your teammate may not have the latest changes[/yellow]")
 
 
-def _export_and_attach_to_issue(session, config, session_name: str, config_loader) -> None:
+def _export_and_attach_to_issue(session, config, session_name: str, config_loader, yes: bool = False, export_commit: Optional[bool] = None) -> None:
     """Export session group and attach to issue tracker (backend-agnostic).
 
     Args:
@@ -1387,6 +1438,8 @@ def _export_and_attach_to_issue(session, config, session_name: str, config_loade
         config: Configuration object
         session_name: Session group name
         config_loader: ConfigLoader instance
+        yes: Skip confirmation prompts
+        export_commit: Control commit before export
     """
     issue_key = session.issue_key
     if not issue_key:
@@ -1396,23 +1449,25 @@ def _export_and_attach_to_issue(session, config, session_name: str, config_loade
     backend = get_issue_tracker_backend(session, config)
 
     if backend == "jira":
-        _export_and_attach_to_jira(issue_key, session_name, config_loader)
+        _export_and_attach_to_jira(issue_key, session_name, config_loader, yes=yes, export_commit=export_commit)
     elif backend == "github":
         # GitHub doesn't support file attachments
         console.print(f"[yellow]ℹ[/yellow] GitHub Issues don't support file attachments")
         console.print(f"[dim]Export will be created locally instead[/dim]")
-        _export_session_locally(issue_key, session_name, config_loader)
+        _export_session_locally(issue_key, session_name, config_loader, yes=yes, export_commit=export_commit)
     else:
         console.print(f"[dim]Export/attach not implemented for backend: {backend}[/dim]")
 
 
-def _export_and_attach_to_jira(issue_key: str, session_name: str, config_loader) -> None:
+def _export_and_attach_to_jira(issue_key: str, session_name: str, config_loader, yes: bool = False, export_commit: Optional[bool] = None) -> None:
     """Export session group and attach to JIRA ticket.
 
     Args:
         issue_key: JIRA issue key
         session_name: Session group name
         config_loader: ConfigLoader instance
+        yes: Skip confirmation prompts
+        export_commit: Control commit before export
     """
     try:
         import tempfile
@@ -1439,7 +1494,7 @@ def _export_and_attach_to_jira(issue_key: str, session_name: str, config_loader)
             None
         )
         if session_with_branch:
-            _sync_branch_for_export(session_with_branch, issue_key, config_loader)
+            _sync_branch_for_export(session_with_branch, issue_key, config_loader, yes=yes, export_commit=export_commit)
 
         # Export with conversation history to temp directory
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -1513,13 +1568,15 @@ _Generated by DevAIFlow_"""
         console.print(f"[yellow]⚠[/yellow] Failed to export and attach: {e}")
 
 
-def _export_session_locally(issue_key: str, session_name: str, config_loader) -> None:
+def _export_session_locally(issue_key: str, session_name: str, config_loader, yes: bool = False, export_commit: Optional[bool] = None) -> None:
     """Export session group locally (for backends that don't support file attachments).
 
     Args:
         issue_key: Issue key
         session_name: Session group name
         config_loader: ConfigLoader instance
+        yes: Skip confirmation prompts
+        export_commit: Control commit before export
     """
     try:
         from datetime import datetime
@@ -1544,7 +1601,7 @@ def _export_session_locally(issue_key: str, session_name: str, config_loader) ->
             None
         )
         if session_with_branch:
-            _sync_branch_for_export(session_with_branch, issue_key, config_loader)
+            _sync_branch_for_export(session_with_branch, issue_key, config_loader, yes=yes, export_commit=export_commit)
 
         # Export to current directory
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -1693,6 +1750,13 @@ def _select_target_branch(working_dir: Path, config, upstream_info: Optional[dic
     Returns:
         Selected branch name or None if skip/error
     """
+    # In non-interactive mode, auto-select default branch
+    if is_non_interactive():
+        default_branch = GitUtils.get_default_branch(working_dir)
+        if default_branch:
+            return default_branch
+        return None
+
     # Check auto_select_target_branch configuration
     if config and config.prompts:
         auto_select = config.prompts.auto_select_target_branch
@@ -2192,13 +2256,16 @@ def _create_pr_mr_for_conversation(session, conversation, working_dir: Path, ses
     return pr_url
 
 
-def _create_pr_mr(session, working_dir: Path, session_manager) -> Optional[str]:
+def _create_pr_mr(session, working_dir: Path, session_manager, yes: bool = False, pr_template_url: Optional[str] = None, no_retry: bool = False) -> Optional[str]:
     """Create PR or MR based on repository type.
 
     Args:
         session: Session object
         working_dir: Working directory path
         session_manager: SessionManager instance
+        yes: Skip all confirmation prompts
+        pr_template_url: PR/MR template URL
+        no_retry: Don't retry on failure
 
     Returns:
         PR/MR URL if successful, None otherwise
@@ -2226,7 +2293,9 @@ def _create_pr_mr(session, working_dir: Path, session_manager) -> Optional[str]:
     if GitUtils.has_unpushed_commits(working_dir, current_branch):
         # Check if auto_push_to_remote is configured
         should_push = True
-        if config and config.prompts and config.prompts.auto_push_to_remote is not None:
+        if yes or is_non_interactive():
+            should_push = True
+        elif config and config.prompts and config.prompts.auto_push_to_remote is not None:
             should_push = config.prompts.auto_push_to_remote
             if should_push:
                 console.print(f"\n[dim]Automatically pushing to remote (configured in prompts)[/dim]")
@@ -2248,7 +2317,7 @@ def _create_pr_mr(session, working_dir: Path, session_manager) -> Optional[str]:
         console.print(f"[dim]Branch '{current_branch}' is up to date with remote[/dim]")
 
     # Generate PR/MR description from session data
-    description = _generate_pr_description(session, working_dir, session_manager.config_loader)
+    description = _generate_pr_description(session, working_dir, session_manager.config_loader, pr_template_url=pr_template_url)
 
     # Generate PR/MR title from session and git data
     title = _generate_pr_title(session, working_dir)
@@ -2287,6 +2356,8 @@ def _create_pr_mr(session, working_dir: Path, session_manager) -> Optional[str]:
             console.print("  - Network connectivity issues")
             console.print("  - Insufficient repository permissions")
 
+            if no_retry or is_non_interactive():
+                break
             if not Confirm.ask(f"\nWould you like to try again? (Attempt {attempt + 2}/{max_retries})", default=True):
                 break
 
@@ -2728,7 +2799,7 @@ def _try_discover_org_template(working_dir: Path) -> Optional[str]:
     return None
 
 
-def _generate_pr_description(session, working_dir: Path, config_loader: ConfigLoader, target_branch: Optional[str] = None) -> str:
+def _generate_pr_description(session, working_dir: Path, config_loader: ConfigLoader, target_branch: Optional[str] = None, pr_template_url: Optional[str] = None) -> str:
     """Generate PR/MR description from session data using AI analysis and template.
 
     Args:
@@ -2736,6 +2807,7 @@ def _generate_pr_description(session, working_dir: Path, config_loader: ConfigLo
         working_dir: Working directory path for git analysis
         config_loader: ConfigLoader instance to get template URL from config
         target_branch: Optional target branch (for story PRs targeting feature branch instead of main)
+        pr_template_url: CLI-provided template URL (overrides config)
 
     Returns:
         Formatted PR/MR description with AI-generated summary
@@ -2765,7 +2837,14 @@ def _generate_pr_description(session, working_dir: Path, config_loader: ConfigLo
         if template_content:
             template_source = "repository"
 
-    # Priority 3: User configured URL (lowest priority - for testing)
+    # Priority 3: CLI-provided template URL
+    if not template_content and pr_template_url:
+        console.print(f"[dim]Using CLI-provided template URL[/dim]")
+        template_content = _fetch_pr_template(pr_template_url)
+        if template_content:
+            template_source = "cli-provided"
+
+    # Priority 4: User configured URL (lowest priority - for testing)
     if not template_content and config and config.pr_template_url:
         console.print(f"[dim]Using user-configured template URL[/dim]")
         template_content = _fetch_pr_template(config.pr_template_url)
@@ -2774,9 +2853,9 @@ def _generate_pr_description(session, working_dir: Path, config_loader: ConfigLo
 
     # If still no template and no user config, optionally prompt (skip if auto-create enabled)
     if not template_content and config and not config.pr_template_url:
-        # Skip prompt if auto_create_pr_on_complete is enabled (automated workflow)
+        # Skip prompt if auto_create_pr_on_complete is enabled (automated workflow) or non-interactive
         auto_create = config.prompts and config.prompts.auto_create_pr_on_complete
-        if not auto_create:
+        if not auto_create and not is_non_interactive():
             console.print("\n[yellow]No PR/MR template discovered or configured.[/yellow]")
             if Confirm.ask("Would you like to configure a PR/MR template URL now?", default=True):
                 console.print(f"\n[dim]Example: https://raw.githubusercontent.com/YOUR-ORG/.github/main/.github/PULL_REQUEST_TEMPLATE.md[/dim]")
@@ -3168,12 +3247,15 @@ def _create_github_pr(session, title: str, description: str, working_dir: Path, 
             create_as_draft = False
             console.print("[dim]Creating as ready for review (configured in prompts)[/dim]")
         else:  # "prompt"
-            create_as_draft = Confirm.ask("Create PR as draft?", default=True)
+            if is_non_interactive():
+                create_as_draft = True
+            else:
+                create_as_draft = Confirm.ask("Create PR as draft?", default=True)
 
     # Detect if this is a fork and get upstream info (if not already provided)
     # prompt_for_remote=True asks user which remote is upstream if auto-detection fails
     if upstream_info is None:
-        upstream_info = GitUtils.get_fork_upstream_info(working_dir, prompt_for_remote=True)
+        upstream_info = GitUtils.get_fork_upstream_info(working_dir, prompt_for_remote=not is_non_interactive())
 
     try:
         # Build command with or without --draft flag
@@ -3350,12 +3432,15 @@ def _create_gitlab_mr(session, title: str, description: str, working_dir: Path, 
             create_as_draft = False
             console.print("[dim]Creating as ready for review (configured in prompts)[/dim]")
         else:  # "prompt"
-            create_as_draft = Confirm.ask("Create MR as draft?", default=True)
+            if is_non_interactive():
+                create_as_draft = True
+            else:
+                create_as_draft = Confirm.ask("Create MR as draft?", default=True)
 
     # Detect if this is a fork and get upstream info (if not already provided)
     # prompt_for_remote=True asks user which remote is upstream if auto-detection fails
     if upstream_info is None:
-        upstream_info = GitUtils.get_fork_upstream_info(working_dir, prompt_for_remote=True)
+        upstream_info = GitUtils.get_fork_upstream_info(working_dir, prompt_for_remote=not is_non_interactive())
 
     try:
         # Build command with or without --draft flag
@@ -3461,7 +3546,7 @@ def _create_gitlab_mr(session, title: str, description: str, working_dir: Path, 
         return None
 
 
-def _prompt_for_commit_message(auto_message: str, config) -> Optional[str]:
+def _prompt_for_commit_message(auto_message: str, config, commit_message: Optional[str] = None) -> Optional[str]:
     """Display commit message and prompt user for confirmation.
 
     This function provides a consistent commit message review flow across all session types.
@@ -3471,13 +3556,22 @@ def _prompt_for_commit_message(auto_message: str, config) -> Optional[str]:
     Args:
         auto_message: Auto-generated commit message to display
         config: Configuration object (may be None)
+        commit_message: CLI-provided commit message (skip prompt if provided)
 
     Returns:
         Final commit message to use, or None if user cancels
     """
+    # If commit message provided via CLI, use it directly
+    if commit_message is not None:
+        return commit_message
+
     # Display the suggested commit message
     console.print(f"\n[dim]Suggested commit message:[/dim]")
     console.print(f"[cyan]{auto_message}[/cyan]")
+
+    # In non-interactive mode, use auto message
+    if is_non_interactive():
+        return auto_message
 
     # Check if user wants to accept AI commit message automatically
     use_auto = True
@@ -3950,6 +4044,8 @@ def _update_issue_pr_field(session, config, pr_url: str, no_issue_update: bool =
     if no_issue_update:
         should_update = False
         console.print(f"\n[dim]Skipping {backend_name} PR update (--no-issue-update flag)[/dim]")
+    elif is_non_interactive():
+        should_update = True
     elif config and config.prompts and config.prompts.auto_update_jira_pr_url is not None:
         should_update = config.prompts.auto_update_jira_pr_url
         if should_update:

--- a/devflow/cli/commands/import_session_command.py
+++ b/devflow/cli/commands/import_session_command.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
-from devflow.cli.utils import get_status_display, require_outside_claude
+from devflow.cli.utils import get_status_display, is_non_interactive, require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.session.discovery import SessionDiscovery
 from devflow.session.manager import SessionManager
@@ -15,13 +15,15 @@ console = Console()
 
 
 @require_outside_claude
-def import_session(uuid: str, issue_key: str = None, goal: str = None) -> None:
+def import_session(uuid: str, issue_key: str = None, goal: str = None, path: str = None, yes: bool = False) -> None:
     """Import an existing Claude Code session into daf tool.
 
     Args:
         uuid: Claude session UUID to import
         issue_key: issue tracker key (will prompt if not provided)
         goal: Session goal (will prompt if not provided)
+        path: Project path (skip path prompt if provided)
+        yes: Skip confirmation prompts
     """
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)
@@ -76,7 +78,10 @@ def import_session(uuid: str, issue_key: str = None, goal: str = None) -> None:
 
     # Prompt for issue key if not provided
     if not issue_key:
-        issue_key= Prompt.ask(
+        if is_non_interactive():
+            console.print("[red]✗[/red] --jira is required in non-interactive mode")
+            return
+        issue_key = Prompt.ask(
             "[bold]issue tracker key[/bold]",
             default="",
         )
@@ -86,41 +91,57 @@ def import_session(uuid: str, issue_key: str = None, goal: str = None) -> None:
 
     # Prompt for goal if not provided
     if not goal:
-        # Use first message as default goal
-        default_goal = session_to_import.first_message or ""
-        if len(default_goal) > 80:
-            default_goal = default_goal[:80] + "..."
+        if is_non_interactive():
+            # Use first message as default goal in non-interactive mode
+            goal = session_to_import.first_message or "Imported session"
+            if len(goal) > 80:
+                goal = goal[:80] + "..."
+        else:
+            # Use first message as default goal
+            default_goal = session_to_import.first_message or ""
+            if len(default_goal) > 80:
+                default_goal = default_goal[:80] + "..."
 
-        goal = Prompt.ask(
-            "[bold]Session goal/description[/bold]",
-            default=default_goal,
-        )
-        if not goal:
-            console.print("[red]Goal is required[/red]")
-            return
+            goal = Prompt.ask(
+                "[bold]Session goal/description[/bold]",
+                default=default_goal,
+            )
+            if not goal:
+                console.print("[red]Goal is required[/red]")
+                return
 
     # Determine project path and working directory
     project_path = session_to_import.project_path
     working_directory = session_to_import.working_directory
 
-    # If project path is not absolute or doesn't exist, prompt
-    if not project_path or not Path(project_path).exists():
-        current_dir = os.getcwd()
-        use_current = Confirm.ask(
-            f"Use current directory?\n  [dim]{current_dir}[/dim]",
-            default=True,
-        )
+    # Use CLI-provided path if given
+    if path:
+        project_path = str(Path(path).expanduser().resolve())
+        working_directory = Path(project_path).name
 
-        if use_current:
+    # If project path is not absolute or doesn't exist, prompt
+    elif not project_path or not Path(project_path).exists():
+        if yes or is_non_interactive():
+            current_dir = os.getcwd()
             project_path = current_dir
             working_directory = Path(current_dir).name
         else:
-            project_path = Prompt.ask("Project path")
-            if not project_path or not project_path.strip():
-                console.print("[red]✗[/red] Project path cannot be empty")
-                return
-            project_path = project_path.strip()
-            working_directory = Path(project_path).name
+            current_dir = os.getcwd()
+            use_current = Confirm.ask(
+                f"Use current directory?\n  [dim]{current_dir}[/dim]",
+                default=True,
+            )
+
+            if use_current:
+                project_path = current_dir
+                working_directory = Path(current_dir).name
+            else:
+                project_path = Prompt.ask("Project path")
+                if not project_path or not project_path.strip():
+                    console.print("[red]✗[/red] Project path cannot be empty")
+                    return
+                project_path = project_path.strip()
+                working_directory = Path(project_path).name
 
     # Check for existing sessions with same issue key
     existing_sessions = session_manager.index.get_sessions(issue_key)
@@ -132,9 +153,10 @@ def import_session(uuid: str, issue_key: str = None, goal: str = None) -> None:
             console.print(f"      Goal: {s.goal}")
         console.print()
 
-        if not Confirm.ask(f"Create new session for {issue_key}?", default=True):
-            console.print("[dim]Import cancelled[/dim]")
-            return
+        if not yes and not is_non_interactive():
+            if not Confirm.ask(f"Create new session for {issue_key}?", default=True):
+                console.print("[dim]Import cancelled[/dim]")
+                return
 
     # Create the session
     # Sanitize session name to remove characters that cause issues in bash (#, /)

--- a/devflow/cli/commands/jira_add_comment_command.py
+++ b/devflow/cli/commands/jira_add_comment_command.py
@@ -5,7 +5,7 @@ import click
 from rich.console import Console
 from rich.prompt import Confirm
 
-from devflow.cli.utils import output_json as json_output, console_print
+from devflow.cli.utils import output_json as json_output, console_print, is_non_interactive
 from devflow.jira import JiraClient
 from devflow.jira.exceptions import (
     JiraError,
@@ -25,7 +25,8 @@ def add_comment(
     file_path: str = None,
     stdin: bool = False,
     public: bool = False,
-    output_json: bool = False
+    output_json: bool = False,
+    yes: bool = False,
 ) -> None:
     """Add a comment to a JIRA issue.
 
@@ -95,8 +96,7 @@ def add_comment(
         sys.exit(1)
 
     # Confirm if making comment public
-    if public and not output_json:
-        # Confirm making comment public
+    if public and not output_json and not yes and not is_non_interactive():
         if not Confirm.ask("Make comment PUBLIC (visible to all)?", default=False):
             console.print("Cancelled. Comment not added.")
             return

--- a/devflow/cli/commands/jira_create_commands.py
+++ b/devflow/cli/commands/jira_create_commands.py
@@ -5,7 +5,7 @@ from typing import Optional
 from rich.console import Console
 from rich.prompt import Prompt, Confirm
 
-from devflow.cli.utils import output_json as json_output, is_json_mode, console_print, require_outside_claude
+from devflow.cli.utils import output_json as json_output, is_json_mode, is_non_interactive, console_print, require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.jira.client import JiraClient
 from devflow.jira.field_mapper import JiraFieldMapper
@@ -189,7 +189,7 @@ def _get_required_custom_fields(
             continue
 
         # Case 3: Prompt user (only in interactive mode)
-        if not is_json_mode():
+        if not is_json_mode() and not is_non_interactive():
             allowed_values = field_info.get("allowed_values", [])
 
             if allowed_values:
@@ -206,7 +206,7 @@ def _get_required_custom_fields(
             else:
                 field_value = Prompt.ask(f"Enter {field_name} value")
         else:
-            # JSON mode - return error for missing required field
+            # Non-interactive or JSON mode - return error for missing required field
             json_output(
                 success=False,
                 error={
@@ -269,7 +269,7 @@ def _get_project(config, config_loader, flag_value: Optional[str]) -> Optional[s
     # Case 3: Prompt user
     console_print("\n[yellow]⚠[/yellow] No JIRA project configured.")
     console_print("[dim]Examples: PROJ, DEVOPS[/dim]")
-    project_key = Prompt.ask("[bold]Enter JIRA project key[/bold]") if not is_json_mode() else None
+    project_key = Prompt.ask("[bold]Enter JIRA project key[/bold]") if not is_json_mode() and not is_non_interactive() else None
 
     if project_key and project_key.strip():
         project_key = project_key.strip().upper()
@@ -393,7 +393,7 @@ def _get_required_system_fields(
             continue
 
         # Case 2: Prompt user (only in interactive mode)
-        if not is_json_mode():
+        if not is_json_mode() and not is_non_interactive():
             allowed_values = field_info.get("allowed_values", [])
 
             if allowed_values:
@@ -410,7 +410,7 @@ def _get_required_system_fields(
             else:
                 field_value = Prompt.ask(f"Enter {field_key} value")
         else:
-            # JSON mode - return error for missing required field
+            # Non-interactive or JSON mode - return error for missing required field
             json_output(
                 success=False,
                 error={
@@ -503,7 +503,7 @@ def _get_affected_version(config, config_loader, field_mapper, flag_value: Optio
     from devflow.utils import is_mock_mode
     if is_mock_mode():
         affected_version = "v1.0.0"
-    elif not is_json_mode():
+    elif not is_json_mode() and not is_non_interactive():
         # Use common prompt function
         from devflow.jira.utils import prompt_for_affected_version
         affected_version = prompt_for_affected_version(field_mapper)
@@ -716,7 +716,7 @@ def create_issue(
 
         # Prompt for summary if not provided
         if not summary:
-            if not is_json_mode():
+            if not is_json_mode() and not is_non_interactive():
                 summary = Prompt.ask(f"\n[bold]{type_config['label']} summary[/bold]")
                 if not summary or not summary.strip():
                     console.print("[red]✗[/red] Summary is required")

--- a/devflow/cli/commands/new_command.py
+++ b/devflow/cli/commands/new_command.py
@@ -12,7 +12,7 @@ from typing import Optional
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
-from devflow.cli.utils import check_concurrent_session, console_print, get_status_display, is_json_mode, output_json as json_output, require_outside_claude, resolve_workspace_path, scan_workspace_repositories, serialize_session, should_launch_claude_code, unified_project_selection
+from devflow.cli.utils import check_concurrent_session, console_print, get_status_display, is_json_mode, is_non_interactive, output_json as json_output, require_outside_claude, resolve_workspace_path, scan_workspace_repositories, serialize_session, should_launch_claude_code, unified_project_selection
 from devflow.config.loader import ConfigLoader
 from devflow.git.utils import GitUtils
 from devflow.jira import JiraClient
@@ -30,35 +30,6 @@ from devflow.utils.daf_agents_validation import validate_daf_agents_md
 console = Console()
 
 
-def _is_non_interactive(output_json: bool = False) -> bool:
-    """Check if running in non-interactive mode.
-
-    Non-interactive mode is enabled when:
-    - --json flag is set
-    - --non-interactive global flag is set (sets DAF_NON_INTERACTIVE=1)
-    - Running in CI environment (CI, GITHUB_ACTIONS, GITLAB_CI, etc.)
-    - DAF_NON_INTERACTIVE=1 environment variable is explicitly set
-
-    Args:
-        output_json: Whether JSON output mode is enabled
-
-    Returns:
-        True if in non-interactive mode (no user prompts allowed)
-    """
-    # Check if in JSON mode
-    if output_json:
-        return True
-
-    # Check for CI environment variables
-    ci_vars = ['CI', 'GITHUB_ACTIONS', 'GITLAB_CI', 'JENKINS_HOME', 'TRAVIS', 'CIRCLECI']
-    if any(os.getenv(var) for var in ci_vars):
-        return True
-
-    # Check for explicit non-interactive flag (set by --non-interactive or manually)
-    if os.getenv('DAF_NON_INTERACTIVE') == '1':
-        return True
-
-    return False
 
 
 
@@ -353,7 +324,7 @@ def create_new_session(
     config = config_loader.load_config()
 
     # Determine if in non-interactive mode
-    non_interactive = _is_non_interactive(output_json)
+    non_interactive = is_non_interactive(output_json)
 
     # Load or auto-detect template
     from devflow.templates.manager import TemplateManager

--- a/devflow/cli/main.py
+++ b/devflow/cli/main.py
@@ -886,8 +886,13 @@ def notes(ctx: click.Context, identifier: str, latest: bool) -> None:
 @click.option("--no-commit", is_flag=True, help="Skip git commit (don't commit changes)")
 @click.option("--no-pr", is_flag=True, help="Skip PR/MR creation (don't create pull request)")
 @click.option("--no-issue-update", is_flag=True, help="Skip issue tracker updates (don't add summary or update fields)")
+@click.option("--yes", is_flag=True, help="Skip all confirmation prompts (use defaults)")
+@click.option("--commit-message", type=str, default=None, help="Provide commit message directly (skip prompt)")
+@click.option("--export-commit/--no-export-commit", default=None, help="Control whether to commit before export")
+@click.option("--pr-template-url", type=str, default=None, help="PR/MR template URL (skip template discovery prompt)")
+@click.option("--no-retry", is_flag=True, help="Don't retry on PR/MR creation failure")
 @json_option
-def complete(ctx: click.Context, identifier: str, status: str, attach_to_issue: bool, latest: bool, no_commit: bool, no_pr: bool, no_issue_update: bool) -> None:
+def complete(ctx: click.Context, identifier: str, status: str, attach_to_issue: bool, latest: bool, no_commit: bool, no_pr: bool, no_issue_update: bool, yes: bool, commit_message: str, export_commit: bool, pr_template_url: str, no_retry: bool) -> None:
     """Mark a session as complete.
 
     IDENTIFIER can be either a session group name or issue tracker key.
@@ -897,10 +902,17 @@ def complete(ctx: click.Context, identifier: str, status: str, attach_to_issue: 
     for team handoff or documentation. The export includes conversation history.
 
     The --no-commit, --no-pr, and --no-issue-update flags skip interactive prompts for automated workflows.
+    Use --yes to skip all confirmation prompts with default values.
     """
     from devflow.cli.commands.complete_command import complete_session
 
-    complete_session(identifier, status, attach_to_issue, latest, no_commit, no_pr, no_issue_update)
+    complete_session(
+        identifier, status, attach_to_issue, latest,
+        no_commit, no_pr, no_issue_update,
+        yes=yes, commit_message=commit_message,
+        export_commit=export_commit, pr_template_url=pr_template_url,
+        no_retry=no_retry,
+    )
 
 
 @cli.command()
@@ -1293,8 +1305,10 @@ def discover(ctx: click.Context) -> None:
 @click.option("--jira", help="issue tracker key (will prompt if not provided)")
 @click.option("--goal", help="Session goal (auto-detection of file:// paths and http(s):// URLs)")
 @click.option("--goal-file", help="Explicit file path or URL for goal input (mutually exclusive with --goal)")
+@click.option("--path", "project_path", type=str, default=None, help="Project path (skip path prompt)")
+@click.option("--yes", is_flag=True, help="Skip confirmation prompts")
 @json_option
-def import_session_cmd(ctx: click.Context, uuid: str, jira: str, goal: str, goal_file: str) -> None:
+def import_session_cmd(ctx: click.Context, uuid: str, jira: str, goal: str, goal_file: str, project_path: str, yes: bool) -> None:
     """Import an existing Claude Code session that is not yet managed by daf tool.
 
     This registers a Claude Code session (created manually with 'claude --session-id')
@@ -1310,7 +1324,7 @@ def import_session_cmd(ctx: click.Context, uuid: str, jira: str, goal: str, goal
     # Process --goal and --goal-file options (mutual exclusion and resolution)
     goal = process_goal_options(goal, goal_file)
 
-    import_session(uuid, issue_key=jira, goal=goal)
+    import_session(uuid, issue_key=jira, goal=goal, path=project_path, yes=yes)
 
 
 @cli.command()
@@ -1571,7 +1585,8 @@ def jira_view(ctx: click.Context, issue_key: str, history: bool, children: bool,
 @click.option("--file", "file_path", type=click.Path(exists=True), help="Read comment from file")
 @click.option("--stdin", is_flag=True, help="Read comment from stdin")
 @click.option("--public", is_flag=True, help="Make comment public (requires confirmation)")
-def jira_add_comment(ctx: click.Context, issue_key: str, comment: str, file_path: str, stdin: bool, public: bool) -> None:
+@click.option("--yes", is_flag=True, help="Skip confirmation prompts")
+def jira_add_comment(ctx: click.Context, issue_key: str, comment: str, file_path: str, stdin: bool, public: bool, yes: bool) -> None:
     """Add a comment to a JIRA issue.
 
     By default, comments are restricted to Example Group visibility.
@@ -1593,7 +1608,7 @@ def jira_add_comment(ctx: click.Context, issue_key: str, comment: str, file_path
     from devflow.cli.commands.jira_add_comment_command import add_comment
 
     output_json = ctx.obj.get('output_json', False) if ctx.obj else False
-    add_comment(issue_key, comment, file_path, stdin, public, output_json)
+    add_comment(issue_key, comment, file_path, stdin, public, output_json, yes=yes)
 
 
 # Add dynamic jira create command with field discovery

--- a/devflow/cli/utils.py
+++ b/devflow/cli/utils.py
@@ -423,6 +423,34 @@ def is_json_mode() -> bool:
         return "--json" in sys.argv
 
 
+def is_non_interactive(output_json: bool = False) -> bool:
+    """Check if running in non-interactive mode.
+
+    Non-interactive mode is enabled when:
+    - --json flag is set (or output_json param is True)
+    - --non-interactive global flag is set (sets DAF_NON_INTERACTIVE=1)
+    - Running in CI environment (CI, GITHUB_ACTIONS, GITLAB_CI, etc.)
+    - DAF_NON_INTERACTIVE=1 environment variable is explicitly set
+
+    Args:
+        output_json: Whether JSON output mode is enabled
+
+    Returns:
+        True if in non-interactive mode (no user prompts allowed)
+    """
+    if output_json or is_json_mode():
+        return True
+
+    ci_vars = ['CI', 'GITHUB_ACTIONS', 'GITLAB_CI', 'JENKINS_HOME', 'TRAVIS', 'CIRCLECI']
+    if any(os.getenv(var) for var in ci_vars):
+        return True
+
+    if os.getenv('DAF_NON_INTERACTIVE') == '1':
+        return True
+
+    return False
+
+
 def get_status_display(status: str) -> tuple[str, str]:
     """Get status display text and color.
 

--- a/tests/test_complete_command.py
+++ b/tests/test_complete_command.py
@@ -3764,7 +3764,7 @@ def test_complete_no_duplicate_push_when_creating_pr(temp_daf_home, tmp_path, mo
     monkeypatch.setattr("devflow.cli.commands.complete_command.Confirm.ask", mock_confirm)
 
     # Mock PR creation to avoid needing gh/glab CLI
-    monkeypatch.setattr("devflow.cli.commands.complete_command._create_pr_mr", lambda s, w, sm: "https://example.com/pr/1")
+    monkeypatch.setattr("devflow.cli.commands.complete_command._create_pr_mr", lambda s, w, sm, **kwargs: "https://example.com/pr/1")
     monkeypatch.setattr("devflow.cli.commands.complete_command._get_pr_for_branch", lambda w, b: None)
 
     # Complete the session

--- a/tests/test_complete_command.py
+++ b/tests/test_complete_command.py
@@ -1542,8 +1542,11 @@ def test_complete_session_latest_with_no_sessions(temp_daf_home, monkeypatch, ca
     assert "No sessions found" in captured.out
 
 
-def test_complete_session_latest_user_cancels(temp_daf_home, monkeypatch, capsys):
+def test_complete_session_latest_user_cancels(temp_daf_home, monkeypatch, capsys, clean_ci_env):
     """Test --latest flag when user cancels confirmation."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.complete_command.is_non_interactive', lambda **kw: False)
+
     # Create a session
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)
@@ -2583,8 +2586,11 @@ def test_fetch_github_template_all_methods_fail(monkeypatch, capsys):
     assert "private repository" in captured.out
 
 
-def test_complete_ticket_creation_session_skips_git_operations(temp_daf_home, tmp_path, monkeypatch, capsys):
+def test_complete_ticket_creation_session_skips_git_operations(temp_daf_home, tmp_path, monkeypatch, capsys, clean_ci_env):
     """Test that ticket_creation sessions skip git operations (commit/PR) entirely."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.complete_command.is_non_interactive', lambda **kw: False)
+
     import subprocess
     from devflow.config.loader import ConfigLoader
     from devflow.session.manager import SessionManager
@@ -3596,8 +3602,11 @@ def test_complete_pushes_commits_after_committing_with_prompt(temp_daf_home, tmp
     assert "Commits pushed to remote" in captured.out
 
 
-def test_complete_skips_push_when_user_declines(temp_daf_home, tmp_path, monkeypatch, capsys):
+def test_complete_skips_push_when_user_declines(temp_daf_home, tmp_path, monkeypatch, capsys, clean_ci_env):
     """Test Push is skipped when user declines the prompt."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.complete_command.is_non_interactive', lambda **kw: False)
+
     import subprocess
 
     # Create a git repository with a remote
@@ -3870,8 +3879,11 @@ def test_complete_no_pr_prompt_when_no_commits(temp_daf_home, tmp_path, monkeypa
             "No new commits - skipping PR creation" in captured.out)
 
 
-def test_complete_prompts_pr_when_commit_made(temp_daf_home, tmp_path, monkeypatch, capsys):
+def test_complete_prompts_pr_when_commit_made(temp_daf_home, tmp_path, monkeypatch, capsys, clean_ci_env):
     """Test that daf complete DOES prompt for PR when a commit was made this cycle."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.complete_command.is_non_interactive', lambda **kw: False)
+
     import subprocess
     from devflow.config.loader import ConfigLoader
     from devflow.session.manager import SessionManager
@@ -3943,8 +3955,11 @@ def test_complete_prompts_pr_when_commit_made(temp_daf_home, tmp_path, monkeypat
     assert len(pr_prompts) > 0, f"Expected PR prompt after making a commit, but got no prompts"
 
 
-def test_complete_prompts_pr_when_uncommitted_changes_exist(temp_daf_home, tmp_path, monkeypatch, capsys):
+def test_complete_prompts_pr_when_uncommitted_changes_exist(temp_daf_home, tmp_path, monkeypatch, capsys, clean_ci_env):
     """Test that daf complete prompts for PR when uncommitted changes exist (even if user declines commit)."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.complete_command.is_non_interactive', lambda **kw: False)
+
     import subprocess
     from devflow.config.loader import ConfigLoader
     from devflow.session.manager import SessionManager
@@ -4182,12 +4197,15 @@ def test_complete_session_skips_pr_when_merged_remotely(temp_daf_home, tmp_path,
     assert "creation" in captured.out
 
 
-def test_complete_session_creates_pr_when_new_changes_after_merge(temp_daf_home, tmp_path, monkeypatch, capsys):
+def test_complete_session_creates_pr_when_new_changes_after_merge(temp_daf_home, tmp_path, monkeypatch, capsys, clean_ci_env):
     """Test that PR creation IS offered when there are genuine new changes after a previous merge.
 
     Scenario: PR was merged, but user made additional commits afterward.
     Even after fetching origin, the diff shows real new changes.
     """
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.complete_command.is_non_interactive', lambda **kw: False)
+
     import subprocess
 
     repo_dir = tmp_path / "test-new-after-merge"

--- a/tests/test_complete_multiproject_commit_message_display.py
+++ b/tests/test_complete_multiproject_commit_message_display.py
@@ -15,8 +15,11 @@ from devflow.session.manager import SessionManager
 from devflow.git.utils import GitUtils
 
 
-def test_multiproject_workflow_displays_commit_message_before_committing(temp_daf_home, monkeypatch, capsys):
+def test_multiproject_workflow_displays_commit_message_before_committing(temp_daf_home, monkeypatch, capsys, clean_ci_env):
     """Test that multi-project workflow (projects array) displays commit message before committing."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.complete_command.is_non_interactive', lambda **kw: False)
+
     # Create session with projects array
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)
@@ -99,8 +102,11 @@ def test_multiproject_workflow_displays_commit_message_before_committing(temp_da
     assert "Changes committed" in captured.out
 
 
-def test_multiproject_with_multiple_repos_displays_commit_messages(temp_daf_home, monkeypatch, capsys):
+def test_multiproject_with_multiple_repos_displays_commit_messages(temp_daf_home, monkeypatch, capsys, clean_ci_env):
     """Test that multi-project sessions with 2+ repos display commit message for each."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.complete_command.is_non_interactive', lambda **kw: False)
+
     # Create session with 2 projects
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)
@@ -181,8 +187,11 @@ def test_multiproject_with_multiple_repos_displays_commit_messages(temp_daf_home
     assert "Changes committed" in captured.out
 
 
-def test_multiproject_user_can_decline_and_edit_message(temp_daf_home, monkeypatch, capsys):
+def test_multiproject_user_can_decline_and_edit_message(temp_daf_home, monkeypatch, capsys, clean_ci_env):
     """Test that user can decline suggested message and provide their own in multi-project."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.complete_command.is_non_interactive', lambda **kw: False)
+
     # Create session with projects array
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)
@@ -260,8 +269,11 @@ def test_multiproject_user_can_decline_and_edit_message(temp_daf_home, monkeypat
     assert "chore: bump package versions" in commit_messages_used[0]
 
 
-def test_multiproject_allows_user_to_edit_commit_message(temp_daf_home, monkeypatch, capsys):
+def test_multiproject_allows_user_to_edit_commit_message(temp_daf_home, monkeypatch, capsys, clean_ci_env):
     """Test that user can edit commit message in multi-project sessions."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.complete_command.is_non_interactive', lambda **kw: False)
+
     # Create session with projects array
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)
@@ -334,8 +346,11 @@ def test_multiproject_allows_user_to_edit_commit_message(temp_daf_home, monkeypa
     assert "🤖 Generated with [Claude Code]" in commit_messages_used[0]
 
 
-def test_single_project_session_still_works_correctly(temp_daf_home, monkeypatch, capsys):
+def test_single_project_session_still_works_correctly(temp_daf_home, monkeypatch, capsys, clean_ci_env):
     """Regression test: Verify single-project sessions continue to work correctly."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.complete_command.is_non_interactive', lambda **kw: False)
+
     # Create single-project session
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)

--- a/tests/test_import_session_command.py
+++ b/tests/test_import_session_command.py
@@ -108,8 +108,11 @@ def test_import_session_with_jira_and_goal(temp_daf_home, monkeypatch, capsys, m
     assert "Imported session for PROJ-999" in captured.out
 
 
-def test_import_session_prompts_for_jira(temp_daf_home, monkeypatch, capsys, mock_discovered_session):
+def test_import_session_prompts_for_jira(temp_daf_home, monkeypatch, capsys, mock_discovered_session, clean_ci_env):
     """Test that import prompts for issue key if not provided."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.import_session_command.is_non_interactive', lambda **kw: False)
+
     # Mock discovery
     mock_discovery = Mock()
     mock_discovery.discover_sessions.return_value = [mock_discovered_session]
@@ -137,8 +140,11 @@ def test_import_session_prompts_for_jira(temp_daf_home, monkeypatch, capsys, moc
     assert sessions[0].issue_key == "PROJ-888"
 
 
-def test_import_session_empty_issue_key(temp_daf_home, monkeypatch, capsys, mock_discovered_session):
+def test_import_session_empty_issue_key(temp_daf_home, monkeypatch, capsys, mock_discovered_session, clean_ci_env):
     """Test import fails when issue key is empty."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.import_session_command.is_non_interactive', lambda **kw: False)
+
     # Mock discovery
     mock_discovery = Mock()
     mock_discovery.discover_sessions.return_value = [mock_discovered_session]
@@ -157,8 +163,11 @@ def test_import_session_empty_issue_key(temp_daf_home, monkeypatch, capsys, mock
     assert "issue key is required" in captured.out
 
 
-def test_import_session_empty_goal(temp_daf_home, monkeypatch, capsys, mock_discovered_session):
+def test_import_session_empty_goal(temp_daf_home, monkeypatch, capsys, mock_discovered_session, clean_ci_env):
     """Test import fails when goal is empty."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.import_session_command.is_non_interactive', lambda **kw: False)
+
     # Mock discovery
     mock_discovery = Mock()
     mock_discovery.discover_sessions.return_value = [mock_discovered_session]
@@ -211,8 +220,11 @@ def test_import_session_long_first_message(temp_daf_home, monkeypatch, capsys):
     assert "..." in captured.out  # Truncation indicator
 
 
-def test_import_session_missing_project_path(temp_daf_home, monkeypatch, capsys):
+def test_import_session_missing_project_path(temp_daf_home, monkeypatch, capsys, clean_ci_env):
     """Test import prompts for project path if missing."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.import_session_command.is_non_interactive', lambda **kw: False)
+
     from devflow.session.discovery import DiscoveredSession
 
     discovered = DiscoveredSession(
@@ -249,8 +261,11 @@ def test_import_session_missing_project_path(temp_daf_home, monkeypatch, capsys)
     assert sessions[0].active_conversation.project_path is not None
 
 
-def test_import_session_custom_project_path(temp_daf_home, monkeypatch, capsys):
+def test_import_session_custom_project_path(temp_daf_home, monkeypatch, capsys, clean_ci_env):
     """Test import with custom project path."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.import_session_command.is_non_interactive', lambda **kw: False)
+
     from devflow.session.discovery import DiscoveredSession
 
     discovered = DiscoveredSession(
@@ -341,8 +356,11 @@ def test_import_session_with_existing_sessions(temp_daf_home, monkeypatch, capsy
     assert "Found 1 existing session" in captured.out
 
 
-def test_import_session_cancel_with_existing(temp_daf_home, monkeypatch, capsys, mock_discovered_session):
+def test_import_session_cancel_with_existing(temp_daf_home, monkeypatch, capsys, mock_discovered_session, clean_ci_env):
     """Test cancelling import when other sessions exist."""
+    # Ensure interactive mode for this test
+    monkeypatch.setattr('devflow.cli.commands.import_session_command.is_non_interactive', lambda **kw: False)
+
     # Create existing session
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)

--- a/tests/test_jira_add_comment_command.py
+++ b/tests/test_jira_add_comment_command.py
@@ -86,9 +86,10 @@ def test_add_comment_public_flag(monkeypatch):
     mock_client.add_comment.assert_called_once_with("PROJ-12345", "Public comment", public=True)
 
 
-def test_add_comment_public_flag_cancelled(monkeypatch):
+def test_add_comment_public_flag_cancelled(monkeypatch, clean_ci_env):
     """Test cancelling public comment."""
     mock_client = MagicMock()
+    monkeypatch.setattr('devflow.cli.commands.jira_add_comment_command.is_non_interactive', lambda **kw: False)
 
     with patch('devflow.cli.commands.jira_add_comment_command.JiraClient', return_value=mock_client):
         with patch('devflow.cli.commands.jira_add_comment_command.Confirm.ask', return_value=False):

--- a/tests/test_jira_create_commands.py
+++ b/tests/test_jira_create_commands.py
@@ -173,10 +173,11 @@ class TestGetProject:
 
         assert result == "PROJ"
 
-    def test_prompt_user_when_no_flag_or_config(self, mock_config, mock_config_loader, monkeypatch):
+    def test_prompt_user_when_no_flag_or_config(self, mock_config, mock_config_loader, monkeypatch, clean_ci_env):
         """Test that user is prompted when no flag or config value."""
         mock_config.jira.project = None
         monkeypatch.setattr('devflow.cli.commands.jira_create_commands.is_json_mode', lambda: False)
+        monkeypatch.setattr('devflow.cli.commands.jira_create_commands.is_non_interactive', lambda **kw: False)
         monkeypatch.setattr('devflow.cli.commands.jira_create_commands.Prompt.ask', lambda *args: "NEWPROJ")
 
         result = _get_project(mock_config, mock_config_loader, None)
@@ -198,6 +199,13 @@ class TestGetProject:
 
 class TestGetAffectedVersion:
     """Tests for _get_affected_version function."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_ci_env(self, monkeypatch):
+        """Ensure is_non_interactive() returns False so prompts are shown."""
+        for var in ['CI', 'GITHUB_ACTIONS', 'GITLAB_CI', 'JENKINS_HOME', 'TRAVIS', 'CIRCLECI', 'DAF_NON_INTERACTIVE']:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr('devflow.cli.commands.jira_create_commands.is_non_interactive', lambda **kw: False)
 
     def test_use_flag_value_when_provided(self, mock_config, mock_config_loader, mock_field_mapper, monkeypatch):
         """Test that flag value is used when provided."""
@@ -699,9 +707,10 @@ class TestCreateIssue:
 class TestCreateBug:
     """Tests for creating bugs using create_issue function."""
 
-    def test_create_bug_prompts_for_summary(self, mock_config, mock_config_loader, mock_jira_client, monkeypatch):
+    def test_create_bug_prompts_for_summary(self, mock_config, mock_config_loader, mock_jira_client, monkeypatch, clean_ci_env):
         """Test that create_issue for bugs prompts for summary when not provided."""
         monkeypatch.setenv("JIRA_API_TOKEN", "test-token")
+        monkeypatch.setattr('devflow.cli.commands.jira_create_commands.is_non_interactive', lambda **kw: False)
         monkeypatch.setattr('devflow.cli.commands.jira_create_commands.Prompt.ask', lambda *args: "Prompted bug summary")
 
         with patch('devflow.cli.commands.jira_create_commands.ConfigLoader', return_value=mock_config_loader):

--- a/tests/test_non_interactive_params.py
+++ b/tests/test_non_interactive_params.py
@@ -26,28 +26,6 @@ sys.path.insert(0, str(Path(__file__).parent))
 from conftest import clear_all_ci_env_vars, restore_env_vars
 
 
-# List of all CI environment variables that trigger non-interactive mode
-CI_ENV_VARS = ['CI', 'GITHUB_ACTIONS', 'GITLAB_CI', 'JENKINS_HOME', 'TRAVIS', 'CIRCLECI', 'DAF_NON_INTERACTIVE']
-
-
-def clear_all_ci_env_vars():
-    """Clear all CI-related environment variables and return their original values."""
-    original_values = {}
-    for var in CI_ENV_VARS:
-        original_values[var] = os.environ.get(var)
-        os.environ.pop(var, None)
-    return original_values
-
-
-def restore_env_vars(original_values):
-    """Restore environment variables to their original values."""
-    for var, value in original_values.items():
-        if value is not None:
-            os.environ[var] = value
-        else:
-            os.environ.pop(var, None)
-
-
 class TestNonInteractiveFlag:
     """Test the global --non-interactive flag."""
 

--- a/tests/test_non_interactive_params.py
+++ b/tests/test_non_interactive_params.py
@@ -26,6 +26,28 @@ sys.path.insert(0, str(Path(__file__).parent))
 from conftest import clear_all_ci_env_vars, restore_env_vars
 
 
+# List of all CI environment variables that trigger non-interactive mode
+CI_ENV_VARS = ['CI', 'GITHUB_ACTIONS', 'GITLAB_CI', 'JENKINS_HOME', 'TRAVIS', 'CIRCLECI', 'DAF_NON_INTERACTIVE']
+
+
+def clear_all_ci_env_vars():
+    """Clear all CI-related environment variables and return their original values."""
+    original_values = {}
+    for var in CI_ENV_VARS:
+        original_values[var] = os.environ.get(var)
+        os.environ.pop(var, None)
+    return original_values
+
+
+def restore_env_vars(original_values):
+    """Restore environment variables to their original values."""
+    for var, value in original_values.items():
+        if value is not None:
+            os.environ[var] = value
+        else:
+            os.environ.pop(var, None)
+
+
 class TestNonInteractiveFlag:
     """Test the global --non-interactive flag."""
 

--- a/tests/test_non_interactive_params.py
+++ b/tests/test_non_interactive_params.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch, call
 from click.testing import CliRunner
 
 from devflow.cli.main import cli
-from devflow.cli.commands.new_command import _is_non_interactive
+from devflow.cli.utils import is_non_interactive as _is_non_interactive
 
 # Import helper functions from conftest (functions are in module scope)
 import sys
@@ -392,3 +392,212 @@ class TestSyncStrategyChoices:
             ])
             # Help should succeed
             assert result.exit_code == 0
+
+
+# ===== Phase 2: daf complete non-interactive params =====
+
+class TestDafCompleteNonInteractiveParams:
+    """Test daf complete command non-interactive parameters."""
+
+    def test_yes_flag(self):
+        """Test --yes flag appears in help."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['complete', '--help'])
+        assert result.exit_code == 0
+        assert '--yes' in result.output
+
+    def test_commit_message_parameter(self):
+        """Test --commit-message parameter appears in help."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['complete', '--help'])
+        assert result.exit_code == 0
+        assert '--commit-message' in result.output
+
+    def test_export_commit_flags(self):
+        """Test --export-commit and --no-export-commit flags."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['complete', '--help'])
+        assert result.exit_code == 0
+        assert '--export-commit' in result.output
+        assert '--no-export-commit' in result.output
+
+    def test_pr_template_url_parameter(self):
+        """Test --pr-template-url parameter appears in help."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['complete', '--help'])
+        assert result.exit_code == 0
+        assert '--pr-template-url' in result.output
+
+    def test_no_retry_flag(self):
+        """Test --no-retry flag appears in help."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['complete', '--help'])
+        assert result.exit_code == 0
+        assert '--no-retry' in result.output
+
+    def test_existing_flags_still_present(self):
+        """Test existing flags are preserved."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['complete', '--help'])
+        assert result.exit_code == 0
+        assert '--no-commit' in result.output
+        assert '--no-pr' in result.output
+        assert '--no-issue-update' in result.output
+        assert '--latest' in result.output
+        assert '--attach-to-issue' in result.output
+
+
+class TestIsNonInteractiveShared:
+    """Test the shared is_non_interactive() from utils."""
+
+    def test_shared_function_import(self):
+        """Test that is_non_interactive can be imported from utils."""
+        from devflow.cli.utils import is_non_interactive
+        assert callable(is_non_interactive)
+
+    def test_shared_function_detects_env_var(self):
+        """Test shared function detects DAF_NON_INTERACTIVE env var."""
+        from devflow.cli.utils import is_non_interactive
+        original_values = clear_all_ci_env_vars()
+        try:
+            assert not is_non_interactive()
+            os.environ['DAF_NON_INTERACTIVE'] = '1'
+            assert is_non_interactive()
+        finally:
+            restore_env_vars(original_values)
+
+    def test_shared_function_detects_json_param(self):
+        """Test shared function detects output_json parameter."""
+        from devflow.cli.utils import is_non_interactive
+        original_values = clear_all_ci_env_vars()
+        try:
+            assert is_non_interactive(output_json=True)
+            assert not is_non_interactive(output_json=False)
+        finally:
+            restore_env_vars(original_values)
+
+
+# ===== Phase 3: JIRA operations non-interactive =====
+
+class TestDafJiraAddCommentNonInteractive:
+    """Test daf jira add-comment non-interactive parameters."""
+
+    def test_yes_flag(self):
+        """Test --yes flag appears in add-comment help."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['jira', 'add-comment', '--help'])
+        assert result.exit_code == 0
+        assert '--yes' in result.output
+
+    def test_existing_flags_preserved(self):
+        """Test existing flags are still present."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['jira', 'add-comment', '--help'])
+        assert result.exit_code == 0
+        assert '--file' in result.output
+        assert '--stdin' in result.output
+        assert '--public' in result.output
+
+
+# ===== Phase 4: daf import-session non-interactive =====
+
+class TestDafImportSessionNonInteractive:
+    """Test daf import-session non-interactive parameters."""
+
+    def test_path_parameter(self):
+        """Test --path parameter appears in import-session help."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['import-session', '--help'])
+        assert result.exit_code == 0
+        assert '--path' in result.output
+
+    def test_yes_flag(self):
+        """Test --yes flag appears in import-session help."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['import-session', '--help'])
+        assert result.exit_code == 0
+        assert '--yes' in result.output
+
+    def test_existing_flags_preserved(self):
+        """Test existing flags are still present."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['import-session', '--help'])
+        assert result.exit_code == 0
+        assert '--jira' in result.output
+        assert '--goal' in result.output
+        assert '--goal-file' in result.output
+
+
+class TestCompleteCommandSignature:
+    """Test complete_session function accepts new parameters."""
+
+    def test_function_accepts_new_params(self):
+        """Test that complete_session accepts all new parameters."""
+        import inspect
+        from devflow.cli.commands.complete_command import complete_session
+
+        sig = inspect.signature(complete_session)
+        param_names = list(sig.parameters.keys())
+
+        assert 'yes' in param_names
+        assert 'commit_message' in param_names
+        assert 'export_commit' in param_names
+        assert 'pr_template_url' in param_names
+        assert 'no_retry' in param_names
+
+    def test_new_params_are_optional(self):
+        """Test that all new parameters have defaults."""
+        import inspect
+        from devflow.cli.commands.complete_command import complete_session
+
+        sig = inspect.signature(complete_session)
+        for param_name in ['yes', 'commit_message', 'export_commit', 'pr_template_url', 'no_retry']:
+            param = sig.parameters[param_name]
+            assert param.default is not inspect.Parameter.empty, f"{param_name} should have a default"
+
+
+class TestImportSessionCommandSignature:
+    """Test import_session function accepts new parameters."""
+
+    def test_function_accepts_new_params(self):
+        """Test that import_session accepts path and yes parameters."""
+        import inspect
+        from devflow.cli.commands.import_session_command import import_session
+
+        sig = inspect.signature(import_session)
+        param_names = list(sig.parameters.keys())
+
+        assert 'path' in param_names
+        assert 'yes' in param_names
+
+    def test_new_params_are_optional(self):
+        """Test that all new parameters have defaults."""
+        import inspect
+        from devflow.cli.commands.import_session_command import import_session
+
+        sig = inspect.signature(import_session)
+        for param_name in ['path', 'yes']:
+            param = sig.parameters[param_name]
+            assert param.default is not inspect.Parameter.empty, f"{param_name} should have a default"
+
+
+class TestJiraAddCommentSignature:
+    """Test add_comment function accepts new parameters."""
+
+    def test_function_accepts_yes_param(self):
+        """Test that add_comment accepts yes parameter."""
+        import inspect
+        from devflow.cli.commands.jira_add_comment_command import add_comment
+
+        sig = inspect.signature(add_comment)
+        param_names = list(sig.parameters.keys())
+
+        assert 'yes' in param_names
+
+    def test_yes_param_defaults_false(self):
+        """Test that yes parameter defaults to False."""
+        import inspect
+        from devflow.cli.commands.jira_add_comment_command import add_comment
+
+        sig = inspect.signature(add_comment)
+        assert sig.parameters['yes'].default is False

--- a/tests/test_pr_target_branch.py
+++ b/tests/test_pr_target_branch.py
@@ -474,7 +474,7 @@ def test_select_target_branch_filters_current_branch(monkeypatch, tmp_path):
     assert result == "main"
 
 
-def test_select_target_branch_filters_current_when_default(monkeypatch, tmp_path):
+def test_select_target_branch_filters_current_when_default(monkeypatch, tmp_path, clean_ci_env):
     """Test filtering works when current branch IS the default branch."""
     def mock_list_remote_branches(path, remote):
         return ["main", "develop", "release/2.5"]
@@ -482,6 +482,7 @@ def test_select_target_branch_filters_current_when_default(monkeypatch, tmp_path
     def mock_get_default_branch(path):
         return "main"
 
+    monkeypatch.setattr("devflow.cli.commands.complete_command.is_non_interactive", lambda **kw: False)
     monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.list_remote_branches", mock_list_remote_branches)
     monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.get_default_branch", mock_get_default_branch)
 
@@ -525,7 +526,7 @@ def test_select_target_branch_empty_after_filtering(monkeypatch, tmp_path):
     assert result is None
 
 
-def test_select_target_branch_fork_filters_current(monkeypatch, tmp_path):
+def test_select_target_branch_fork_filters_current(monkeypatch, tmp_path, clean_ci_env):
     """Test fork scenario - current local branch filtered from both upstream and origin branches."""
     def mock_list_remote_branches(path, remote):
         # Return different branches for different remotes
@@ -541,6 +542,7 @@ def test_select_target_branch_fork_filters_current(monkeypatch, tmp_path):
     def mock_get_remote_name_for_url(path, url):
         return "upstream"
 
+    monkeypatch.setattr("devflow.cli.commands.complete_command.is_non_interactive", lambda **kw: False)
     monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.list_remote_branches", mock_list_remote_branches)
     monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.get_default_branch", mock_get_default_branch)
     monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.get_remote_name_for_url", mock_get_remote_name_for_url)
@@ -678,7 +680,7 @@ def test_create_gitlab_mr_strips_remote_prefix_from_target_branch(monkeypatch, t
     assert "upstream/develop" not in glab_cmd
 
 
-def test_select_target_branch_shows_both_upstream_and_origin(monkeypatch, tmp_path):
+def test_select_target_branch_shows_both_upstream_and_origin(monkeypatch, tmp_path, clean_ci_env):
     """Test that branch selection shows branches from both upstream and origin when upstream exists."""
 
     # Mock git utilities
@@ -699,6 +701,7 @@ def test_select_target_branch_shows_both_upstream_and_origin(monkeypatch, tmp_pa
             return "upstream"
         return None
 
+    monkeypatch.setattr("devflow.cli.commands.complete_command.is_non_interactive", lambda **kw: False)
     monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.list_remote_branches", mock_list_remote_branches)
     monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.get_default_branch", mock_get_default_branch)
     monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.get_remote_name_for_url", mock_get_remote_name_for_url)
@@ -738,7 +741,7 @@ def test_select_target_branch_shows_both_upstream_and_origin(monkeypatch, tmp_pa
     assert "/" in result  # Should have remote prefix when multiple remotes
 
 
-def test_select_target_branch_origin_only_no_prefix(monkeypatch, tmp_path):
+def test_select_target_branch_origin_only_no_prefix(monkeypatch, tmp_path, clean_ci_env):
     """Test that branch selection shows branches without prefix when only origin exists (no upstream)."""
 
     # Mock git utilities
@@ -751,6 +754,7 @@ def test_select_target_branch_origin_only_no_prefix(monkeypatch, tmp_path):
     def mock_get_default_branch(path):
         return "main"
 
+    monkeypatch.setattr("devflow.cli.commands.complete_command.is_non_interactive", lambda **kw: False)
     monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.list_remote_branches", mock_list_remote_branches)
     monkeypatch.setattr("devflow.cli.commands.complete_command.GitUtils.get_default_branch", mock_get_default_branch)
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -94,7 +94,7 @@ def test_session_workspace_name_optional():
     assert session.workspace_name is None
 
 
-def test_get_active_session_for_project_with_workspace():
+def test_get_active_session_for_project_with_workspace(temp_daf_home):
     """Test workspace-aware concurrent session detection."""
     from devflow.config.loader import ConfigLoader
     from devflow.session.manager import SessionManager
@@ -157,7 +157,7 @@ def test_get_active_session_for_project_with_workspace():
     manager.delete_session(f"workspace-session-2-{unique_suffix}")
 
 
-def test_get_active_session_for_project_no_workspace():
+def test_get_active_session_for_project_no_workspace(temp_daf_home):
     """Test backward compatibility - workspace_name=None still works."""
     from devflow.config.loader import ConfigLoader
     from devflow.session.manager import SessionManager
@@ -196,7 +196,7 @@ def test_get_active_session_for_project_no_workspace():
     manager.delete_session(f"legacy-session-{unique_suffix}")
 
 
-def test_workspace_persistence_in_session():
+def test_workspace_persistence_in_session(temp_daf_home):
     """Test that workspace_name is persisted in session metadata."""
     from devflow.config.loader import ConfigLoader
     from devflow.session.manager import SessionManager


### PR DESCRIPTION
Jira Issue: <!-- This PR does not need a corresponding Jira item. -->

## Description

Add CLI parameters for all interactive prompts in DevAIFlow commands, enabling full automation and CI/CD pipeline integration.

**Phase 1 - Session Creation/Opening:**
- `daf new`: `--create-branch`, `--source-branch`, `--on-branch-exists`, `--allow-uncommitted`, `--sync-upstream`, `--auto-workspace`, `--session-index`
- `daf open`: All Phase 1 params plus `--sync-strategy`
- `daf jira new`, `daf git new`, `daf investigate`: `--projects`, `--temp-clone`
- Global `--non-interactive` flag with CI environment auto-detection

**Phase 2 - Session Completion:**
- `daf complete`: `--yes`, `--commit-message`, `--export-commit/--no-export-commit`, `--pr-template-url`, `--no-retry`
- All 28 prompts now respect `--yes` flag and `is_non_interactive()`

**Phase 3 - JIRA Operations:**
- `daf jira create`: `is_non_interactive()` check on all field prompts (errors on missing required fields)
- `daf jira add-comment`: `--yes` flag to skip public confirmation

**Phase 4 - Management Commands:**
- `daf import-session`: `--path` and `--yes` flags
- `daf delete` and `daf import` already had `--force`

**Additional fixes:**
- Moved `is_non_interactive()` to `devflow/cli/utils.py` as shared utility
- Fixed TUI crash when Select widget receives boolean `False` value (`Select.NULL` vs `Select.BLANK`)
- Fixed flaky workspace test with session isolation fixture
- Added `.wolf/` and `.ai-guardian/` to `.gitignore`

Assisted-by: Claude Code (Anthropic)

## Testing

### Steps to test
1. Pull down the PR
2. Run `pytest tests/test_non_interactive_params.py -v` — 52 tests covering all new parameters
3. Run `pytest` — full suite (3437 passed)
4. Test non-interactive mode: `daf --non-interactive complete --latest --yes --no-pr`
5. Test CI detection: `CI=1 daf complete --latest --yes`

### Scenarios tested
- All new CLI parameters appear in `--help` output
- Function signatures accept new parameters with correct defaults
- `is_non_interactive()` detects CI env vars, `--json`, and `DAF_NON_INTERACTIVE`
- Backward compatibility: all commands work without new parameters
- Existing `--no-commit`, `--no-pr`, `--no-issue-update` flags preserved

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed:

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>