### PR TITLE
itdove/devaiflow#416: Terminal display garbled after OpenCode TUI exits in daf open

### DIFF
--- a/devflow/cli/commands/git_new_command.py
+++ b/devflow/cli/commands/git_new_command.py
@@ -761,6 +761,9 @@ def create_git_issue_session(
         )
         # Wait for the agent process to complete
         process.wait()
+        if not headless:
+            from devflow.cli.utils import reset_terminal_after_tui
+            reset_terminal_after_tui()
     finally:
         if not is_cleanup_done():
             console_print(f"\n[green]✓[/green] Claude session completed")

--- a/devflow/cli/commands/jira_new_command.py
+++ b/devflow/cli/commands/jira_new_command.py
@@ -654,6 +654,9 @@ def create_jira_ticket_session(
         )
         # Wait for the agent process to complete
         process.wait()
+        if not headless:
+            from devflow.cli.utils import reset_terminal_after_tui
+            reset_terminal_after_tui()
     finally:
         if not is_cleanup_done():
             console_print(f"\n[green]✓[/green] Claude session completed")

--- a/devflow/cli/commands/new_command.py
+++ b/devflow/cli/commands/new_command.py
@@ -885,6 +885,9 @@ def create_new_session(
             )
             # Wait for the agent process to complete
             process.wait()
+            if not headless:
+                from devflow.cli.utils import reset_terminal_after_tui
+                reset_terminal_after_tui()
         finally:
             if not is_cleanup_done():
                 console.print(f"\n[green]✓[/green] Claude session completed")

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -1115,6 +1115,9 @@ def open_session(
                         auto_approve=auto_approve
                     )
                     process.wait()
+                    if not headless:
+                        from devflow.cli.utils import reset_terminal_after_tui
+                        reset_terminal_after_tui()
             finally:
                 if not is_cleanup_done():
                     console.print(f"\n[green]✓[/green] Claude session completed")
