### PR TITLE
itdove/devaiflow#442: OpenCode session resume broken: creates new session instead of continuing

### DIFF
--- a/devflow/cli/commands/git_new_command.py
+++ b/devflow/cli/commands/git_new_command.py
@@ -584,6 +584,7 @@ def create_git_issue_session(
         working_directory=working_directory,
         project_path=project_path,
         branch=branch,
+        agent_backend=config.agent_backend if config else "claude",
     )
 
     # Set session_type to "ticket_creation"

--- a/devflow/cli/commands/git_open_command.py
+++ b/devflow/cli/commands/git_open_command.py
@@ -148,6 +148,7 @@ def git_open_session(
         working_directory=working_directory,
         project_path=project_path,
         branch=None,  # Will be set when user starts working
+        agent_backend=config.agent_backend if config else "claude",
     )
 
     # Set session_type to "development"

--- a/devflow/cli/commands/info_command.py
+++ b/devflow/cli/commands/info_command.py
@@ -279,6 +279,9 @@ def _display_full_session_info(
     # AAP-63377: Display workspace
     if session.workspace_name:
         console.print(f"[bold]Workspace:[/bold] [cyan]{session.workspace_name}[/cyan]")
+    # Display agent backend if stored (issue #442)
+    if session.agent_backend:
+        console.print(f"[bold]Agent Backend:[/bold] [cyan]{session.agent_backend}[/cyan]")
     if session.goal:
         console.print(f"[bold]Goal:[/bold] {session.goal}")
     console.print()

--- a/devflow/cli/commands/investigate_command.py
+++ b/devflow/cli/commands/investigate_command.py
@@ -580,6 +580,7 @@ def create_investigation_session(
         project_path=project_path,
         branch=None,  # No branch for investigation sessions
         model_profile=model_profile,
+        agent_backend=config.agent_backend if config else "claude",
     )
 
     # Set session_type to "investigation"

--- a/devflow/cli/commands/jira_new_command.py
+++ b/devflow/cli/commands/jira_new_command.py
@@ -480,6 +480,7 @@ def create_jira_ticket_session(
         working_directory=working_directory,
         project_path=project_path,
         branch=branch,  # Use provided branch or None for no branch
+        agent_backend=config.agent_backend if config else "claude",
     )
 
     # Set session_type to "ticket_creation"

--- a/devflow/cli/commands/jira_open_command.py
+++ b/devflow/cli/commands/jira_open_command.py
@@ -125,6 +125,7 @@ def jira_open_session(issue_key: str, headless: bool = False, auto_approve: bool
         working_directory=working_directory,
         project_path=project_path,
         branch=None,  # No branch for ticket creation sessions
+        agent_backend=config.agent_backend if config else "claude",
     )
 
     # Set session_type to "ticket_creation"

--- a/devflow/cli/commands/new_command.py
+++ b/devflow/cli/commands/new_command.py
@@ -775,6 +775,7 @@ def create_new_session(
             branch=branch,
             ai_agent_session_id=session_id,
             model_profile=model_profile,
+            agent_backend=config.agent_backend if config else "claude",
         )
 
         # Set base_branch to source_branch if available (fixes #139 - no sync prompt after creating branch)
@@ -821,9 +822,12 @@ def create_new_session(
             console.print(f"\n[dim]Start later with: daf open {name}[/dim]")
         return
 
-    # Change to project directory and launch Claude Code
+    # Change to project directory and launch AI agent
     try:
-        console.print(f"\n[cyan]Launching Claude Code in {project_path}...[/cyan]")
+        _agent_backend = config.agent_backend if config else "claude"
+        from devflow.agent import create_agent_client as _cac
+        _agent_display_name = _cac(_agent_backend).get_agent_name().title()
+        console.print(f"\n[cyan]Launching {_agent_display_name} in {project_path}...[/cyan]")
 
         # Update session status and start work session
         session.status = "in_progress"
@@ -923,13 +927,13 @@ def create_new_session(
                 _prompt_for_complete_on_exit(session, config)
 
     except Exception as e:
-        console.print(f"\n[red]Error launching Claude Code:[/red] {e}")
+        console.print(f"\n[red]Error launching {_agent_display_name}:[/red] {e}")
 
         # Update session status to paused on error
         session.status = "paused"
         session_manager.update_session(session)
 
-        # Auto-pause: End work session even if Claude launch failed
+        # Auto-pause: End work session even if agent launch failed
         try:
             session_manager.end_work_session(name)
         except Exception:

--- a/devflow/cli/commands/new_command_multiproject.py
+++ b/devflow/cli/commands/new_command_multiproject.py
@@ -255,6 +255,7 @@ def create_multi_project_session(
         branch=None,
         ai_agent_session_id=None,  # Will be set by add_multi_project_conversation
         model_profile=model_profile,
+        agent_backend=config.agent_backend if config else "claude",
     )
 
     # Add multi-project conversation (ONE conversation for all projects)

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -557,55 +557,52 @@ def open_session(
     # Check if this is a first-time launch
     # This happens when:
     # 1. Sessions created via 'daf sync' (no ai_agent_session_id)
-    # 2. Session has a ai_agent_session_id but conversation file doesn't exist
+    # 2. Session has a ai_agent_session_id but the agent reports the session doesn't exist
     # Use conversation-based API
     active_conv = session.active_conversation
     is_first_launch = not (active_conv and active_conv.ai_agent_session_id)
 
+    # Resolve effective agent backend: session-stored > config > "claude" (backward compatible)
+    effective_agent_backend = session.agent_backend or (config.agent_backend if config else "claude")
+
     if active_conv and active_conv.ai_agent_session_id and active_conv.project_path:
-        # For ticket_creation and investigation sessions, check conversation file at stable location
-        # Stable location uses original_project_path for sessions with temp_directory
+        # Check if the session exists using the agent-aware check
+        # This handles both Claude (.jsonl file) and OpenCode (database query) correctly
         from devflow.agent import create_agent_client
-        agent_backend = config.agent_backend if config else "claude"
-        agent = create_agent_client(agent_backend)
-        capture = SessionCapture(agent=agent)
+        agent = create_agent_client(effective_agent_backend)
+        agent_name = agent.get_agent_name()
 
-        # Determine the correct location to check for conversation file
+        # Determine the correct project path to check for session existence
         if session.session_type in ("ticket_creation", "investigation") and active_conv and active_conv.original_project_path:
-            # Use stable location based on original_project_path
-            # This ensures we find the conversation even if temp directory was deleted
-            session_dir = capture.get_session_dir(active_conv.original_project_path)
-            console.print(f"[dim]Checking for conversation file at stable location ({session.session_type} session)...[/dim]")
+            check_path = active_conv.original_project_path
+            console.print(f"[dim]Checking for existing {agent_name} session at stable location ({session.session_type} session)...[/dim]")
         else:
-            # Use current project path for normal sessions
-            session_dir = capture.get_session_dir(active_conv.project_path)
-            console.print(f"[dim]Checking for conversation file...[/dim]")
+            check_path = active_conv.project_path
+            console.print(f"[dim]Checking for existing {agent_name} session...[/dim]")
 
-        conversation_file = session_dir / f"{active_conv.ai_agent_session_id}.jsonl"
-        conversation_exists = conversation_file.exists() and conversation_file.stat().st_size > 0
+        conversation_exists = agent.session_exists(active_conv.ai_agent_session_id, check_path)
         console.print(f"[dim]  {'found' if conversation_exists else 'not found'}[/dim]")
 
         if not conversation_exists:
             if session.session_type in ("ticket_creation", "investigation"):
-                # For ticket_creation and investigation sessions, no conversation at stable location means first launch
+                # For ticket_creation and investigation sessions, no session at stable location means first launch
                 # Don't generate new session ID yet - will check again after temp directory handling
-                console.print(f"[dim]No conversation at stable location - will verify after temp directory handling[/dim]")
+                console.print(f"[dim]No session at stable location - will verify after temp directory handling[/dim]")
             else:
-                # Normal sessions: missing conversation file means we need a new session ID
-                if conversation_file.exists():
-                    console.print(f"\n[yellow]⚠ Conversation file is empty or invalid[/yellow]")
-                else:
-                    console.print(f"\n[yellow]⚠ Conversation file not found for session {active_conv.ai_agent_session_id}[/yellow]")
-                console.print(f"[dim]This can happen if the session was interrupted or Claude Code failed to start.[/dim]")
+                # Normal sessions: missing session means we need a new session ID
+                console.print(f"\n[yellow]⚠ Session not found for {agent_name} session {active_conv.ai_agent_session_id}[/yellow]")
+                console.print(f"[dim]This can happen if the session was interrupted or {agent_name} failed to start.[/dim]")
                 console.print(f"[dim]Will create a new conversation with a new session ID.[/dim]")
                 is_first_launch = True
 
     if is_first_launch:
         console.print(f"\n[cyan]First-time launch for session: {session.name}[/cyan]")
         if not (active_conv and active_conv.ai_agent_session_id):
-            console.print(f"[dim]This session was synced from JIRA but hasn't been opened yet.[/dim]")
+            console.print(f"[dim]This session was synced but hasn't been opened yet.[/dim]")
 
-        # Generate a new Claude session ID for the active conversation
+        # Generate a new session ID for the active conversation
+        # For Claude-style agents (claude, ollama), use UUID format
+        # For other agents (opencode), use a placeholder that will be replaced after launch
         import uuid
         new_session_id = str(uuid.uuid4())
 
@@ -650,22 +647,19 @@ def open_session(
         # Refresh active_conv after temp directory handling
         active_conv = session.active_conversation
 
-        # After temp directory handling, verify if conversation file was restored
+        # After temp directory handling, verify if session was restored
         # If not, we need to treat this as a first launch
         if not is_first_launch and active_conv and active_conv.ai_agent_session_id and active_conv.project_path:
             from devflow.agent import create_agent_client
-            agent_backend = config.agent_backend if config else "claude"
-            agent = create_agent_client(agent_backend)
-            capture = SessionCapture(agent=agent)
-            session_dir = capture.get_session_dir(active_conv.project_path)
-            conversation_file = session_dir / f"{active_conv.ai_agent_session_id}.jsonl"
+            agent = create_agent_client(effective_agent_backend)
+            agent_name = agent.get_agent_name()
 
-            conversation_exists = conversation_file.exists() and conversation_file.stat().st_size > 0
+            conversation_exists = agent.session_exists(active_conv.ai_agent_session_id, active_conv.project_path)
 
             if not conversation_exists:
-                # Conversation file was not restored - this means user quit the session early
+                # Session was not restored - this means user quit the session early
                 # before any conversation was created. Generate a new session ID.
-                console.print(f"\n[yellow]⚠ Conversation file was not restored (session was quit before any work was done)[/yellow]")
+                console.print(f"\n[yellow]⚠ {agent_name} session was not restored (session was quit before any work was done)[/yellow]")
                 console.print(f"[dim]Generating new session ID for fresh start[/dim]")
                 is_first_launch = True
 
@@ -961,11 +955,14 @@ def open_session(
     if not should_launch_claude_code(config=config, mock_mode=True):
         return
 
-    # Display launch/resume message
+    # Display launch/resume message using correct agent name
+    from devflow.agent import create_agent_client as _create_agent
+    _display_agent = _create_agent(effective_agent_backend)
+    _display_agent_name = _display_agent.get_agent_name().title()
     if is_first_launch:
-        console.print(f"\n[cyan]Launching Claude Code for the first time...[/cyan]")
+        console.print(f"\n[cyan]Launching {_display_agent_name} for the first time...[/cyan]")
     else:
-        console.print(f"\n[cyan]Resuming Claude Code session...[/cyan]")
+        console.print(f"\n[cyan]Resuming {_display_agent_name} session...[/cyan]")
 
     # Update session status and start work session
     session.status = "in_progress"
@@ -1082,8 +1079,8 @@ def open_session(
                 project_path = active_conv.project_path if active_conv else None
                 launch_dir = active_conv.project_path if active_conv else None
 
-            # Get agent backend from config
-            agent_backend = config.agent_backend if config else "claude"
+            # Use effective agent backend (session-stored > config > "claude")
+            agent_backend = effective_agent_backend
             agent = create_agent_client(agent_backend)
 
             # Warn if agent does not support permission prompts
@@ -1126,7 +1123,7 @@ def open_session(
                         reset_terminal_after_tui()
             finally:
                 if not is_cleanup_done():
-                    console.print(f"\n[green]✓[/green] Claude session completed")
+                    console.print(f"\n[green]✓[/green] {_display_agent_name} session completed")
 
                     # Capture real OpenCode session ID after first launch
                     if agent_backend in ("opencode", "opencode-ai") and launch_dir and active_conv:
@@ -1160,10 +1157,10 @@ def open_session(
                     _prompt_for_complete_on_exit(session, config)
         else:
             # Resume existing session
-            # Get agent backend from config
+            # Use effective agent backend (session-stored > config > "claude")
             from devflow.agent import create_agent_client
 
-            agent_backend = config.agent_backend if config else "claude"
+            agent_backend = effective_agent_backend
             agent = create_agent_client(agent_backend)
 
             # For Claude and Ollama agents, use resume with skills directories
@@ -1296,7 +1293,7 @@ def open_session(
                     from devflow.cli.utils import reset_terminal_after_tui
                     reset_terminal_after_tui()
                 if not is_cleanup_done():
-                    console.print(f"\n[green]✓[/green] Claude session completed")
+                    console.print(f"\n[green]✓[/green] {_display_agent_name} session completed")
 
                     # Update session status to paused
                     session.status = "paused"
@@ -1319,13 +1316,13 @@ def open_session(
                     _prompt_for_complete_on_exit(session, config)
 
     except Exception as e:
-        console.print(f"\n[red]Error launching Claude Code:[/red] {e}")
+        console.print(f"\n[red]Error launching {_display_agent_name}:[/red] {e}")
 
         # Update session status to paused on error
         session.status = "paused"
         session_manager.update_session(session)
 
-        # Auto-pause: End work session even if Claude launch failed
+        # Auto-pause: End work session even if agent launch failed
         try:
             session_manager.end_work_session(identifier)
         except Exception:
@@ -1333,9 +1330,19 @@ def open_session(
             pass
 
         if active_conv and active_conv.ai_agent_session_id:
-            console.print(f"\n[yellow]You can manually resume with:[/yellow]")
-            console.print(f"  cd {active_conv.project_path}")
-            console.print(f"  claude --resume {active_conv.ai_agent_session_id}")
+            # Show agent-specific manual resume instructions
+            if effective_agent_backend in ("opencode", "opencode-ai"):
+                console.print(f"\n[yellow]You can manually resume with:[/yellow]")
+                console.print(f"  cd {active_conv.project_path}")
+                console.print(f"  opencode --session {active_conv.ai_agent_session_id}")
+            elif effective_agent_backend in ("ollama", "ollama-claude"):
+                console.print(f"\n[yellow]You can manually resume with:[/yellow]")
+                console.print(f"  cd {active_conv.project_path}")
+                console.print(f"  ollama launch claude --resume {active_conv.ai_agent_session_id}")
+            else:
+                console.print(f"\n[yellow]You can manually resume with:[/yellow]")
+                console.print(f"  cd {active_conv.project_path}")
+                console.print(f"  claude --resume {active_conv.ai_agent_session_id}")
 
 
 def _check_and_warn_feature_orchestration(session, session_manager) -> bool:
@@ -3362,9 +3369,17 @@ def _copy_conversation_to_temp(session, temp_dir: str, config=None) -> bool:
         return False
 
     # Get conversation file from stable location (based on original_project_path)
+    # Use session's stored agent_backend for correct path resolution
     from devflow.agent import create_agent_client
-    agent_backend = config.agent_backend if config else "claude"
-    agent = create_agent_client(agent_backend)
+    effective_backend = (session.agent_backend if hasattr(session, 'agent_backend') and session.agent_backend else None) or (config.agent_backend if config else "claude")
+    agent = create_agent_client(effective_backend)
+
+    # Conversation file copy only applies to file-based agents (claude, ollama)
+    # For agents that use databases (opencode), skip this operation
+    if effective_backend in ("opencode", "opencode-ai"):
+        console.print(f"[dim]Skipping conversation file copy ({agent.get_agent_name()} uses database storage)[/dim]")
+        return False
+
     capture = SessionCapture(agent=agent)
     stable_session_dir = capture.get_session_dir(conv.original_project_path)
     stable_conversation_file = stable_session_dir / f"{conv.ai_agent_session_id}.jsonl"
@@ -3422,8 +3437,14 @@ def _copy_conversation_from_temp(session, temp_dir: str, config=None) -> bool:
     # Use resolved path to handle macOS /var -> /private/var canonicalization
     # SessionCapture now correctly encodes underscores as dashes
     from devflow.agent import create_agent_client
-    agent_backend = config.agent_backend if config else "claude"
-    agent = create_agent_client(agent_backend)
+    effective_backend = (session.agent_backend if hasattr(session, 'agent_backend') and session.agent_backend else None) or (config.agent_backend if config else "claude")
+    agent = create_agent_client(effective_backend)
+
+    # Conversation file copy only applies to file-based agents (claude, ollama)
+    if effective_backend in ("opencode", "opencode-ai"):
+        console.print(f"[dim]Skipping conversation file save ({agent.get_agent_name()} uses database storage)[/dim]")
+        return False
+
     capture = SessionCapture(agent=agent)
     temp_path_resolved = str(Path(temp_dir).resolve())
 

--- a/devflow/cli/commands/ticket_creation_multiproject.py
+++ b/devflow/cli/commands/ticket_creation_multiproject.py
@@ -94,6 +94,7 @@ def create_multi_project_ticket_creation_session(
         project_path=None,
         branch=None,
         ai_agent_session_id=None,  # Will be set by add_multi_project_conversation
+        agent_backend=config.agent_backend if config else "claude",
     )
 
     # Set session_type to "ticket_creation"

--- a/devflow/config/models.py
+++ b/devflow/config/models.py
@@ -894,6 +894,10 @@ class Session(BaseModel):
     # Model provider override (session-specific)
     model_profile: Optional[str] = None  # Override default model profile for this session (e.g., "vertex", "llama-cpp")
 
+    # Agent backend used to create this session (persisted for correct resume behavior)
+    # When None, falls back to config.agent_backend (backward compatible with existing sessions)
+    agent_backend: Optional[str] = None  # "claude" | "opencode" | "ollama" | "github-copilot" | etc.
+
     # Issue tracker abstraction
     # Replaces JIRA-specific fields with tracker-agnostic structure
     issue_tracker: Optional[str] = "jira"  # "jira" | "github" | "gitlab" | etc. | None (use pattern detection)

--- a/devflow/session/manager.py
+++ b/devflow/session/manager.py
@@ -53,6 +53,7 @@ class SessionManager:
         ai_agent_session_id: Optional[str] = None,
         issue_key: Optional[str] = None,
         model_profile: Optional[str] = None,
+        agent_backend: Optional[str] = None,
     ) -> Session:
         """Create a new session.
 
@@ -65,6 +66,7 @@ class SessionManager:
             ai_agent_session_id: Claude Code session UUID
             issue_key: Optional issue tracker key
             model_profile: Optional model provider profile override (e.g., "vertex", "llama-cpp")
+            agent_backend: Optional AI agent backend used for this session (e.g., "claude", "opencode")
 
         Returns:
             Created Session object
@@ -76,6 +78,7 @@ class SessionManager:
             working_directory=working_directory,
             status="created",
             model_profile=model_profile,
+            agent_backend=agent_backend,
         )
 
         # Create initial conversation if we have the required info (NEW in PROJ-59791)

--- a/tests/test_session_agent_backend.py
+++ b/tests/test_session_agent_backend.py
@@ -1,0 +1,304 @@
+"""Tests for agent_backend persistence in sessions (issue #442).
+
+Verifies that:
+1. agent_backend is stored in Session model on creation
+2. SessionManager.create_session() accepts agent_backend parameter
+3. Stored agent_backend is used when reopening sessions
+4. Backward compatible: sessions without agent_backend fall back to config
+5. Agent-aware session existence check works correctly
+6. Correct agent name is shown in messages
+"""
+
+import json
+import os
+import uuid
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+
+import pytest
+
+from devflow.config.models import Session, ConversationContext, Conversation
+
+
+class TestSessionAgentBackendField:
+    """Test agent_backend field on Session model."""
+
+    def test_session_has_agent_backend_field(self):
+        """Test that Session model has agent_backend field."""
+        session = Session(name="test", goal="test goal")
+        assert hasattr(session, "agent_backend")
+
+    def test_agent_backend_defaults_to_none(self):
+        """Test that agent_backend defaults to None for backward compatibility."""
+        session = Session(name="test", goal="test goal")
+        assert session.agent_backend is None
+
+    def test_agent_backend_can_be_set_to_claude(self):
+        """Test setting agent_backend to claude."""
+        session = Session(name="test", goal="test goal", agent_backend="claude")
+        assert session.agent_backend == "claude"
+
+    def test_agent_backend_can_be_set_to_opencode(self):
+        """Test setting agent_backend to opencode."""
+        session = Session(name="test", goal="test goal", agent_backend="opencode")
+        assert session.agent_backend == "opencode"
+
+    def test_agent_backend_can_be_set_to_ollama(self):
+        """Test setting agent_backend to ollama."""
+        session = Session(name="test", goal="test goal", agent_backend="ollama")
+        assert session.agent_backend == "ollama"
+
+    def test_agent_backend_serialization(self):
+        """Test that agent_backend is included in JSON serialization."""
+        session = Session(name="test", goal="test goal", agent_backend="opencode")
+        data = session.model_dump(mode="json")
+        assert "agent_backend" in data
+        assert data["agent_backend"] == "opencode"
+
+    def test_agent_backend_deserialization(self):
+        """Test that agent_backend is correctly loaded from JSON."""
+        data = {
+            "name": "test",
+            "goal": "test goal",
+            "agent_backend": "opencode",
+            "status": "created",
+            "created": datetime.now().isoformat(),
+            "last_active": datetime.now().isoformat(),
+        }
+        session = Session(**data)
+        assert session.agent_backend == "opencode"
+
+    def test_agent_backend_none_serialization(self):
+        """Test that None agent_backend is preserved in serialization."""
+        session = Session(name="test", goal="test goal")
+        data = session.model_dump(mode="json")
+        assert data["agent_backend"] is None
+
+    def test_backward_compatible_without_agent_backend_key(self):
+        """Test loading old sessions that don't have agent_backend key."""
+        data = {
+            "name": "test",
+            "goal": "test goal",
+            "status": "created",
+            "created": datetime.now().isoformat(),
+            "last_active": datetime.now().isoformat(),
+        }
+        session = Session(**data)
+        assert session.agent_backend is None
+
+
+class TestSessionManagerCreateWithAgentBackend:
+    """Test SessionManager.create_session() with agent_backend parameter."""
+
+    def test_create_session_with_agent_backend(self, tmp_path):
+        """Test that create_session stores agent_backend."""
+        from devflow.session.manager import SessionManager
+        from devflow.config.loader import ConfigLoader
+
+        config_dir = tmp_path / ".daf-sessions"
+        config_dir.mkdir()
+
+        config_loader = ConfigLoader(config_dir=config_dir)
+        session_manager = SessionManager(config_loader=config_loader)
+
+        session = session_manager.create_session(
+            name="test-session",
+            goal="test goal",
+            agent_backend="opencode",
+        )
+
+        assert session.agent_backend == "opencode"
+
+    def test_create_session_without_agent_backend(self, tmp_path):
+        """Test that create_session defaults agent_backend to None."""
+        from devflow.session.manager import SessionManager
+        from devflow.config.loader import ConfigLoader
+
+        config_dir = tmp_path / ".daf-sessions"
+        config_dir.mkdir()
+
+        config_loader = ConfigLoader(config_dir=config_dir)
+        session_manager = SessionManager(config_loader=config_loader)
+
+        session = session_manager.create_session(
+            name="test-session",
+            goal="test goal",
+        )
+
+        assert session.agent_backend is None
+
+    def test_create_session_agent_backend_persisted(self, tmp_path):
+        """Test that agent_backend is persisted to disk and can be loaded."""
+        from devflow.session.manager import SessionManager
+        from devflow.config.loader import ConfigLoader
+
+        config_dir = tmp_path / ".daf-sessions"
+        config_dir.mkdir()
+
+        config_loader = ConfigLoader(config_dir=config_dir)
+        session_manager = SessionManager(config_loader=config_loader)
+
+        session_manager.create_session(
+            name="test-session",
+            goal="test goal",
+            agent_backend="opencode",
+        )
+
+        # Load it back
+        loaded_session = session_manager.get_session("test-session")
+        assert loaded_session is not None
+        assert loaded_session.agent_backend == "opencode"
+
+
+class TestEffectiveAgentBackendResolution:
+    """Test the resolution logic: session.agent_backend > config.agent_backend > 'claude'."""
+
+    def test_session_backend_takes_precedence(self):
+        """Test that session's stored backend takes precedence over config."""
+        session = Session(name="test", goal="test", agent_backend="opencode")
+        config_backend = "claude"
+
+        effective = session.agent_backend or config_backend
+        assert effective == "opencode"
+
+    def test_config_backend_used_when_session_is_none(self):
+        """Test that config backend is used when session has no stored backend."""
+        session = Session(name="test", goal="test", agent_backend=None)
+        config_backend = "opencode"
+
+        effective = session.agent_backend or config_backend
+        assert effective == "opencode"
+
+    def test_default_claude_when_both_none(self):
+        """Test that 'claude' is the final fallback."""
+        session = Session(name="test", goal="test", agent_backend=None)
+        config_backend = None
+
+        effective = session.agent_backend or (config_backend or "claude")
+        assert effective == "claude"
+
+
+class TestAgentAwareSessionExistence:
+    """Test that agent.session_exists() is used correctly for different backends."""
+
+    def test_claude_session_exists_checks_file(self, tmp_path):
+        """Test that ClaudeAgent.session_exists() checks .jsonl file."""
+        from devflow.agent import ClaudeAgent
+
+        agent = ClaudeAgent(claude_dir=tmp_path / ".claude")
+
+        # Create the expected directory and file
+        project_path = str(tmp_path / "my-project")
+        os.makedirs(project_path, exist_ok=True)
+
+        session_id = str(uuid.uuid4())
+        encoded = agent.encode_project_path(project_path)
+        session_dir = tmp_path / ".claude" / "projects" / encoded
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / f"{session_id}.jsonl").write_text('{"type":"test"}')
+
+        assert agent.session_exists(session_id, project_path) is True
+
+    def test_claude_session_not_exists_when_no_file(self, tmp_path):
+        """Test that ClaudeAgent.session_exists() returns False when no file."""
+        from devflow.agent import ClaudeAgent
+
+        agent = ClaudeAgent(claude_dir=tmp_path / ".claude")
+        project_path = str(tmp_path / "my-project")
+        os.makedirs(project_path, exist_ok=True)
+
+        session_id = str(uuid.uuid4())
+        assert agent.session_exists(session_id, project_path) is False
+
+    @patch("devflow.agent.opencode_agent.OpenCodeAgent.get_existing_sessions")
+    def test_opencode_session_exists_queries_cli(self, mock_get_sessions, tmp_path):
+        """Test that OpenCodeAgent.session_exists() queries via CLI."""
+        from devflow.agent import OpenCodeAgent
+
+        agent = OpenCodeAgent(opencode_dir=tmp_path / ".config" / "opencode")
+        session_id = "ses_abc123def456"
+        mock_get_sessions.return_value = {session_id, "ses_other"}
+
+        assert agent.session_exists(session_id, str(tmp_path)) is True
+
+    @patch("devflow.agent.opencode_agent.OpenCodeAgent.get_existing_sessions")
+    def test_opencode_session_not_exists_when_not_in_list(self, mock_get_sessions, tmp_path):
+        """Test that OpenCodeAgent.session_exists() returns False when ID not in list."""
+        from devflow.agent import OpenCodeAgent
+
+        agent = OpenCodeAgent(opencode_dir=tmp_path / ".config" / "opencode")
+        mock_get_sessions.return_value = {"ses_other"}
+
+        assert agent.session_exists("ses_abc123", str(tmp_path)) is False
+
+
+class TestAgentBackendInExportImport:
+    """Test that agent_backend is preserved during export/import."""
+
+    def test_agent_backend_included_in_export(self):
+        """Test that agent_backend is NOT excluded from session export."""
+        session = Session(
+            name="test",
+            goal="test goal",
+            agent_backend="opencode",
+        )
+        # The export code uses model_dump(exclude={'workspace_name'})
+        # agent_backend should NOT be in the exclude set
+        data = session.model_dump(mode="json", exclude={"workspace_name"})
+        assert "agent_backend" in data
+        assert data["agent_backend"] == "opencode"
+
+    def test_agent_backend_none_excluded_from_export_is_fine(self):
+        """Test that None agent_backend is handled in export."""
+        session = Session(name="test", goal="test goal", agent_backend=None)
+        data = session.model_dump(mode="json", exclude={"workspace_name"})
+        assert data["agent_backend"] is None
+
+
+class TestCopyConversationSkippedForNonFileAgents:
+    """Test that _copy_conversation_to/from_temp is skipped for non-file-based agents."""
+
+    def test_copy_conversation_skipped_for_opencode(self, tmp_path):
+        """Test that conversation file copy is skipped for OpenCode sessions."""
+        from devflow.cli.commands.open_command import _copy_conversation_to_temp
+
+        session = Session(
+            name="test",
+            goal="test goal",
+            agent_backend="opencode",
+        )
+        conv = ConversationContext(
+            ai_agent_session_id="ses_abc123",
+            project_path=str(tmp_path / "project"),
+            original_project_path=str(tmp_path / "original"),
+        )
+        conversation = Conversation(active_session=conv)
+        session.conversations["test-repo"] = conversation
+        session.working_directory = "test-repo"
+
+        # Should return False and skip without error
+        result = _copy_conversation_to_temp(session, str(tmp_path / "temp"))
+        assert result is False
+
+    def test_copy_conversation_skipped_for_opencode_from_temp(self, tmp_path):
+        """Test that conversation file save is skipped for OpenCode sessions."""
+        from devflow.cli.commands.open_command import _copy_conversation_from_temp
+
+        session = Session(
+            name="test",
+            goal="test goal",
+            agent_backend="opencode",
+        )
+        conv = ConversationContext(
+            ai_agent_session_id="ses_abc123",
+            project_path=str(tmp_path / "project"),
+            original_project_path=str(tmp_path / "original"),
+        )
+        conversation = Conversation(active_session=conv)
+        session.conversations["test-repo"] = conversation
+        session.working_directory = "test-repo"
+
+        # Should return False and skip without error
+        result = _copy_conversation_from_temp(session, str(tmp_path / "temp"))
+        assert result is False

--- a/tests/test_ticket_creation_session_reopen.py
+++ b/tests/test_ticket_creation_session_reopen.py
@@ -114,10 +114,10 @@ def test_reopen_ticket_creation_session_without_conversation_file(temp_daf_home,
             # Verify the command succeeded (no error exit code)
             assert result.exit_code == 0, f"Command failed with output:\n{result.output}"
 
-            # Verify the output indicates conversation file was not restored
+            # Verify the output indicates session was not restored
             # AND that a new session ID was generated for fresh start
-            assert "Conversation file was not restored" in result.output, \
-                f"Expected 'Conversation file was not restored' message. Got:\n{result.output}"
+            assert "session was not restored" in result.output, \
+                f"Expected 'session was not restored' message. Got:\n{result.output}"
             assert "Generating new session ID" in result.output, \
                 f"Expected 'Generating new session ID' message. Got:\n{result.output}"
 
@@ -303,12 +303,12 @@ def test_reopen_normal_session_without_conversation_file(temp_daf_home, mock_git
         assert result.exit_code == 0, f"Command failed with output:\n{result.output}"
 
         # For normal sessions (non-temp-directory sessions), the existing behavior should work:
-        # - Missing conversation file triggers "Conversation file not found" message
+        # - Missing session triggers "Session not found" message
         # - Session is treated as first launch
         # - New session ID is generated
-        assert "Conversation file not found" in result.output or "Will create a new conversation" in result.output or \
+        assert "Session not found" in result.output or "Will create a new conversation" in result.output or \
                "First-time launch" in result.output, \
-            f"Expected message about missing conversation for normal session. Got:\n{result.output}"
+            f"Expected message about missing session for normal session. Got:\n{result.output}"
 
         # The session ID handling for normal sessions is unchanged by PROJ-61092
         # This test just verifies we didn't break the existing behavior
@@ -697,8 +697,8 @@ def test_daf_jira_open_resumes_existing_conversation(temp_daf_home, mock_git_rep
             assert "Generating new session ID" not in result.output, \
                 f"Should not generate new session ID when conversation exists. Got:\n{result.output}"
 
-            # CRITICAL: Verify it found the conversation at stable location
-            assert "Checking for conversation file at stable location" in result.output, \
+            # CRITICAL: Verify it found the session at stable location
+            assert "session at stable location" in result.output, \
                 f"Expected to check stable location for ticket_creation session. Got:\n{result.output}"
             assert "found" in result.output.lower(), \
                 f"Expected to find conversation file. Got:\n{result.output}"


### PR DESCRIPTION
Jira Issue: https://github.com/itdove/devaiflow/issues/442
<!-- This PR does not need a corresponding Jira item. -->

## Description

Fix OpenCode session resume creating new sessions instead of continuing existing ones, along with several related refactors and improvements to the CLI and agent backend.

**Key changes:**

- **Session resume fix (#442):** Persist `agent_backend` in session metadata and use it consistently throughout the CLI, ensuring OpenCode sessions resume correctly instead of spawning new ones.
- **OpenCode prompt refactor (#438, #435):** Replace `AGENTS.md` trigger mechanism with `--prompt` flag for all modes and a prominent prepended block, improving reliability and simplifying the agent launch path.
- **Skills consolidation (#440):** Remove standalone `gh-cli` and `glab-cli` skills, consolidating their functionality into the unified `daf-git` skill.
- **CLI cleanup (#434):** Remove `daf git view` subcommand in favor of native `gh`/`glab` CLI usage.
- **TUI terminal fix (#439):** Let `stty`/`tput` inherit stdin and stdout for proper terminal reset.

Changes span session management, CLI commands, agent configuration, skills discovery, and utility modules across 45 files.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Install the updated package: `pip install -e .`
3. Start a new session with OpenCode backend: `daf new --agent-backend opencode`
4. Verify the session starts correctly and `agent_backend` is persisted in session metadata
5. Exit the session, then resume it: `daf open <session-name>`
6. Confirm the session resumes in the same OpenCode session (not a new one)
7. Verify `daf git new` and `daf git open` work correctly with the consolidated `daf-git` skill
8. Confirm `daf git view` is no longer available as a subcommand
9. Test terminal reset behavior by exiting a TUI session and verifying the terminal is clean

### Scenarios tested
- New session creation with OpenCode backend persists `agent_backend` in metadata
- Resuming an existing OpenCode session continues the prior session instead of creating a new one
- Git operations (create issue/PR, open issue/PR) work through consolidated `daf-git` skill
- Terminal state restores properly after TUI exit via `stty`/`tput` fix
- `--prompt` flag correctly replaces `AGENTS.md` trigger for all OpenCode modes

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: