### PR TITLE
fix: include token usage data in daf list --json output (#400)

### DIFF
--- a/devflow/cli/commands/list_command.py
+++ b/devflow/cli/commands/list_command.py
@@ -2,18 +2,92 @@
 
 import os
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from rich.console import Console
 from rich.table import Table
 
 from devflow.agent import create_agent_client
-from devflow.cli.utils import get_active_conversation, get_status_display, output_json as json_output, serialize_sessions
+from devflow.cli.utils import get_active_conversation, get_status_display, output_json as json_output, serialize_session, serialize_sessions
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
 from devflow.utils.time_parser import parse_time_expression
 
 console = Console()
+
+
+def _compute_session_token_usage(session, agent) -> Optional[Dict[str, Any]]:
+    """Compute aggregated token usage for a session across all conversations.
+
+    Args:
+        session: Session object with conversations
+        agent: Agent client instance for extracting token usage
+
+    Returns:
+        Dict with token usage data if any tokens found, None otherwise.
+        Keys: total_tokens, input_tokens, output_tokens,
+              cache_creation_input_tokens, cache_read_input_tokens
+    """
+    if not session.conversations:
+        return None
+
+    total_input = 0
+    total_output = 0
+    total_cache_creation = 0
+    total_cache_read = 0
+    found_any = False
+
+    for working_dir, conversation in session.conversations.items():
+        # Handle both Conversation (new format) and ConversationContext (old format)
+        conv = conversation.active_session if hasattr(conversation, 'active_session') else conversation
+        if conv and conv.project_path and conv.ai_agent_session_id:
+            try:
+                token_usage = agent.extract_token_usage(
+                    conv.ai_agent_session_id,
+                    conv.project_path
+                )
+                if token_usage:
+                    found_any = True
+                    total_input += token_usage.get("input_tokens", 0)
+                    total_output += token_usage.get("output_tokens", 0)
+                    total_cache_creation += token_usage.get("cache_creation_input_tokens", 0)
+                    total_cache_read += token_usage.get("cache_read_input_tokens", 0)
+            except Exception:
+                pass  # Silently ignore errors for this conversation
+
+    if not found_any:
+        return None
+
+    return {
+        "total_tokens": total_input + total_output,
+        "input_tokens": total_input,
+        "output_tokens": total_output,
+        "cache_creation_input_tokens": total_cache_creation,
+        "cache_read_input_tokens": total_cache_read,
+    }
+
+
+def _serialize_sessions_with_tokens(
+    sessions: list,
+    agent_backend: str,
+) -> List[Dict[str, Any]]:
+    """Serialize sessions with token usage data included.
+
+    Args:
+        sessions: List of Session objects to serialize
+        agent_backend: Agent backend name for token extraction
+
+    Returns:
+        List of JSON-compatible dicts with token_usage field added
+    """
+    agent = create_agent_client(agent_backend)
+    result = []
+    for session in sessions:
+        session_dict = serialize_session(session)
+        token_usage = _compute_session_token_usage(session, agent)
+        session_dict["token_usage"] = token_usage
+        result.append(session_dict)
+    return result
 
 
 def _display_page(
@@ -149,19 +223,9 @@ def _display_page(
         total_tokens = 0
         if session.conversations:
             agent = create_agent_client(agent_backend)
-            for working_dir, conversation in session.conversations.items():
-                # Handle both Conversation (new format) and ConversationContext (old format)
-                conv = conversation.active_session if hasattr(conversation, 'active_session') else conversation
-                if conv and conv.project_path and conv.ai_agent_session_id:
-                    try:
-                        token_usage = agent.extract_token_usage(
-                            conv.ai_agent_session_id,
-                            conv.project_path
-                        )
-                        if token_usage:
-                            total_tokens += token_usage.get("total_tokens", 0)
-                    except Exception:
-                        pass  # Silently ignore errors for this conversation
+            usage = _compute_session_token_usage(session, agent)
+            if usage:
+                total_tokens = usage.get("total_tokens", 0)
 
             # Format total tokens
             if total_tokens > 0:
@@ -349,11 +413,15 @@ def list_sessions(
             end_idx = limit
             sessions_to_output = sessions[start_idx:end_idx]
 
-        # Output JSON
+        # Get agent backend for token extraction
+        config = config_loader.load_config()
+        agent_backend = config.agent_backend if config else "claude"
+
+        # Output JSON with token usage data
         json_output(
             success=True,
             data={
-                "sessions": serialize_sessions(sessions_to_output),
+                "sessions": _serialize_sessions_with_tokens(sessions_to_output, agent_backend),
                 "total_count": total_sessions,
             },
             metadata={

--- a/tests/test_list_json_token_usage.py
+++ b/tests/test_list_json_token_usage.py
@@ -1,0 +1,544 @@
+"""Tests for daf list --json token usage data (itdove/devaiflow#400)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from devflow.cli.main import cli
+from devflow.cli.commands.list_command import (
+    _compute_session_token_usage,
+    _serialize_sessions_with_tokens,
+)
+from devflow.config.loader import ConfigLoader
+from devflow.session.manager import SessionManager
+
+
+def _parse_json_output(output):
+    """Parse JSON from CLI output, filtering out warning lines."""
+    output_lines = output.strip().split('\n')
+    json_part = '\n'.join([line for line in output_lines if not line.startswith('Warning:')])
+    return json.loads(json_part)
+
+
+# --- Unit tests for _compute_session_token_usage ---
+
+
+def test_compute_token_usage_no_conversations():
+    """Token usage returns None when session has no conversations."""
+    session = MagicMock()
+    session.conversations = {}
+    agent = MagicMock()
+
+    result = _compute_session_token_usage(session, agent)
+    assert result is None
+
+
+def test_compute_token_usage_single_conversation():
+    """Token usage aggregates data from a single conversation."""
+    session = MagicMock()
+    conv = MagicMock()
+    conv.project_path = "/path/to/project"
+    conv.ai_agent_session_id = "uuid-123"
+    # Simulate new format (Conversation with active_session)
+    conv_wrapper = MagicMock()
+    conv_wrapper.active_session = conv
+    session.conversations = {"repo1": conv_wrapper}
+
+    agent = MagicMock()
+    agent.extract_token_usage.return_value = {
+        "input_tokens": 1000,
+        "output_tokens": 500,
+        "cache_creation_input_tokens": 100,
+        "cache_read_input_tokens": 200,
+        "total_tokens": 1500,
+        "message_count": 5,
+    }
+
+    result = _compute_session_token_usage(session, agent)
+
+    assert result is not None
+    assert result["total_tokens"] == 1500
+    assert result["input_tokens"] == 1000
+    assert result["output_tokens"] == 500
+    assert result["cache_creation_input_tokens"] == 100
+    assert result["cache_read_input_tokens"] == 200
+
+
+def test_compute_token_usage_multiple_conversations():
+    """Token usage aggregates data across multiple conversations."""
+    session = MagicMock()
+
+    # First conversation
+    conv1 = MagicMock()
+    conv1.project_path = "/path/to/repo1"
+    conv1.ai_agent_session_id = "uuid-1"
+    conv1_wrapper = MagicMock()
+    conv1_wrapper.active_session = conv1
+
+    # Second conversation
+    conv2 = MagicMock()
+    conv2.project_path = "/path/to/repo2"
+    conv2.ai_agent_session_id = "uuid-2"
+    conv2_wrapper = MagicMock()
+    conv2_wrapper.active_session = conv2
+
+    session.conversations = {"repo1": conv1_wrapper, "repo2": conv2_wrapper}
+
+    agent = MagicMock()
+    agent.extract_token_usage.side_effect = [
+        {
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_creation_input_tokens": 50,
+            "cache_read_input_tokens": 100,
+            "total_tokens": 1500,
+        },
+        {
+            "input_tokens": 2000,
+            "output_tokens": 800,
+            "cache_creation_input_tokens": 75,
+            "cache_read_input_tokens": 150,
+            "total_tokens": 2800,
+        },
+    ]
+
+    result = _compute_session_token_usage(session, agent)
+
+    assert result is not None
+    assert result["total_tokens"] == 4300  # (1000+2000) + (500+800)
+    assert result["input_tokens"] == 3000
+    assert result["output_tokens"] == 1300
+    assert result["cache_creation_input_tokens"] == 125
+    assert result["cache_read_input_tokens"] == 250
+
+
+def test_compute_token_usage_no_data_returns_none():
+    """Token usage returns None when agent returns None for all conversations."""
+    session = MagicMock()
+    conv = MagicMock()
+    conv.project_path = "/path/to/project"
+    conv.ai_agent_session_id = "uuid-123"
+    conv_wrapper = MagicMock()
+    conv_wrapper.active_session = conv
+    session.conversations = {"repo1": conv_wrapper}
+
+    agent = MagicMock()
+    agent.extract_token_usage.return_value = None
+
+    result = _compute_session_token_usage(session, agent)
+    assert result is None
+
+
+def test_compute_token_usage_missing_project_path():
+    """Token usage skips conversations without project_path."""
+    session = MagicMock()
+    conv = MagicMock()
+    conv.project_path = None
+    conv.ai_agent_session_id = "uuid-123"
+    conv_wrapper = MagicMock()
+    conv_wrapper.active_session = conv
+    session.conversations = {"repo1": conv_wrapper}
+
+    agent = MagicMock()
+
+    result = _compute_session_token_usage(session, agent)
+    assert result is None
+    agent.extract_token_usage.assert_not_called()
+
+
+def test_compute_token_usage_missing_session_id():
+    """Token usage skips conversations without ai_agent_session_id."""
+    session = MagicMock()
+    conv = MagicMock()
+    conv.project_path = "/path/to/project"
+    conv.ai_agent_session_id = None
+    conv_wrapper = MagicMock()
+    conv_wrapper.active_session = conv
+    session.conversations = {"repo1": conv_wrapper}
+
+    agent = MagicMock()
+
+    result = _compute_session_token_usage(session, agent)
+    assert result is None
+    agent.extract_token_usage.assert_not_called()
+
+
+def test_compute_token_usage_exception_silenced():
+    """Token usage silently ignores exceptions from extract_token_usage."""
+    session = MagicMock()
+    conv = MagicMock()
+    conv.project_path = "/path/to/project"
+    conv.ai_agent_session_id = "uuid-123"
+    conv_wrapper = MagicMock()
+    conv_wrapper.active_session = conv
+    session.conversations = {"repo1": conv_wrapper}
+
+    agent = MagicMock()
+    agent.extract_token_usage.side_effect = IOError("File not found")
+
+    result = _compute_session_token_usage(session, agent)
+    assert result is None
+
+
+def test_compute_token_usage_partial_failure():
+    """Token usage aggregates data even when some conversations fail."""
+    session = MagicMock()
+
+    conv1 = MagicMock()
+    conv1.project_path = "/path/to/repo1"
+    conv1.ai_agent_session_id = "uuid-1"
+    conv1_wrapper = MagicMock()
+    conv1_wrapper.active_session = conv1
+
+    conv2 = MagicMock()
+    conv2.project_path = "/path/to/repo2"
+    conv2.ai_agent_session_id = "uuid-2"
+    conv2_wrapper = MagicMock()
+    conv2_wrapper.active_session = conv2
+
+    session.conversations = {"repo1": conv1_wrapper, "repo2": conv2_wrapper}
+
+    agent = MagicMock()
+    agent.extract_token_usage.side_effect = [
+        {
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_creation_input_tokens": 50,
+            "cache_read_input_tokens": 100,
+            "total_tokens": 1500,
+        },
+        IOError("File not found"),
+    ]
+
+    result = _compute_session_token_usage(session, agent)
+
+    assert result is not None
+    assert result["total_tokens"] == 1500
+    assert result["input_tokens"] == 1000
+    assert result["output_tokens"] == 500
+
+
+def test_compute_token_usage_old_format_conversation():
+    """Token usage works with old ConversationContext format (no active_session)."""
+    session = MagicMock()
+    # Old format: conversation IS the context directly (no active_session attribute)
+    conv = MagicMock(spec=["project_path", "ai_agent_session_id", "last_active"])
+    conv.project_path = "/path/to/project"
+    conv.ai_agent_session_id = "uuid-123"
+    session.conversations = {"repo1": conv}
+
+    agent = MagicMock()
+    agent.extract_token_usage.return_value = {
+        "input_tokens": 500,
+        "output_tokens": 200,
+        "cache_creation_input_tokens": 10,
+        "cache_read_input_tokens": 20,
+        "total_tokens": 700,
+    }
+
+    result = _compute_session_token_usage(session, agent)
+
+    assert result is not None
+    assert result["total_tokens"] == 700
+
+
+def test_compute_token_usage_missing_cache_fields():
+    """Token usage handles missing cache fields gracefully (defaults to 0)."""
+    session = MagicMock()
+    conv = MagicMock()
+    conv.project_path = "/path/to/project"
+    conv.ai_agent_session_id = "uuid-123"
+    conv_wrapper = MagicMock()
+    conv_wrapper.active_session = conv
+    session.conversations = {"repo1": conv_wrapper}
+
+    agent = MagicMock()
+    # Some agents (e.g., OpenCode) may not return cache fields
+    agent.extract_token_usage.return_value = {
+        "input_tokens": 1000,
+        "output_tokens": 500,
+        "total_tokens": 1500,
+    }
+
+    result = _compute_session_token_usage(session, agent)
+
+    assert result is not None
+    assert result["total_tokens"] == 1500
+    assert result["cache_creation_input_tokens"] == 0
+    assert result["cache_read_input_tokens"] == 0
+
+
+# --- Unit tests for _serialize_sessions_with_tokens ---
+
+
+@patch("devflow.cli.commands.list_command.create_agent_client")
+@patch("devflow.cli.commands.list_command._compute_session_token_usage")
+@patch("devflow.cli.commands.list_command.serialize_session")
+def test_serialize_sessions_with_tokens(mock_serialize, mock_compute, mock_create_agent):
+    """Serialize sessions includes token_usage field for each session."""
+    mock_agent = MagicMock()
+    mock_create_agent.return_value = mock_agent
+
+    session1 = MagicMock()
+    session2 = MagicMock()
+
+    mock_serialize.side_effect = [
+        {"name": "session1", "status": "in_progress"},
+        {"name": "session2", "status": "complete"},
+    ]
+
+    mock_compute.side_effect = [
+        {"total_tokens": 1500, "input_tokens": 1000, "output_tokens": 500,
+         "cache_creation_input_tokens": 50, "cache_read_input_tokens": 100},
+        None,  # session2 has no token data
+    ]
+
+    result = _serialize_sessions_with_tokens([session1, session2], "claude")
+
+    assert len(result) == 2
+    assert result[0]["name"] == "session1"
+    assert result[0]["token_usage"] is not None
+    assert result[0]["token_usage"]["total_tokens"] == 1500
+    assert result[1]["name"] == "session2"
+    assert result[1]["token_usage"] is None
+
+
+@patch("devflow.cli.commands.list_command.create_agent_client")
+@patch("devflow.cli.commands.list_command._compute_session_token_usage")
+@patch("devflow.cli.commands.list_command.serialize_session")
+def test_serialize_sessions_with_tokens_empty_list(mock_serialize, mock_compute, mock_create_agent):
+    """Serialize empty list of sessions returns empty list."""
+    mock_create_agent.return_value = MagicMock()
+
+    result = _serialize_sessions_with_tokens([], "claude")
+    assert result == []
+
+
+# --- Integration tests with CLI ---
+
+
+@patch("devflow.cli.commands.list_command.create_agent_client")
+def test_list_json_includes_token_usage_field(mock_create_agent, temp_daf_home):
+    """Test that daf list --json includes token_usage field (itdove/devaiflow#400)."""
+    # Mock agent to return token data
+    mock_agent = MagicMock()
+    mock_agent.extract_token_usage.return_value = {
+        "input_tokens": 100000,
+        "output_tokens": 25000,
+        "cache_creation_input_tokens": 5000,
+        "cache_read_input_tokens": 10000,
+        "total_tokens": 125000,
+        "message_count": 42,
+    }
+    mock_create_agent.return_value = mock_agent
+
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session_manager.create_session(
+        name="token-test-session",
+        goal="Test token usage in JSON",
+        working_directory="test-repo",
+        project_path="/path/to/repo",
+        ai_agent_session_id="uuid-token-test",
+        issue_key="PROJ-400",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    output = _parse_json_output(result.output)
+
+    assert output["success"] is True
+    assert len(output["data"]["sessions"]) == 1
+
+    session_data = output["data"]["sessions"][0]
+    assert "token_usage" in session_data, "token_usage field must be present in JSON output"
+
+    token_usage = session_data["token_usage"]
+    assert token_usage is not None
+    assert token_usage["total_tokens"] == 125000
+    assert token_usage["input_tokens"] == 100000
+    assert token_usage["output_tokens"] == 25000
+    assert token_usage["cache_creation_input_tokens"] == 5000
+    assert token_usage["cache_read_input_tokens"] == 10000
+
+
+@patch("devflow.cli.commands.list_command.create_agent_client")
+def test_list_json_token_usage_null_when_no_data(mock_create_agent, temp_daf_home):
+    """Test that token_usage is null when no token data available (itdove/devaiflow#400)."""
+    mock_agent = MagicMock()
+    mock_agent.extract_token_usage.return_value = None
+    mock_create_agent.return_value = mock_agent
+
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session_manager.create_session(
+        name="no-token-session",
+        goal="Test no token data",
+        working_directory="test-repo",
+        project_path="/path/to/repo",
+        ai_agent_session_id="uuid-no-tokens",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    output = _parse_json_output(result.output)
+
+    session_data = output["data"]["sessions"][0]
+    assert "token_usage" in session_data
+    assert session_data["token_usage"] is None
+
+
+@patch("devflow.cli.commands.list_command.create_agent_client")
+def test_list_json_token_usage_multiple_sessions(mock_create_agent, temp_daf_home):
+    """Test token_usage with multiple sessions, some with data, some without (itdove/devaiflow#400)."""
+    token_data = {
+        "input_tokens": 50000,
+        "output_tokens": 10000,
+        "cache_creation_input_tokens": 1000,
+        "cache_read_input_tokens": 2000,
+        "total_tokens": 60000,
+    }
+
+    def extract_side_effect(session_id, project_path):
+        """Return token data only for the session with tokens."""
+        if session_id == "uuid-with-tokens":
+            return token_data
+        return None
+
+    mock_agent = MagicMock()
+    mock_agent.extract_token_usage.side_effect = extract_side_effect
+    mock_create_agent.return_value = mock_agent
+
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session_manager.create_session(
+        name="session-with-tokens",
+        goal="Has tokens",
+        working_directory="repo1",
+        project_path="/path/to/repo1",
+        ai_agent_session_id="uuid-with-tokens",
+    )
+    session_manager.create_session(
+        name="session-no-tokens",
+        goal="No tokens",
+        working_directory="repo2",
+        project_path="/path/to/repo2",
+        ai_agent_session_id="uuid-no-tokens",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    output = _parse_json_output(result.output)
+
+    sessions = output["data"]["sessions"]
+    assert len(sessions) == 2
+
+    sessions_by_name = {s["name"]: s for s in sessions}
+
+    # Session with tokens has token data
+    assert sessions_by_name["session-with-tokens"]["token_usage"] is not None
+    assert sessions_by_name["session-with-tokens"]["token_usage"]["total_tokens"] == 60000
+
+    # Session without tokens has null token data
+    assert sessions_by_name["session-no-tokens"]["token_usage"] is None
+
+
+@patch("devflow.cli.commands.list_command.create_agent_client")
+def test_list_json_token_usage_with_pagination(mock_create_agent, temp_daf_home):
+    """Test token_usage works correctly with pagination (itdove/devaiflow#400)."""
+    mock_agent = MagicMock()
+    mock_agent.extract_token_usage.return_value = {
+        "input_tokens": 1000,
+        "output_tokens": 500,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "total_tokens": 1500,
+    }
+    mock_create_agent.return_value = mock_agent
+
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    # Create 5 sessions
+    for i in range(5):
+        session_manager.create_session(
+            name=f"paginated-session-{i}",
+            goal=f"Goal {i}",
+            working_directory=f"repo{i}",
+            project_path=f"/path/to/repo{i}",
+            ai_agent_session_id=f"uuid-page-{i}",
+        )
+
+    runner = CliRunner()
+    # Request page 1 with limit 2
+    result = runner.invoke(cli, ["list", "--json", "--limit", "2", "--page", "1"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    output = _parse_json_output(result.output)
+
+    # Should only have 2 sessions on page 1
+    assert len(output["data"]["sessions"]) == 2
+    assert output["data"]["total_count"] == 5
+
+    # Both sessions should have token_usage
+    for session_data in output["data"]["sessions"]:
+        assert "token_usage" in session_data
+        assert session_data["token_usage"] is not None
+        assert session_data["token_usage"]["total_tokens"] == 1500
+
+
+@patch("devflow.cli.commands.list_command.create_agent_client")
+def test_list_json_no_sessions_no_token_usage(mock_create_agent, temp_daf_home):
+    """Test that empty session list in JSON output works correctly (itdove/devaiflow#400)."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    output = _parse_json_output(result.output)
+
+    assert output["success"] is True
+    assert output["data"]["sessions"] == []
+    assert output["data"]["total_count"] == 0
+    # create_agent_client should not be called when there are no sessions
+    mock_create_agent.assert_not_called()
+
+
+@patch("devflow.cli.commands.list_command.create_agent_client")
+def test_list_json_token_usage_session_without_conversations(mock_create_agent, temp_daf_home):
+    """Test token_usage for sessions without conversations (e.g., ticket_creation) (itdove/devaiflow#400)."""
+    mock_agent = MagicMock()
+    mock_create_agent.return_value = mock_agent
+
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    # Create session and manually clear conversations to simulate edge case
+    session = session_manager.create_session(
+        name="empty-conv-session",
+        goal="No conversations",
+        working_directory="test-repo",
+        project_path="/path/to/repo",
+        ai_agent_session_id="uuid-empty",
+    )
+    session.conversations = {}
+    session_manager.update_session(session)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    output = _parse_json_output(result.output)
+
+    session_data = output["data"]["sessions"][0]
+    assert "token_usage" in session_data
+    assert session_data["token_usage"] is None


### PR DESCRIPTION
Closes https://github.com/itdove/devaiflow/issues/400

## Description

`daf list --json` was missing token usage data that the table output already computed and displayed. This PR adds a `token_usage` field to each session in the JSON output.

**Root Cause:** `serialize_sessions()` calls `session.model_dump()` which only serializes Session model fields. Token usage is computed on-the-fly from Claude Code JSONL files via `agent.extract_token_usage()` and was only used for the Rich table display, never passed to JSON serialization.

**Changes:**
- Extracted token computation into a reusable `_compute_session_token_usage()` helper
- Added `_serialize_sessions_with_tokens()` to enrich serialized sessions with token data
- Refactored `_display_page()` to use the shared helper (no duplication)
- JSON output now includes `token_usage` field per session

**JSON output example:**
```json
{
  "name": "session-name",
  "token_usage": {
    "total_tokens": 125000,
    "input_tokens": 100000,
    "output_tokens": 25000,
    "cache_creation_input_tokens": 5000,
    "cache_read_input_tokens": 10000
  }
}
```

When no token data is available, `token_usage` is `null`.

Assisted-by: Claude (OpenCode)

## Testing

### Steps to test
1. Pull down the PR
2. Run `daf list --json` and verify each session includes a `token_usage` field
3. Run `daf list` (table mode) and verify tokens column still displays correctly
4. Run `pytest tests/test_list_json_token_usage.py -v` to run the 18 new tests

### Scenarios tested
- Single session with token data
- Multiple sessions with mixed token data (some with, some without)
- Session with no conversations (token_usage = null)
- Pagination with token data
- Old ConversationContext format compatibility
- Exception handling (silently ignored)
- Missing project_path or session_id (skipped)
- Missing cache fields (defaults to 0)
- Empty session list

## Deployment considerations
- [x] This code change is ready for deployment on its own

---
Co-Authored-By: Claude <noreply@anthropic.com>