@@ -1283,6 +1286,9 @@ def open_session(
                     # For non-resumable agents, wait for the launched process
                     process.wait()
             finally:
+                if not headless:
+                    from devflow.cli.utils import reset_terminal_after_tui
+                    reset_terminal_after_tui()
                 if not is_cleanup_done():
                     console.print(f"\n[green]✓[/green] Claude session completed")
 

--- a/devflow/cli/utils.py
+++ b/devflow/cli/utils.py
@@ -22,6 +22,38 @@ from devflow.utils.backend_detection import detect_backend_from_key
 console = Console()
 
 
+def reset_terminal_after_tui() -> None:
+    """Reset terminal state after a TUI-based agent (e.g. OpenCode) exits.
+
+    TUI agents use the alternate screen buffer and may not fully restore
+    terminal state on exit. This resets the terminal to a known-good state
+    so subsequent CLI output renders correctly.
+
+    Safe to call after any agent — these operations are no-ops when the
+    terminal is already in normal state. Silently skipped in non-TTY
+    environments (CI, tests, pipes).
+    """
+    import subprocess
+
+    try:
+        if not sys.stdout.isatty():
+            return
+        sys.stdout.write("\033[?1049l")  # exit alternate screen buffer
+        sys.stdout.write("\033[0m")  # reset text attributes
+        sys.stdout.flush()
+    except (OSError, ValueError):
+        pass
+    try:
+        subprocess.run(
+            ["stty", "sane"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, FileNotFoundError):
+        pass
+
+
 def check_outside_ai_session() -> None:
     """Check if running inside an AI agent session and exit with error if so.
 

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -17,6 +17,7 @@ from devflow.cli.utils import (
     get_status_display,
     resolve_goal_input,
     process_goal_options,
+    reset_terminal_after_tui,
     _is_valid_file_or_url,
     _resolve_file_or_url,
     require_outside_claude,
@@ -950,3 +951,54 @@ def test_resolve_file_or_url_nonexistent_file():
         _resolve_file_or_url("/tmp/nonexistent_file_12345.md")
 
     assert "File not found" in str(exc_info.value)
+
+
+class TestResetTerminalAfterTui:
+    """Tests for reset_terminal_after_tui."""
+
+    @patch("subprocess.run")
+    def test_writes_escape_sequences_and_calls_stty(self, mock_run):
+        """Verify escape sequences are written and stty sane is called."""
+        import io
+        import sys
+        import subprocess
+
+        fake_stdout = io.StringIO()
+        fake_stdout.isatty = lambda: True
+        with patch.object(sys, "stdout", fake_stdout):
+            reset_terminal_after_tui()
+
+        written = fake_stdout.getvalue()
+        assert "\033[?1049l" in written
+        assert "\033[0m" in written
+        mock_run.assert_called_once()
+        args = mock_run.call_args
+        assert args[0][0] == ["stty", "sane"]
+        assert args[1]["stdin"] == subprocess.DEVNULL
+        assert args[1]["stdout"] == subprocess.DEVNULL
+        assert args[1]["stderr"] == subprocess.DEVNULL
+
+    @patch("subprocess.run", side_effect=OSError("stty not found"))
+    def test_stty_failure_is_silenced(self, mock_run):
+        """If stty fails, exception is silenced (non-TTY safe)."""
+        import io
+        import sys
+
+        fake_stdout = io.StringIO()
+        fake_stdout.isatty = lambda: True
+        with patch.object(sys, "stdout", fake_stdout):
+            reset_terminal_after_tui()
+
+    @patch("subprocess.run")
+    def test_skipped_when_not_tty(self, mock_run):
+        """No escape sequences or stty when stdout is not a TTY."""
+        import io
+        import sys
+
+        fake_stdout = io.StringIO()
+        fake_stdout.isatty = lambda: False
+        with patch.object(sys, "stdout", fake_stdout):
+            reset_terminal_after_tui()
+
+        assert fake_stdout.getvalue() == ""
+        mock_run.assert_not_called()


### PR DESCRIPTION
Jira Issue: N/A (GitHub issue)
<!-- This PR does not need a corresponding Jira item. -->

## Description

Fixes terminal display garbling after TUI-based agents (e.g. OpenCode) exit during `daf open` and other session commands.

TUI agents use the alternate screen buffer and raw terminal mode. When they exit, they don't always fully restore terminal state, leaving subsequent CLI output garbled (missing newlines, broken formatting, invisible cursor).

This PR adds a `reset_terminal_after_tui()` utility that:
- Sends ANSI escape sequences to exit the alternate screen buffer (`\033[?1049l`) and reset text attributes (`\033[0m`)
- Runs `stty sane` to restore line discipline
- Safely no-ops in non-TTY environments (CI, pipes) and silences errors on systems without `stty`

The reset is called after `process.wait()` in all non-headless agent launch paths:
- `open_command.py` (both resumable and non-resumable agent paths)
- `new_command.py`
- `git_new_command.py`
- `jira_new_command.py`

Closes itdove/devaiflow#416

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `daf open` with a TUI-based agent backend (e.g. OpenCode)
3. Exit the TUI agent (Ctrl+C or normal exit)
4. Verify terminal output renders correctly — no garbled text, cursor visible, newlines working
5. Run `daf new` and `daf git new` with a TUI agent, repeat steps 3-4
6. Run `daf open --headless` and verify the reset is **not** called (no unnecessary escape sequences in pipe output)
7. Run unit tests: `python -m pytest tests/test_cli_utils.py::TestResetTerminalAfterTui -v`

### Scenarios tested
- TUI agent (OpenCode) exit → terminal resets correctly, subsequent output is clean
- Non-TTY environment (piped stdout) → reset is safely skipped
- `stty` not available → `OSError` is silenced, ANSI escapes still sent
- Headless mode → reset not invoked

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: