### PR TITLE
itdove/devaiflow#407: OpenCode agent: Invalid session ID error when launching new sessions

### DIFF
--- a/devflow/agent/opencode_agent.py
+++ b/devflow/agent/opencode_agent.py
@@ -138,7 +138,7 @@ class OpenCodeAgent(AgentInterface):
         else:
             cmd = ["opencode", "--prompt", initial_prompt]
 
-        if session_id:
+        if session_id and session_id.startswith("ses"):
             cmd.extend(["--session", session_id])
 
         if model_provider_profile:

--- a/tests/test_opencode_agent.py
+++ b/tests/test_opencode_agent.py
@@ -84,7 +84,7 @@ class TestOpenCodeAgentLaunch:
         result = agent.launch_with_prompt(
             project_path="/home/user/project",
             initial_prompt="Fix the login bug",
-            session_id="test-session-id",
+            session_id="ses_abc123",
         )
 
         mock_require.assert_called_once()
@@ -94,7 +94,7 @@ class TestOpenCodeAgentLaunch:
         assert "--prompt" in cmd
         assert "Fix the login bug" in cmd
         assert "--session" in cmd
-        assert "test-session-id" in cmd
+        assert "ses_abc123" in cmd
         assert "run" not in cmd
         assert call_args[1]["cwd"] == "/home/user/project"
         assert result == mock_process
@@ -109,7 +109,7 @@ class TestOpenCodeAgentLaunch:
         agent.launch_with_prompt(
             project_path="/home/user/project",
             initial_prompt="Fix the login bug",
-            session_id="test-session-id",
+            session_id="ses_headless123",
             headless=True,
         )
 
@@ -158,6 +158,59 @@ class TestOpenCodeAgentLaunch:
         cmd = call_args[0][0]
         assert cmd[1] == "run"
         assert "--dangerously-skip-permissions" in cmd
+
+    @patch("devflow.agent.opencode_agent.require_tool")
+    @patch("subprocess.Popen")
+    def test_launch_with_prompt_skips_uuid_session_id(self, mock_popen, mock_require):
+        """Test that DevAIFlow UUID session IDs are NOT passed to --session."""
+        agent = OpenCodeAgent()
+        mock_popen.return_value = Mock()
+
+        agent.launch_with_prompt(
+            project_path="/home/user/project",
+            initial_prompt="Fix bug",
+            session_id="29798353-1758-43a9-b95a-05bac425c3f3",
+        )
+
+        call_args = mock_popen.call_args
+        cmd = call_args[0][0]
+        assert "--session" not in cmd
+        assert "--prompt" in cmd
+
+    @patch("devflow.agent.opencode_agent.require_tool")
+    @patch("subprocess.Popen")
+    def test_launch_with_prompt_passes_ses_prefixed_session_id(self, mock_popen, mock_require):
+        """Test that OpenCode session IDs (ses-prefixed) ARE passed to --session."""
+        agent = OpenCodeAgent()
+        mock_popen.return_value = Mock()
+
+        agent.launch_with_prompt(
+            project_path="/home/user/project",
+            initial_prompt="Fix bug",
+            session_id="ses_real_opencode_id",
+        )
+
+        call_args = mock_popen.call_args
+        cmd = call_args[0][0]
+        assert "--session" in cmd
+        assert "ses_real_opencode_id" in cmd
+
+    @patch("devflow.agent.opencode_agent.require_tool")
+    @patch("subprocess.Popen")
+    def test_launch_with_prompt_empty_session_id(self, mock_popen, mock_require):
+        """Test that empty session ID does not add --session flag."""
+        agent = OpenCodeAgent()
+        mock_popen.return_value = Mock()
+
+        agent.launch_with_prompt(
+            project_path="/home/user/project",
+            initial_prompt="Fix bug",
+            session_id="",
+        )
+
+        call_args = mock_popen.call_args
+        cmd = call_args[0][0]
+        assert "--session" not in cmd
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")


### PR DESCRIPTION
Jira Issue: <https://github.com/itdove/devaiflow/issues/407>

## Description

When DevAIFlow launches an OpenCode agent session, it passes its own UUID-format session ID (e.g., `29798353-1758-43a9-b95a-05bac425c3f3`) via the `--session` flag. OpenCode only recognizes its own `ses`-prefixed session IDs, causing an "invalid session ID" error on new session launches.

This fix adds a prefix check so only OpenCode-native session IDs (starting with `"ses"`) are passed to the `--session` flag. DevAIFlow UUID session IDs are silently skipped, allowing OpenCode to create a fresh session instead of erroring.

**Changes:**
- `devflow/agent/opencode_agent.py`: Add `session_id.startswith("ses")` guard before passing `--session`
- `tests/test_opencode_agent.py`: Update existing tests to use `ses`-prefixed IDs; add tests for UUID filtering, `ses`-prefix passing, and empty session ID

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run unit tests: `pytest tests/test_opencode_agent.py -v`
3. Launch a DevAIFlow session with OpenCode agent (`daf open --agent opencode`) — verify no "invalid session ID" error
4. Resume an existing OpenCode session with a `ses`-prefixed ID — verify `--session` flag is passed correctly

### Scenarios tested
- UUID-format session ID (`29798353-...`) is filtered out, `--session` flag not added
- `ses`-prefixed session ID (`ses_abc123`) is passed through to `--session`
- Empty string session ID does not add `--session` flag
- Headless mode with `ses`-prefixed session ID works correctly

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: