### PR TITLE
itdove/devaiflow#430: OpenCode: use AGENTS.md trigger + daf-workflow skill instead of --prompt

### DIFF
--- a/devflow/agent/opencode_agent.py
+++ b/devflow/agent/opencode_agent.py
@@ -66,6 +66,45 @@ class OpenCodeAgent(AgentInterface):
 
         self.opencode_dir = Path(opencode_dir)
 
+    # Trigger line appended to the project's AGENTS.md so OpenCode
+    # discovers the daf-workflow skill on startup without --prompt.
+    AGENTS_MD_TRIGGER = (
+        "When DAF_SESSION_NAME environment variable is set, "
+        "immediately follow the daf-workflow skill instructions."
+    )
+
+    def ensure_agents_md_trigger(self, project_path: str) -> bool:
+        """Ensure the project's AGENTS.md contains the daf-workflow trigger.
+
+        Checks if ``AGENTS.md`` in *project_path* already contains the trigger
+        line.  If the file exists but the line is missing, it is appended.  If
+        the file does not exist it is created with just the trigger line.
+
+        The operation is idempotent -- calling it multiple times on the same
+        project is safe and will not duplicate the trigger.
+
+        Args:
+            project_path: Absolute path to the project directory whose
+                ``AGENTS.md`` should be updated.
+
+        Returns:
+            ``True`` if the file was created or modified, ``False`` if the
+            trigger was already present.
+        """
+        agents_md = Path(project_path) / "AGENTS.md"
+
+        if agents_md.exists():
+            content = agents_md.read_text()
+            if self.AGENTS_MD_TRIGGER not in content:
+                with open(agents_md, "a") as f:
+                    f.write(f"\n\n{self.AGENTS_MD_TRIGGER}\n")
+                return True
+            return False
+
+        # File does not exist -- create it with the trigger line.
+        agents_md.write_text(f"{self.AGENTS_MD_TRIGGER}\n")
+        return True
+
     def launch_session(
         self,
         project_path: str,
@@ -108,8 +147,16 @@ class OpenCodeAgent(AgentInterface):
     ) -> subprocess.Popen:
         """Launch OpenCode with initial prompt.
 
-        By default launches in interactive TUI mode with ``opencode --prompt``.
-        Use ``headless=True`` for non-interactive execution via ``opencode run``.
+        In **interactive** mode the prompt is NOT passed via ``--prompt``.
+        Instead, the project's ``AGENTS.md`` is updated with a daf-workflow
+        trigger (idempotent) so that OpenCode discovers the session context
+        on its own.  This preserves OpenCode's native permission system --
+        the LLM no longer interprets a ``--prompt`` flag as blanket
+        authorisation to modify files.
+
+        In **headless** mode (``headless=True``) the prompt is still passed
+        via ``opencode run <prompt>`` because there is no human present to
+        interact with permission dialogs.
 
         Args:
             project_path: Absolute path to project
@@ -134,10 +181,12 @@ class OpenCodeAgent(AgentInterface):
         final_env = env if env is not None else os.environ.copy()
 
         if headless:
+            # Non-interactive: prompt must be passed directly.
             cmd = ["opencode", "run", initial_prompt]
-        elif initial_prompt:
-            cmd = ["opencode", "--prompt", initial_prompt]
         else:
+            # Interactive: rely on AGENTS.md trigger + daf-workflow skill.
+            # Do NOT pass --prompt so OpenCode's permission system stays intact.
+            self.ensure_agents_md_trigger(project_path)
             cmd = ["opencode"]
 
         if session_id and session_id.startswith("ses"):
@@ -349,15 +398,17 @@ class OpenCodeAgent(AgentInterface):
         return "opencode"
 
     def supports_permission_prompts(self) -> bool:
-        """OpenCode auto-approves all tool calls without user confirmation.
+        """OpenCode supports permission prompts when launched without ``--prompt``.
 
-        Unlike Claude Code, OpenCode does not have a built-in permission system.
-        File edits and shell commands execute immediately without prompts.
+        When launched interactively (without ``--prompt``), OpenCode shows
+        permission prompts for file edits and shell commands, identical to
+        standalone usage.  The ``--prompt`` flag is only used in headless mode
+        where no human is present.
 
         Returns:
-            False — OpenCode has no permission prompt system.
+            True — OpenCode has a permission prompt system.
         """
-        return False
+        return True
 
     def extract_token_usage(self, session_id: str, project_path: str) -> Optional[Dict[str, Any]]:
         """Extract token usage statistics using ``opencode stats``.

--- a/tests/test_agent_interface.py
+++ b/tests/test_agent_interface.py
@@ -1768,7 +1768,7 @@ class TestSupportsPermissionPrompts:
         agent = CrushAgent()
         assert agent.supports_permission_prompts() is True
 
-    def test_opencode_does_not_support_permissions(self):
-        """OpenCode auto-approves all tool calls — returns False."""
+    def test_opencode_supports_permissions(self):
+        """OpenCode supports permissions when launched without --prompt (#430)."""
         agent = OpenCodeAgent()
-        assert agent.supports_permission_prompts() is False
+        assert agent.supports_permission_prompts() is True

--- a/tests/test_opencode_agent.py
+++ b/tests/test_opencode_agent.py
@@ -1,6 +1,7 @@
 """Tests for OpenCode agent implementation."""
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
@@ -75,14 +76,19 @@ class TestOpenCodeAgentLaunch:
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")
-    def test_launch_with_prompt_interactive_default(self, mock_popen, mock_require):
-        """Test launching OpenCode with prompt uses --prompt in TUI mode."""
+    def test_launch_with_prompt_interactive_no_prompt_flag(self, mock_popen, mock_require, tmp_path):
+        """Test interactive launch does NOT pass --prompt; uses AGENTS.md trigger (#430)."""
         agent = OpenCodeAgent()
         mock_process = Mock()
         mock_popen.return_value = mock_process
 
+        # Create a project directory with an existing AGENTS.md
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / "AGENTS.md").write_text("# Agent instructions\n")
+
         result = agent.launch_with_prompt(
-            project_path="/home/user/project",
+            project_path=str(project_dir),
             initial_prompt="Fix the login bug",
             session_id="ses_abc123",
         )
@@ -91,13 +97,17 @@ class TestOpenCodeAgentLaunch:
         call_args = mock_popen.call_args
         cmd = call_args[0][0]
         assert cmd[0] == "opencode"
-        assert "--prompt" in cmd
-        assert "Fix the login bug" in cmd
+        assert "--prompt" not in cmd
+        assert "Fix the login bug" not in cmd
         assert "--session" in cmd
         assert "ses_abc123" in cmd
         assert "run" not in cmd
-        assert call_args[1]["cwd"] == "/home/user/project"
+        assert call_args[1]["cwd"] == str(project_dir)
         assert result == mock_process
+
+        # Verify AGENTS.md was updated with trigger
+        content = (project_dir / "AGENTS.md").read_text()
+        assert agent.AGENTS_MD_TRIGGER in content
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")
@@ -122,13 +132,16 @@ class TestOpenCodeAgentLaunch:
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")
-    def test_launch_with_prompt_auto_approve(self, mock_popen, mock_require):
+    def test_launch_with_prompt_auto_approve(self, mock_popen, mock_require, tmp_path):
         """Test launching OpenCode with auto-approve adds --dangerously-skip-permissions."""
         agent = OpenCodeAgent()
         mock_popen.return_value = Mock()
 
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
         agent.launch_with_prompt(
-            project_path="/home/user/project",
+            project_path=str(project_dir),
             initial_prompt="Fix bug",
             session_id="test-id",
             auto_approve=True,
@@ -137,7 +150,8 @@ class TestOpenCodeAgentLaunch:
         call_args = mock_popen.call_args
         cmd = call_args[0][0]
         assert "--dangerously-skip-permissions" in cmd
-        assert "--prompt" in cmd
+        # Interactive mode: no --prompt (#430)
+        assert "--prompt" not in cmd
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")
@@ -161,13 +175,16 @@ class TestOpenCodeAgentLaunch:
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")
-    def test_launch_with_prompt_skips_uuid_session_id(self, mock_popen, mock_require):
+    def test_launch_with_prompt_skips_uuid_session_id(self, mock_popen, mock_require, tmp_path):
         """Test that DevAIFlow UUID session IDs are NOT passed to --session."""
         agent = OpenCodeAgent()
         mock_popen.return_value = Mock()
 
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
         agent.launch_with_prompt(
-            project_path="/home/user/project",
+            project_path=str(project_dir),
             initial_prompt="Fix bug",
             session_id="29798353-1758-43a9-b95a-05bac425c3f3",
         )
@@ -175,17 +192,21 @@ class TestOpenCodeAgentLaunch:
         call_args = mock_popen.call_args
         cmd = call_args[0][0]
         assert "--session" not in cmd
-        assert "--prompt" in cmd
+        # Interactive mode: no --prompt (#430)
+        assert "--prompt" not in cmd
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")
-    def test_launch_with_prompt_passes_ses_prefixed_session_id(self, mock_popen, mock_require):
+    def test_launch_with_prompt_passes_ses_prefixed_session_id(self, mock_popen, mock_require, tmp_path):
         """Test that OpenCode session IDs (ses-prefixed) ARE passed to --session."""
         agent = OpenCodeAgent()
         mock_popen.return_value = Mock()
 
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
         agent.launch_with_prompt(
-            project_path="/home/user/project",
+            project_path=str(project_dir),
             initial_prompt="Fix bug",
             session_id="ses_real_opencode_id",
         )
@@ -194,16 +215,21 @@ class TestOpenCodeAgentLaunch:
         cmd = call_args[0][0]
         assert "--session" in cmd
         assert "ses_real_opencode_id" in cmd
+        # Interactive mode: no --prompt (#430)
+        assert "--prompt" not in cmd
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")
-    def test_launch_with_prompt_empty_session_id(self, mock_popen, mock_require):
+    def test_launch_with_prompt_empty_session_id(self, mock_popen, mock_require, tmp_path):
         """Test that empty session ID does not add --session flag."""
         agent = OpenCodeAgent()
         mock_popen.return_value = Mock()
 
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
         agent.launch_with_prompt(
-            project_path="/home/user/project",
+            project_path=str(project_dir),
             initial_prompt="Fix bug",
             session_id="",
         )
@@ -214,13 +240,16 @@ class TestOpenCodeAgentLaunch:
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")
-    def test_launch_with_empty_prompt_no_prompt_flag(self, mock_popen, mock_require):
-        """Test interactive launch with empty prompt omits --prompt (#421)."""
+    def test_launch_with_empty_prompt_no_prompt_flag(self, mock_popen, mock_require, tmp_path):
+        """Test interactive launch with empty prompt omits --prompt (#421, #430)."""
         agent = OpenCodeAgent()
         mock_popen.return_value = Mock()
 
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
         agent.launch_with_prompt(
-            project_path="/home/user/project",
+            project_path=str(project_dir),
             initial_prompt="",
             session_id="ses_abc123",
         )
@@ -232,13 +261,16 @@ class TestOpenCodeAgentLaunch:
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")
-    def test_launch_with_empty_prompt_no_session(self, mock_popen, mock_require):
+    def test_launch_with_empty_prompt_no_session(self, mock_popen, mock_require, tmp_path):
         """Test interactive launch with empty prompt and UUID session ID."""
         agent = OpenCodeAgent()
         mock_popen.return_value = Mock()
 
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
         agent.launch_with_prompt(
-            project_path="/home/user/project",
+            project_path=str(project_dir),
             initial_prompt="",
             session_id="29798353-1758-43a9-b95a-05bac425c3f3",
         )
@@ -251,13 +283,16 @@ class TestOpenCodeAgentLaunch:
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")
-    def test_launch_with_prompt_and_model(self, mock_popen, mock_require):
+    def test_launch_with_prompt_and_model(self, mock_popen, mock_require, tmp_path):
         """Test launching OpenCode with model provider profile."""
         agent = OpenCodeAgent()
         mock_popen.return_value = Mock()
 
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
         agent.launch_with_prompt(
-            project_path="/home/user/project",
+            project_path=str(project_dir),
             initial_prompt="Fix bug",
             session_id="test-id",
             model_provider_profile={"model_name": "anthropic/claude-sonnet"},
@@ -267,6 +302,8 @@ class TestOpenCodeAgentLaunch:
         cmd = call_args[0][0]
         assert "--model" in cmd
         assert "anthropic/claude-sonnet" in cmd
+        # Interactive mode: no --prompt (#430)
+        assert "--prompt" not in cmd
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")
@@ -509,16 +546,146 @@ class TestOpenCodeAgentCaptureSession:
 class TestOpenCodeAgentPermissions:
     """Test OpenCodeAgent permission prompt support."""
 
-    def test_supports_permission_prompts_returns_false(self):
-        """OpenCode does not support permission prompts."""
+    def test_supports_permission_prompts_returns_true(self):
+        """OpenCode supports permission prompts when launched without --prompt (#430)."""
         agent = OpenCodeAgent()
-        assert agent.supports_permission_prompts() is False
+        assert agent.supports_permission_prompts() is True
 
     def test_supports_permission_prompts_is_consistent(self):
         """Multiple calls return same value."""
         agent = OpenCodeAgent()
-        assert agent.supports_permission_prompts() is False
-        assert agent.supports_permission_prompts() is False
+        assert agent.supports_permission_prompts() is True
+        assert agent.supports_permission_prompts() is True
+
+
+class TestOpenCodeAgentAgentsMdTrigger:
+    """Test AGENTS.md trigger for daf-workflow skill (#430)."""
+
+    def test_ensure_trigger_appends_to_existing_agents_md(self, tmp_path):
+        """Test trigger is appended to an existing AGENTS.md."""
+        agent = OpenCodeAgent()
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        agents_md = project_dir / "AGENTS.md"
+        agents_md.write_text("# Existing agent instructions\n\nSome content.\n")
+
+        result = agent.ensure_agents_md_trigger(str(project_dir))
+
+        assert result is True
+        content = agents_md.read_text()
+        assert "# Existing agent instructions" in content
+        assert "Some content." in content
+        assert agent.AGENTS_MD_TRIGGER in content
+
+    def test_ensure_trigger_creates_agents_md_if_missing(self, tmp_path):
+        """Test AGENTS.md is created with trigger when file does not exist."""
+        agent = OpenCodeAgent()
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        result = agent.ensure_agents_md_trigger(str(project_dir))
+
+        assert result is True
+        agents_md = project_dir / "AGENTS.md"
+        assert agents_md.exists()
+        content = agents_md.read_text()
+        assert content == f"{agent.AGENTS_MD_TRIGGER}\n"
+
+    def test_ensure_trigger_idempotent(self, tmp_path):
+        """Test calling ensure_agents_md_trigger twice does not duplicate."""
+        agent = OpenCodeAgent()
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / "AGENTS.md").write_text("# Instructions\n")
+
+        # First call adds trigger
+        assert agent.ensure_agents_md_trigger(str(project_dir)) is True
+        content_after_first = (project_dir / "AGENTS.md").read_text()
+
+        # Second call is a no-op
+        assert agent.ensure_agents_md_trigger(str(project_dir)) is False
+        content_after_second = (project_dir / "AGENTS.md").read_text()
+
+        assert content_after_first == content_after_second
+        assert content_after_second.count(agent.AGENTS_MD_TRIGGER) == 1
+
+    def test_ensure_trigger_preserves_existing_content(self, tmp_path):
+        """Test existing AGENTS.md content is preserved when trigger is added."""
+        agent = OpenCodeAgent()
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        original = "# My Project\n\n## Guidelines\n\n- Follow PEP 8\n- Write tests\n"
+        (project_dir / "AGENTS.md").write_text(original)
+
+        agent.ensure_agents_md_trigger(str(project_dir))
+
+        content = (project_dir / "AGENTS.md").read_text()
+        assert content.startswith(original)
+        assert agent.AGENTS_MD_TRIGGER in content
+
+    def test_ensure_trigger_already_present(self, tmp_path):
+        """Test no modification when trigger line already exists."""
+        agent = OpenCodeAgent()
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        existing = f"# Instructions\n\n{agent.AGENTS_MD_TRIGGER}\n"
+        (project_dir / "AGENTS.md").write_text(existing)
+
+        result = agent.ensure_agents_md_trigger(str(project_dir))
+
+        assert result is False
+        assert (project_dir / "AGENTS.md").read_text() == existing
+
+    @patch("devflow.agent.opencode_agent.require_tool")
+    @patch("subprocess.Popen")
+    def test_launch_interactive_updates_agents_md(self, mock_popen, mock_require, tmp_path):
+        """Test interactive launch calls ensure_agents_md_trigger (#430)."""
+        agent = OpenCodeAgent()
+        mock_popen.return_value = Mock()
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        agent.launch_with_prompt(
+            project_path=str(project_dir),
+            initial_prompt="Work on feature",
+            session_id="test-id",
+        )
+
+        # AGENTS.md should have been created with trigger
+        agents_md = project_dir / "AGENTS.md"
+        assert agents_md.exists()
+        assert agent.AGENTS_MD_TRIGGER in agents_md.read_text()
+
+        # Command should NOT have --prompt
+        cmd = mock_popen.call_args[0][0]
+        assert "--prompt" not in cmd
+
+    @patch("devflow.agent.opencode_agent.require_tool")
+    @patch("subprocess.Popen")
+    def test_launch_headless_does_not_update_agents_md(self, mock_popen, mock_require, tmp_path):
+        """Test headless launch does NOT modify AGENTS.md (#430)."""
+        agent = OpenCodeAgent()
+        mock_popen.return_value = Mock()
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        agent.launch_with_prompt(
+            project_path=str(project_dir),
+            initial_prompt="Work on feature",
+            session_id="test-id",
+            headless=True,
+        )
+
+        # AGENTS.md should NOT have been created
+        agents_md = project_dir / "AGENTS.md"
+        assert not agents_md.exists()
+
+        # Command should have prompt via 'run'
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[1] == "run"
+        assert "Work on feature" in cmd
 
 
 class TestOpenCodeAgentFactory:


### PR DESCRIPTION
Got enough context from commits and diff. Here's the filled template:

---

<!-- This PR does not need a corresponding Jira item. -->

## Description

Changes the OpenCode agent to use an AGENTS.md trigger instead of the `--prompt` flag for interactive sessions. Previously, passing `--prompt` caused OpenCode's LLM to interpret it as blanket authorization to modify files, bypassing the native permission system. Now, in interactive mode:

- `ensure_agents_md_trigger()` injects a daf-workflow skill trigger into the project's `AGENTS.md` (idempotent — safe to call multiple times)
- The `--prompt` flag is no longer passed in interactive mode, preserving OpenCode's permission prompts
- `supports_permission_prompts()` now returns `True` to reflect this
- Headless mode (`opencode run`) still passes the prompt directly since no human is present

The `--prompt` flag is retained only for headless mode where there is no user to interact with permission dialogs.

Fixes: itdove/devaiflow#430

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run the test suite: `pytest tests/test_opencode_agent.py tests/test_agent_interface.py -v`
3. Verify interactive launch no longer includes `--prompt` in the command: check that `launch_session()` without `headless=True` produces `["opencode"]` (not `["opencode", "--prompt", ...]`)
4. Verify headless launch still passes the prompt: `launch_session(..., headless=True)` should produce `["opencode", "run", "<prompt>"]`
5. Verify `ensure_agents_md_trigger()` is idempotent: call it twice on the same project and confirm AGENTS.md contains only one trigger line
6. Verify `supports_permission_prompts()` returns `True`

### Scenarios tested
- Interactive session launch without `--prompt` flag
- Headless session launch with prompt passed via `opencode run`
- AGENTS.md trigger creation when file does not exist
- AGENTS.md trigger append when file exists but trigger is missing
- AGENTS.md unchanged when trigger already present (idempotent)
- `supports_permission_prompts()` returns `True`

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: