### PR TITLE
itdove/devaiflow#433: AGENTS.md daf-workflow trigger appended at end — not prominent enough, agent ignores it

### DIFF
--- a/devflow/agent/opencode_agent.py
+++ b/devflow/agent/opencode_agent.py
@@ -66,9 +66,25 @@ class OpenCodeAgent(AgentInterface):
 
         self.opencode_dir = Path(opencode_dir)
 
-    # Trigger line appended to the project's AGENTS.md so OpenCode
-    # discovers the daf-workflow skill on startup without --prompt.
-    AGENTS_MD_TRIGGER = (
+    # Prominent trigger block prepended to the project's AGENTS.md so
+    # OpenCode discovers the daf-workflow skill on startup without --prompt.
+    # Must be at the TOP of the file so the LLM sees it first.
+    AGENTS_MD_TRIGGER = "\n".join(
+        [
+            "# DevAIFlow Session",
+            "",
+            "**IMPORTANT:** If the `DAF_SESSION_NAME` environment variable is set, you MUST:",
+            "1. Read and follow the **daf-workflow** skill instructions immediately",
+            "2. Run `daf info` to get session metadata",
+            "3. Read the issue tracker ticket with comments",
+            "4. Start working on the task described in the session goal",
+            "",
+            "Do NOT wait for user input — begin the session initialization workflow now.",
+        ]
+    )
+
+    # Legacy trigger text (pre-#433) — detected for migration.
+    _LEGACY_TRIGGER = (
         "When DAF_SESSION_NAME environment variable is set, "
         "immediately follow the daf-workflow skill instructions."
     )
@@ -77,8 +93,12 @@ class OpenCodeAgent(AgentInterface):
         """Ensure the project's AGENTS.md contains the daf-workflow trigger.
 
         Checks if ``AGENTS.md`` in *project_path* already contains the trigger
-        line.  If the file exists but the line is missing, it is appended.  If
-        the file does not exist it is created with just the trigger line.
+        block.  If the file exists but the block is missing, it is **prepended**
+        at the top so the LLM sees it first.  If the file does not exist it is
+        created with just the trigger block.
+
+        When a legacy (pre-#433) single-line trigger is found, it is removed
+        and replaced by the new prominent block at the top of the file.
 
         The operation is idempotent -- calling it multiple times on the same
         project is safe and will not duplicate the trigger.
@@ -95,13 +115,23 @@ class OpenCodeAgent(AgentInterface):
 
         if agents_md.exists():
             content = agents_md.read_text()
-            if self.AGENTS_MD_TRIGGER not in content:
-                with open(agents_md, "a") as f:
-                    f.write(f"\n\n{self.AGENTS_MD_TRIGGER}\n")
-                return True
-            return False
 
-        # File does not exist -- create it with the trigger line.
+            # Already has the new trigger block — nothing to do.
+            if self.AGENTS_MD_TRIGGER in content:
+                return False
+
+            # Remove legacy trigger if present.
+            if self._LEGACY_TRIGGER in content:
+                content = content.replace(f"\n\n{self._LEGACY_TRIGGER}\n", "")
+                content = content.replace(f"{self._LEGACY_TRIGGER}\n", "")
+                content = content.replace(self._LEGACY_TRIGGER, "")
+
+            # Prepend the new trigger block at the top.
+            content = content.lstrip("\n")
+            agents_md.write_text(f"{self.AGENTS_MD_TRIGGER}\n\n{content}")
+            return True
+
+        # File does not exist -- create it with the trigger block.
         agents_md.write_text(f"{self.AGENTS_MD_TRIGGER}\n")
         return True
 

--- a/tests/test_opencode_agent.py
+++ b/tests/test_opencode_agent.py
@@ -559,10 +559,10 @@ class TestOpenCodeAgentPermissions:
 
 
 class TestOpenCodeAgentAgentsMdTrigger:
-    """Test AGENTS.md trigger for daf-workflow skill (#430)."""
+    """Test AGENTS.md trigger for daf-workflow skill (#430, #433)."""
 
-    def test_ensure_trigger_appends_to_existing_agents_md(self, tmp_path):
-        """Test trigger is appended to an existing AGENTS.md."""
+    def test_ensure_trigger_prepends_to_existing_agents_md(self, tmp_path):
+        """Test trigger is prepended to an existing AGENTS.md (#433)."""
         agent = OpenCodeAgent()
         project_dir = tmp_path / "project"
         project_dir.mkdir()
@@ -576,6 +576,8 @@ class TestOpenCodeAgentAgentsMdTrigger:
         assert "# Existing agent instructions" in content
         assert "Some content." in content
         assert agent.AGENTS_MD_TRIGGER in content
+        # Trigger must be at the TOP of the file
+        assert content.startswith(agent.AGENTS_MD_TRIGGER)
 
     def test_ensure_trigger_creates_agents_md_if_missing(self, tmp_path):
         """Test AGENTS.md is created with trigger when file does not exist."""
@@ -610,7 +612,7 @@ class TestOpenCodeAgentAgentsMdTrigger:
         assert content_after_second.count(agent.AGENTS_MD_TRIGGER) == 1
 
     def test_ensure_trigger_preserves_existing_content(self, tmp_path):
-        """Test existing AGENTS.md content is preserved when trigger is added."""
+        """Test existing AGENTS.md content is preserved below trigger (#433)."""
         agent = OpenCodeAgent()
         project_dir = tmp_path / "project"
         project_dir.mkdir()
@@ -620,21 +622,69 @@ class TestOpenCodeAgentAgentsMdTrigger:
         agent.ensure_agents_md_trigger(str(project_dir))
 
         content = (project_dir / "AGENTS.md").read_text()
-        assert content.startswith(original)
-        assert agent.AGENTS_MD_TRIGGER in content
+        # Trigger at top, existing content preserved below
+        assert content.startswith(agent.AGENTS_MD_TRIGGER)
+        assert original.strip() in content
 
     def test_ensure_trigger_already_present(self, tmp_path):
-        """Test no modification when trigger line already exists."""
+        """Test no modification when trigger block already exists."""
         agent = OpenCodeAgent()
         project_dir = tmp_path / "project"
         project_dir.mkdir()
-        existing = f"# Instructions\n\n{agent.AGENTS_MD_TRIGGER}\n"
+        existing = f"{agent.AGENTS_MD_TRIGGER}\n\n# Instructions\n"
         (project_dir / "AGENTS.md").write_text(existing)
 
         result = agent.ensure_agents_md_trigger(str(project_dir))
 
         assert result is False
         assert (project_dir / "AGENTS.md").read_text() == existing
+
+    def test_ensure_trigger_migrates_legacy_trigger(self, tmp_path):
+        """Test legacy trigger at end is replaced with new block at top (#433)."""
+        agent = OpenCodeAgent()
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        agents_md = project_dir / "AGENTS.md"
+        legacy_content = (
+            "# My Project Instructions\n\n"
+            "Follow the coding standards.\n\n"
+            f"{agent._LEGACY_TRIGGER}\n"
+        )
+        agents_md.write_text(legacy_content)
+
+        result = agent.ensure_agents_md_trigger(str(project_dir))
+
+        assert result is True
+        content = agents_md.read_text()
+        # New trigger at the top
+        assert content.startswith(agent.AGENTS_MD_TRIGGER)
+        # Legacy trigger removed
+        assert agent._LEGACY_TRIGGER not in content
+        # Original content preserved
+        assert "# My Project Instructions" in content
+        assert "Follow the coding standards." in content
+
+    def test_ensure_trigger_migrates_legacy_trigger_appended_with_newlines(self, tmp_path):
+        """Test legacy trigger appended with \\n\\n prefix is cleaned up (#433)."""
+        agent = OpenCodeAgent()
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        agents_md = project_dir / "AGENTS.md"
+        # Simulate the old append behavior: original content + \n\n + trigger + \n
+        legacy_content = (
+            "# Instructions\n\nSome content.\n"
+            f"\n\n{agent._LEGACY_TRIGGER}\n"
+        )
+        agents_md.write_text(legacy_content)
+
+        result = agent.ensure_agents_md_trigger(str(project_dir))
+
+        assert result is True
+        content = agents_md.read_text()
+        assert content.startswith(agent.AGENTS_MD_TRIGGER)
+        assert agent._LEGACY_TRIGGER not in content
+        assert "# Instructions" in content
+        assert "Some content." in content
 
     @patch("devflow.agent.opencode_agent.require_tool")
     @patch("subprocess.Popen")


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN>
<!-- This PR does not need a corresponding Jira item. -->

## Description

Fixes [#433](https://github.com/itdove/devaiflow/issues/433): The daf-workflow trigger was appended to the end of AGENTS.md, where LLMs often ignore it. This change replaces the single-line append with a prominent multi-line instruction block that is **prepended** to the top of the file, ensuring the agent sees and follows the daf-workflow skill on session startup.

Key changes:
- Replace `AGENTS_MD_TRIGGER` single-line string with a structured, prominent multi-line block containing numbered steps
- Change `ensure_agents_md_trigger()` from appending to **prepending** the trigger at the top of AGENTS.md
- Add legacy trigger detection and migration — old single-line triggers are removed and replaced with the new block
- Preserve `_LEGACY_TRIGGER` constant for backward-compatible detection

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `pytest tests/test_opencode_agent.py::TestOpenCodeAgentAgentsMdTrigger -v` to verify all trigger tests pass
3. Create a temp project directory with an existing AGENTS.md containing other content
4. Run `daf open` against that project and verify the trigger block appears at the **top** of AGENTS.md, not appended at the bottom
5. Run `daf open` again against the same project and verify no duplicate trigger is added (idempotent)
6. Create an AGENTS.md with the old legacy trigger text ("When DAF_SESSION_NAME environment variable is set...") and run `daf open` — verify the legacy trigger is removed and replaced by the new block at the top

### Scenarios tested
- Trigger prepended to existing AGENTS.md with preserved content below
- AGENTS.md created from scratch when missing
- Idempotent — no duplicate on repeated calls
- Legacy trigger migration (both `\n\n`-prefixed and plain variants)
- Existing content fully preserved after migration

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: