### PR TITLE
itdove/devaiflow#412: TUI saves agent_backend to enterprise.json instead of config.json

### DIFF
--- a/devflow/config/loader.py
+++ b/devflow/config/loader.py
@@ -740,14 +740,14 @@ class ConfigLoader:
         # Merge GitHub configs
         merged_github = self._merge_github_config(enterprise_config, org_config, team_config)
 
-        # Merge agent_backend with priority: Enterprise > Organization > Team > User
+        # Merge agent_backend with priority: Enterprise > Team > User > default
         # Enterprise can enforce agent backend for all organizations
-        # Organization can enforce agent backend for all teams
         # Team can enforce agent backend for that team
-        # User can only choose if enterprise/org/team haven't enforced it
+        # User can only choose if enterprise/team haven't enforced it
         agent_backend = (
             enterprise_config.agent_backend  # Enterprise takes highest precedence
             or team_config.agent_backend  # Then team
+            or user_config.agent_backend  # Then user preference
             or "claude"  # Default to claude if not set anywhere
         )
 
@@ -914,8 +914,16 @@ class ConfigLoader:
             # Model provider is enforced - don't save user override
             user_model_provider = None
 
+        # Check if agent_backend is enforced by enterprise or team
+        # If enforced, don't save it in user config (prevent user override)
+        user_agent_backend = config.agent_backend
+        if enterprise_config.agent_backend or team_config.agent_backend:
+            # agent_backend is enforced - don't save user override
+            user_agent_backend = None
+
         # Extract user config
         user_config = UserConfig(
+            agent_backend=user_agent_backend,  # User's agent backend choice (only if not enforced)
             backend_config_source=config.backend_config_source,
             repos=config.repos,
             time_tracking=config.time_tracking,
@@ -952,30 +960,24 @@ class ConfigLoader:
         with open(backends_dir / "jira.json", "w") as f:
             json.dump(backend_config.model_dump(by_alias=True, exclude_none=False), f, indent=2)
 
-        # Extract enterprise config
-        # Note: agent_backend is retrieved from config.agent_backend (already merged with Enterprise > Team priority)
-        # backend_overrides come from field_mappings which don't exist in the merged config
-        # For now, we'll need to check if enterprise.json exists and preserve its content
-        # This is because the merged config doesn't preserve the source of these values
-        enterprise_config = EnterpriseConfig(
-            agent_backend=config.agent_backend,  # This is already the merged value
-            backend_overrides=None,  # Preserve existing value if file exists
-        )
-
-        # If enterprise.json exists, preserve backend_overrides
+        # Extract enterprise config — preserve existing values, never overwrite with user choices
         enterprise_file = self.config_dir / "enterprise.json"
+        existing_enterprise_data = {}
         if enterprise_file.exists():
             try:
                 with open(enterprise_file, "r") as f:
-                    existing_data = json.load(f)
-                if "backend_overrides" in existing_data:
-                    enterprise_config.backend_overrides = existing_data["backend_overrides"]
+                    existing_enterprise_data = json.load(f)
             except Exception:
-                pass  # Ignore errors, will use default
+                pass
+
+        enterprise_config_to_save = EnterpriseConfig(
+            agent_backend=existing_enterprise_data.get("agent_backend"),
+            backend_overrides=existing_enterprise_data.get("backend_overrides"),
+        )
 
         # Save enterprise config (enterprise.json)
         with open(self.config_dir / "enterprise.json", "w") as f:
-            json.dump(enterprise_config.model_dump(by_alias=True, exclude_none=False), f, indent=2)
+            json.dump(enterprise_config_to_save.model_dump(by_alias=True, exclude_none=False), f, indent=2)
 
         # Extract organization config (workflow policies and project settings)
         org_config = OrganizationConfig(

--- a/devflow/config/models.py
+++ b/devflow/config/models.py
@@ -537,6 +537,7 @@ class UserConfig(BaseModel):
     prompts: PromptsConfig = Field(default_factory=PromptsConfig)
     pr_template_url: Optional[str] = None  # URL to PR/MR template
     storage: StorageConfig = Field(default_factory=StorageConfig)  # Storage backend config
+    agent_backend: Optional[str] = None  # AI agent backend preference (e.g., "claude", "opencode") — only saved when not enforced by enterprise/team
     mock_services: Optional[MockServicesConfig] = None  # Reserved for future use
     gcp_vertex_region: Optional[str] = None  # GCP Vertex AI region (deprecated - use model_provider.profiles.vertex.vertex_region instead)
     update_checker_timeout: int = 10  # Timeout in seconds for update check requests

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -751,3 +751,141 @@ def test_hierarchical_config_source_no_migration_if_already_in_new_location(temp
         org_config_data = json.load(f)
     assert "hierarchical_config_source" in org_config_data
     assert org_config_data["hierarchical_config_source"] == "file:///Users/test/old-configs"
+
+
+def test_save_agent_backend_to_user_config_not_enterprise(temp_daf_home):
+    """Test that TUI saves agent_backend to config.json, not enterprise.json.
+
+    Regression test for issue #412: agent_backend was incorrectly written to
+    enterprise.json instead of config.json when changed via TUI.
+    """
+    loader = ConfigLoader()
+    config = loader.create_default_config()
+
+    config.agent_backend = "opencode"
+    loader.save_config(config)
+
+    # agent_backend should be in config.json (user config)
+    with open(loader.config_file, "r") as f:
+        user_data = json.load(f)
+    assert user_data.get("agent_backend") == "opencode"
+
+    # enterprise.json should NOT have agent_backend set
+    enterprise_file = loader.config_dir / "enterprise.json"
+    with open(enterprise_file, "r") as f:
+        enterprise_data = json.load(f)
+    assert enterprise_data.get("agent_backend") is None
+
+
+def test_save_preserves_enterprise_agent_backend(temp_daf_home):
+    """Test that saving config preserves existing enterprise agent_backend.
+
+    When enterprise.json already has agent_backend set by an admin,
+    a user saving via TUI should not overwrite it.
+    """
+    loader = ConfigLoader()
+
+    # Simulate enterprise admin setting agent_backend
+    enterprise_file = loader.config_dir / "enterprise.json"
+    with open(enterprise_file, "w") as f:
+        json.dump({"agent_backend": "claude"}, f)
+
+    config = loader.create_default_config()
+    config.agent_backend = "opencode"
+    loader.save_config(config)
+
+    # enterprise.json should still have admin's value
+    with open(enterprise_file, "r") as f:
+        enterprise_data = json.load(f)
+    assert enterprise_data.get("agent_backend") == "claude"
+
+    # When enterprise enforces, user config should NOT store agent_backend
+    with open(loader.config_file, "r") as f:
+        user_data = json.load(f)
+    assert user_data.get("agent_backend") is None
+
+
+def test_save_preserves_enterprise_backend_overrides(temp_daf_home):
+    """Test that saving config preserves existing enterprise backend_overrides."""
+    loader = ConfigLoader()
+
+    enterprise_file = loader.config_dir / "enterprise.json"
+    overrides = {"field_mappings": {"components": {"required_for": ["Bug", "Story"]}}}
+    with open(enterprise_file, "w") as f:
+        json.dump({"agent_backend": "claude", "backend_overrides": overrides}, f)
+
+    config = loader.create_default_config()
+    loader.save_config(config)
+
+    with open(enterprise_file, "r") as f:
+        enterprise_data = json.load(f)
+    assert enterprise_data.get("backend_overrides") == overrides
+
+
+def test_agent_backend_merge_hierarchy(temp_daf_home):
+    """Test agent_backend merge: Enterprise > Team > User > default.
+
+    Verifies config hierarchy for agent_backend follows the correct priority.
+    """
+    loader = ConfigLoader()
+
+    # Set user config with agent_backend = "opencode"
+    user_data = {
+        "agent_backend": "opencode",
+        "repos": {
+            "workspaces": [
+                {"name": "default", "path": str(Path.home() / "development")}
+            ]
+        }
+    }
+    with open(loader.config_file, "w") as f:
+        json.dump(user_data, f)
+
+    config = loader.load_config()
+    assert config is not None
+    assert config.agent_backend == "opencode"
+
+
+def test_agent_backend_enterprise_overrides_user(temp_daf_home):
+    """Test that enterprise agent_backend overrides user's choice."""
+    loader = ConfigLoader()
+
+    # User wants opencode
+    user_data = {
+        "agent_backend": "opencode",
+        "repos": {
+            "workspaces": [
+                {"name": "default", "path": str(Path.home() / "development")}
+            ]
+        }
+    }
+    with open(loader.config_file, "w") as f:
+        json.dump(user_data, f)
+
+    # Enterprise enforces claude
+    enterprise_file = loader.config_dir / "enterprise.json"
+    with open(enterprise_file, "w") as f:
+        json.dump({"agent_backend": "claude"}, f)
+
+    config = loader.load_config()
+    assert config is not None
+    assert config.agent_backend == "claude"
+
+
+def test_agent_backend_defaults_to_claude(temp_daf_home):
+    """Test that agent_backend defaults to 'claude' when not set anywhere."""
+    loader = ConfigLoader()
+
+    user_data = {
+        "repos": {
+            "workspaces": [
+                {"name": "default", "path": str(Path.home() / "development")}
+            ]
+        }
+    }
+    with open(loader.config_file, "w") as f:
+        json.dump(user_data, f)
+
+    config = loader.load_config()
+    assert config is not None
+    assert config.agent_backend == "claude"


### PR DESCRIPTION
Got enough from diff. Here's the filled template:

---

Jira Issue: <!-- This PR does not need a corresponding Jira item. -->
<!-- This PR does not need a corresponding Jira item. -->

## Description

Fixes #412: TUI saves `agent_backend` to `enterprise.json` instead of `config.json`.

When a user changed `agent_backend` via the TUI, the save logic incorrectly wrote it to `enterprise.json`, overwriting admin-enforced values. This happened because:

1. **Save path bug**: `save_config()` always wrote the merged `config.agent_backend` value into `EnterpriseConfig`, even when the value came from the user — not from an enterprise admin.
2. **Merge priority gap**: The merge chain skipped `user_config.agent_backend` entirely (`Enterprise > Org > Team > default`), so user preferences were never loaded.

**Changes:**
- **`loader.py` — save logic**: Enterprise config now preserves its existing on-disk values instead of being overwritten with the merged value. User's `agent_backend` is saved to `UserConfig` (config.json) only when not enforced by enterprise or team.
- **`loader.py` — merge logic**: Fixed priority chain to `Enterprise > Team > User > default`, adding the missing `user_config.agent_backend` fallback. Removed unused Organization tier from `agent_backend` merge.
- **`models.py`**: Added `agent_backend` field to `UserConfig` model.
- **`test_config_loader.py`**: Added 6 regression tests covering save destination, enterprise preservation, merge hierarchy, enterprise override, and default fallback.

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run the test suite: `python -m pytest tests/test_config_loader.py -v -k agent_backend`
3. Verify all 6 new tests pass
4. Manual test: launch TUI, change `agent_backend` to `opencode`, save, then inspect `~/.daf/config.json` — it should contain `"agent_backend": "opencode"`
5. Verify `~/.daf/enterprise.json` does **not** have `agent_backend` set (or retains admin value if pre-existing)
6. Test enterprise enforcement: manually set `agent_backend` in `enterprise.json`, change it in TUI, save — enterprise value should persist unchanged

### Scenarios tested
- User sets `agent_backend` via TUI — saved to `config.json`, not `enterprise.json`
- Enterprise admin has pre-set `agent_backend` — preserved after user save
- Enterprise `backend_overrides` — preserved after user save
- Merge priority: enterprise value overrides user value
- User value used when no enterprise/team enforcement
- Default to `"claude"` when no config sets `agent_backend`

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: