### PR TITLE
itdove/devaiflow#437: tput reset and stty sane ineffective — stdout/stdin redirected to DEVNULL

### DIFF
--- a/devflow/cli/utils.py
+++ b/devflow/cli/utils.py
@@ -46,8 +46,6 @@ def reset_terminal_after_tui() -> None:
     try:
         subprocess.run(
             ["stty", "sane"],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
     except (OSError, FileNotFoundError):
@@ -55,8 +53,6 @@ def reset_terminal_after_tui() -> None:
     try:
         subprocess.run(
             ["tput", "reset"],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
     except (OSError, FileNotFoundError):

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -973,17 +973,17 @@ class TestResetTerminalAfterTui:
         assert "\033[?1049l" in written
         assert "\033[0m" in written
         assert mock_run.call_count == 2
-        # First call: stty sane
+        # First call: stty sane — only stderr suppressed (stdin/stdout inherit terminal)
         stty_args = mock_run.call_args_list[0]
         assert stty_args[0][0] == ["stty", "sane"]
-        assert stty_args[1]["stdin"] == subprocess.DEVNULL
-        assert stty_args[1]["stdout"] == subprocess.DEVNULL
+        assert "stdin" not in stty_args[1]
+        assert "stdout" not in stty_args[1]
         assert stty_args[1]["stderr"] == subprocess.DEVNULL
-        # Second call: tput reset
+        # Second call: tput reset — only stderr suppressed (stdout delivers reset sequences)
         tput_args = mock_run.call_args_list[1]
         assert tput_args[0][0] == ["tput", "reset"]
-        assert tput_args[1]["stdin"] == subprocess.DEVNULL
-        assert tput_args[1]["stdout"] == subprocess.DEVNULL
+        assert "stdin" not in tput_args[1]
+        assert "stdout" not in tput_args[1]
         assert tput_args[1]["stderr"] == subprocess.DEVNULL
 
     @patch("subprocess.run", side_effect=OSError("command not found"))


### PR DESCRIPTION
Jira Issue: <!-- This PR does not need a corresponding Jira item. -->
GitHub Issue: https://github.com/itdove/devaiflow/issues/437

## Description

`stty sane` and `tput reset` were being called with `stdin=subprocess.DEVNULL` and `stdout=subprocess.DEVNULL`, which prevented them from actually resetting the terminal. `stty sane` needs to read the real terminal's stdin to reconfigure it, and `tput reset` needs to write escape sequences to stdout for them to take effect. This fix removes the stdin/stdout redirections while keeping `stderr=subprocess.DEVNULL` to suppress error noise.

**Changes:**
- Remove `stdin=subprocess.DEVNULL` and `stdout=subprocess.DEVNULL` from `stty sane` and `tput reset` calls in `devflow/cli/utils.py`
- Update tests to assert stdin/stdout are not redirected (inherited from parent process)

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run the test suite: `pytest tests/test_cli_utils.py::TestResetTerminalAfterTui -v`
3. Launch a TUI session (e.g., `daf opencode`), exit it, and verify terminal is properly restored (echo, cursor, line discipline all normal)
4. Verify no stray escape sequences or garbled output after TUI exit

### Scenarios tested
- Unit tests verify `stty sane` and `tput reset` are called without stdin/stdout redirection
- Unit tests verify `stderr=subprocess.DEVNULL` is still set
- OSError handling path tested (commands not found)

## Deployment considerations

- [x] This code change is ready for deployment on its own