### PR TITLE
itdove/devaiflow#445: Add --agent flag to daf open/new/investigate for per-command agent override

### DIFF
--- a/devflow/agent/__init__.py
+++ b/devflow/agent/__init__.py
@@ -28,7 +28,7 @@ from devflow.agent.aider_agent import AiderAgent
 from devflow.agent.continue_agent import ContinueAgent
 from devflow.agent.crush_agent import CrushAgent
 from devflow.agent.opencode_agent import OpenCodeAgent
-from devflow.agent.factory import create_agent_client
+from devflow.agent.factory import create_agent_client, SUPPORTED_BACKENDS, validate_agent_backend
 
 __all__ = [
     "AgentInterface",
@@ -42,4 +42,6 @@ __all__ = [
     "CrushAgent",
     "OpenCodeAgent",
     "create_agent_client",
+    "SUPPORTED_BACKENDS",
+    "validate_agent_backend",
 ]

--- a/devflow/agent/factory.py
+++ b/devflow/agent/factory.py
@@ -19,6 +19,45 @@ from devflow.agent.continue_agent import ContinueAgent
 from devflow.agent.crush_agent import CrushAgent
 from devflow.agent.opencode_agent import OpenCodeAgent
 
+# Canonical list of supported agent backend names (used for CLI validation)
+SUPPORTED_BACKENDS = [
+    "claude",
+    "ollama",
+    "ollama-claude",
+    "github-copilot",
+    "copilot",
+    "cursor",
+    "windsurf",
+    "aider",
+    "continue",
+    "crush",
+    "opencode",
+    "opencode-ai",
+]
+
+
+def validate_agent_backend(backend: str) -> str:
+    """Validate and normalize an agent backend name.
+
+    Args:
+        backend: Agent backend name to validate
+
+    Returns:
+        Lowercased backend name
+
+    Raises:
+        click.BadParameter: If backend is not supported
+    """
+    import click
+
+    normalized = backend.lower()
+    if normalized not in SUPPORTED_BACKENDS:
+        raise click.BadParameter(
+            f"Unsupported agent backend: '{backend}'. "
+            f"Supported: {', '.join(sorted(set(SUPPORTED_BACKENDS) - {'ollama-claude', 'copilot', 'opencode-ai'}))}"
+        )
+    return normalized
+
 
 def create_agent_client(backend: str = "claude", agent_home: Optional[Path] = None) -> AgentInterface:
     """Create an agent client for the specified backend.

--- a/devflow/cli/commands/git_new_command.py
+++ b/devflow/cli/commands/git_new_command.py
@@ -232,6 +232,7 @@ def create_git_issue_session(
     temp_clone: Optional[bool] = None,
     headless: bool = False,
     auto_approve: bool = False,
+    agent: Optional[str] = None,
 ) -> None:
     """Create a new session for GitHub/GitLab issue creation.
 
@@ -584,7 +585,7 @@ def create_git_issue_session(
         working_directory=working_directory,
         project_path=project_path,
         branch=branch,
-        agent_backend=config.agent_backend if config else "claude",
+        agent_backend=agent or (config.agent_backend if config else "claude"),
     )
 
     # Set session_type to "ticket_creation"
@@ -712,8 +713,8 @@ def create_git_issue_session(
         # Get agent backend from config
         from devflow.agent import create_agent_client
 
-        agent_backend = config.agent_backend if config else "claude"
-        agent = create_agent_client(agent_backend)
+        agent_backend = agent or (config.agent_backend if config else "claude")
+        agent_client = create_agent_client(agent_backend)
 
         # Get model provider profile if configured
         from devflow.utils.model_provider import get_active_profile as get_model_profile
@@ -728,10 +729,10 @@ def create_git_issue_session(
             workspace_path_for_skills = config.repos.get_default_workspace_path()
 
         # Warn if agent does not support permission prompts
-        if not agent.supports_permission_prompts():
+        if not agent_client.supports_permission_prompts():
             console_print(
                 "\n[bold yellow]⚠  Warning:[/bold yellow] [yellow]"
-                f"{agent.get_agent_name()} does not support permission prompts. "
+                f"{agent_client.get_agent_name()} does not support permission prompts. "
                 "This is a ticket-creation (analysis-only) session, but the agent "
                 "may still modify files without confirmation.[/yellow]"
             )
@@ -754,7 +755,7 @@ def create_git_issue_session(
         console_print()
 
         # Launch agent with initial prompt
-        process = agent.launch_with_prompt(
+        process = agent_client.launch_with_prompt(
             project_path=project_path,
             initial_prompt=initial_prompt,
             session_id=ai_agent_session_id,

--- a/devflow/cli/commands/investigate_command.py
+++ b/devflow/cli/commands/investigate_command.py
@@ -38,6 +38,7 @@ def create_investigation_from_issue(
     model_profile: Optional[str] = None,
     projects: Optional[str] = None,
     temp_clone: Optional[bool] = None,
+    agent: Optional[str] = None,
 ) -> None:
     """Create investigation session from an existing issue tracker ticket.
 
@@ -154,6 +155,7 @@ def create_investigation_from_issue(
         temp_clone=temp_clone,
         issue_key=issue_key,
         issue_details={"summary": issue_summary, "description": issue_description},
+        agent=agent,
     )
 
 
@@ -363,6 +365,7 @@ def create_investigation_session(
     issue_details: Optional[dict] = None,
     headless: bool = False,
     auto_approve: bool = False,
+    agent: Optional[str] = None,
 ) -> None:
     """Create a new investigation session for codebase analysis.
 
@@ -580,7 +583,7 @@ def create_investigation_session(
         project_path=project_path,
         branch=None,  # No branch for investigation sessions
         model_profile=model_profile,
-        agent_backend=config.agent_backend if config else "claude",
+        agent_backend=agent or (config.agent_backend if config else "claude"),
     )
 
     # Set session_type to "investigation"
@@ -699,8 +702,8 @@ def create_investigation_session(
         # Get agent backend from config
         from devflow.agent import create_agent_client
 
-        agent_backend = config.agent_backend if config else "claude"
-        agent = create_agent_client(agent_backend)
+        agent_backend = agent or (config.agent_backend if config else "claude")
+        agent_client = create_agent_client(agent_backend)
 
         # Get model provider profile if configured
         from devflow.utils.model_provider import get_active_profile as get_model_profile
@@ -721,7 +724,7 @@ def create_investigation_session(
         console_print()
 
         # Launch agent with initial prompt
-        process = agent.launch_with_prompt(
+        process = agent_client.launch_with_prompt(
             project_path=project_path,
             initial_prompt=initial_prompt,
             session_id=ai_agent_session_id,
@@ -1144,8 +1147,8 @@ def _create_multi_project_investigation_session(
         # Get agent backend from config
         from devflow.agent import create_agent_client
 
-        agent_backend = config.agent_backend if config else "claude"
-        agent = create_agent_client(agent_backend)
+        agent_backend = agent or (config.agent_backend if config else "claude")
+        agent_client = create_agent_client(agent_backend)
 
         # Get model provider profile if configured
         from devflow.utils.model_provider import get_active_profile as get_model_profile
@@ -1166,7 +1169,7 @@ def _create_multi_project_investigation_session(
         console_print()
 
         # Launch agent with initial prompt at workspace level
-        process = agent.launch_with_prompt(
+        process = agent_client.launch_with_prompt(
             project_path=workspace_path,  # Launch at workspace level
             initial_prompt=initial_prompt,
             session_id=ai_agent_session_id,

--- a/devflow/cli/commands/jira_new_command.py
+++ b/devflow/cli/commands/jira_new_command.py
@@ -232,6 +232,7 @@ def create_jira_ticket_session(
     temp_clone: Optional[bool] = None,
     headless: bool = False,
     auto_approve: bool = False,
+    agent: Optional[str] = None,
 ) -> None:
     """Create a new session for issue tracker ticket creation.
 
@@ -480,7 +481,7 @@ def create_jira_ticket_session(
         working_directory=working_directory,
         project_path=project_path,
         branch=branch,  # Use provided branch or None for no branch
-        agent_backend=config.agent_backend if config else "claude",
+        agent_backend=agent or (config.agent_backend if config else "claude"),
     )
 
     # Set session_type to "ticket_creation"
@@ -603,8 +604,8 @@ def create_jira_ticket_session(
         # Get agent backend from config
         from devflow.agent import create_agent_client
 
-        agent_backend = config.agent_backend if config else "claude"
-        agent = create_agent_client(agent_backend)
+        agent_backend = agent or (config.agent_backend if config else "claude")
+        agent_client = create_agent_client(agent_backend)
 
         # Get model provider profile if configured
         from devflow.utils.model_provider import get_active_profile as get_model_profile
@@ -621,10 +622,10 @@ def create_jira_ticket_session(
             workspace_path_for_skills = config.repos.get_default_workspace_path()
 
         # Warn if agent does not support permission prompts
-        if not agent.supports_permission_prompts():
+        if not agent_client.supports_permission_prompts():
             console_print(
                 "\n[bold yellow]⚠  Warning:[/bold yellow] [yellow]"
-                f"{agent.get_agent_name()} does not support permission prompts. "
+                f"{agent_client.get_agent_name()} does not support permission prompts. "
                 "This is a ticket-creation (analysis-only) session, but the agent "
                 "may still modify files without confirmation.[/yellow]"
             )
@@ -647,7 +648,7 @@ def create_jira_ticket_session(
         console_print()
 
         # Launch agent with initial prompt
-        process = agent.launch_with_prompt(
+        process = agent_client.launch_with_prompt(
             project_path=project_path,
             initial_prompt=initial_prompt,
             session_id=ai_agent_session_id,

--- a/devflow/cli/commands/list_command.py
+++ b/devflow/cli/commands/list_command.py
@@ -128,6 +128,7 @@ def _display_page(
     table = Table(title="Your Sessions", show_header=True, header_style="bold magenta")
     table.add_column("Status")
     table.add_column("Name", style="bold", no_wrap=True)
+    table.add_column("Agent", style="dim")
     table.add_column("Workspace", style="cyan")
     table.add_column("Issue")
     table.add_column("Summary")
@@ -236,10 +237,14 @@ def _display_page(
                 else:
                     token_display = str(total_tokens)
 
+        # Agent display
+        agent_display = session.agent_backend or "-"
+
         # Add row
         table.add_row(
             status_display,
             name_display,
+            agent_display,
             workspace_display,
             issue_display,
             session.issue_metadata.get("summary") if session.issue_metadata else session.goal or "",

--- a/devflow/cli/commands/new_command.py
+++ b/devflow/cli/commands/new_command.py
@@ -305,6 +305,7 @@ def create_new_session(
     session_index: Optional[int] = None,
     headless: bool = False,
     auto_approve: bool = False,
+    agent: Optional[str] = None,
 ) -> None:
     """Create a new session or add conversation to existing session.
 
@@ -775,7 +776,7 @@ def create_new_session(
             branch=branch,
             ai_agent_session_id=session_id,
             model_profile=model_profile,
-            agent_backend=config.agent_backend if config else "claude",
+            agent_backend=agent or (config.agent_backend if config else "claude"),
         )
 
         # Set base_branch to source_branch if available (fixes #139 - no sync prompt after creating branch)
@@ -824,7 +825,7 @@ def create_new_session(
 
     # Change to project directory and launch AI agent
     try:
-        _agent_backend = config.agent_backend if config else "claude"
+        _agent_backend = agent or (config.agent_backend if config else "claude")
         from devflow.agent import create_agent_client as _cac
         _agent_display_name = _cac(_agent_backend).get_agent_name().title()
         console.print(f"\n[cyan]Launching {_agent_display_name} in {project_path}...[/cyan]")
@@ -854,8 +855,8 @@ def create_new_session(
         # Get agent backend from config
         from devflow.agent import create_agent_client
 
-        agent_backend = config.agent_backend if config else "claude"
-        agent = create_agent_client(agent_backend)
+        agent_backend = agent or (config.agent_backend if config else "claude")
+        agent_client = create_agent_client(agent_backend)
 
         # Get model provider profile if configured
         from devflow.utils.model_provider import get_active_profile as get_model_profile
@@ -891,7 +892,7 @@ def create_new_session(
 
         # Launch agent with initial prompt
         try:
-            process = agent.launch_with_prompt(
+            process = agent_client.launch_with_prompt(
                 project_path=project_path,
                 initial_prompt=initial_prompt,
                 session_id=session_id,

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -239,6 +239,7 @@ def open_session(
     skip_feature_warning: bool = False,
     headless: bool = False,
     auto_approve: bool = False,
+    agent: Optional[str] = None,
 ) -> None:
     """Open/resume an existing session.
 
@@ -562,8 +563,8 @@ def open_session(
     active_conv = session.active_conversation
     is_first_launch = not (active_conv and active_conv.ai_agent_session_id)
 
-    # Resolve effective agent backend: session-stored > config > "claude" (backward compatible)
-    effective_agent_backend = session.agent_backend or (config.agent_backend if config else "claude")
+    # Resolve effective agent backend: --agent flag > session-stored > config > "claude" (backward compatible)
+    effective_agent_backend = agent or session.agent_backend or (config.agent_backend if config else "claude")
 
     if active_conv and active_conv.ai_agent_session_id and active_conv.project_path:
         # Check if the session exists using the agent-aware check

--- a/devflow/cli/main.py
+++ b/devflow/cli/main.py
@@ -333,8 +333,9 @@ def cli(ctx: click.Context, non_interactive: bool, experimental: bool) -> None:
 @click.option("--session-index", type=int, help="Select existing session by index (for multi-session selection)")
 @click.option("--headless", is_flag=True, help="Run agent in headless mode (no interactive UI, exits after completion)")
 @click.option("--auto-approve", is_flag=True, help="Auto-approve all agent tool permissions (file edits, commands)")
+@click.option("--agent", default=None, help="AI agent backend to use (e.g., claude, opencode, cursor, windsurf, ollama)")
 @json_option
-def new(ctx: click.Context, name: str, goal: str, goal_file: str, jira: str, working_directory: str, path: str, branch: str, template: str, workspace: str, projects: str, new_session: bool, model_profile: str, create_branch: bool, source_branch: str, on_branch_exists: str, allow_uncommitted: bool, sync_upstream: bool, auto_workspace: bool, session_index: int, headless: bool, auto_approve: bool) -> None:
+def new(ctx: click.Context, name: str, goal: str, goal_file: str, jira: str, working_directory: str, path: str, branch: str, template: str, workspace: str, projects: str, new_session: bool, model_profile: str, create_branch: bool, source_branch: str, on_branch_exists: str, allow_uncommitted: bool, sync_upstream: bool, auto_workspace: bool, session_index: int, headless: bool, auto_approve: bool, agent: str) -> None:
     """Create a new session or add conversation to existing session.
 
     By default, if a session already exists with the same name, this command will
@@ -406,6 +407,11 @@ def new(ctx: click.Context, name: str, goal: str, goal_file: str, jira: str, wor
     # Get output_json flag from context
     output_json = ctx.obj.get('output_json', False) if ctx.obj else False
 
+    # Validate --agent if provided
+    if agent:
+        from devflow.agent.factory import validate_agent_backend
+        agent = validate_agent_backend(agent)
+
     create_new_session(
         name,
         goal,
@@ -428,6 +434,7 @@ def new(ctx: click.Context, name: str, goal: str, goal_file: str, jira: str, wor
         session_index=session_index,
         headless=headless,
         auto_approve=auto_approve,
+        agent=agent,
     )
 
 
@@ -450,8 +457,9 @@ def new(ctx: click.Context, name: str, goal: str, goal_file: str, jira: str, wor
 @click.option("--sync-strategy", type=click.Choice(['merge', 'rebase', 'skip'], case_sensitive=False), help="Strategy for syncing with upstream (merge/rebase/skip)")
 @click.option("--headless", is_flag=True, help="Run agent in headless mode (no interactive UI, exits after completion)")
 @click.option("--auto-approve", is_flag=True, help="Auto-approve all agent tool permissions (file edits, commands)")
+@click.option("--agent", default=None, help="AI agent backend to use (overrides session stored agent)")
 @json_option
-def open(ctx: click.Context, identifier: str, edit: bool, status: str, path: str, workspace: str, projects: str, new_conversation: bool, conversation_id: str, model_profile: str, create_branch: bool, source_branch: str, on_branch_exists: str, allow_uncommitted: bool, sync_upstream: bool, auto_workspace: bool, sync_strategy: str, headless: bool, auto_approve: bool) -> None:
+def open(ctx: click.Context, identifier: str, edit: bool, status: str, path: str, workspace: str, projects: str, new_conversation: bool, conversation_id: str, model_profile: str, create_branch: bool, source_branch: str, on_branch_exists: str, allow_uncommitted: bool, sync_upstream: bool, auto_workspace: bool, sync_strategy: str, headless: bool, auto_approve: bool, agent: str) -> None:
     """Open/resume an existing session.
 
     IDENTIFIER can be either a session group name or issue tracker key.
@@ -529,6 +537,11 @@ def open(ctx: click.Context, identifier: str, edit: bool, status: str, path: str
         console.print("[dim]Example: daf open PROJ-123 -w primary --projects backend,frontend[/dim]")
         sys.exit(1)
 
+    # Validate --agent if provided
+    if agent:
+        from devflow.agent.factory import validate_agent_backend
+        agent = validate_agent_backend(agent)
+
     open_session(
         identifier,
         output_json=ctx.obj.get('output_json', False),
@@ -547,6 +560,7 @@ def open(ctx: click.Context, identifier: str, edit: bool, status: str, path: str
         sync_strategy=sync_strategy,
         headless=headless,
         auto_approve=auto_approve,
+        agent=agent,
     )
 
 
@@ -1636,7 +1650,8 @@ jira.add_command(create_jira_update_command())
 @click.option("--affects-versions", help="Affected version for bugs (required for bug type)")
 @click.option("--headless", is_flag=True, help="Run agent in headless mode (no interactive UI, exits after completion)")
 @click.option("--auto-approve", is_flag=True, help="Auto-approve all agent tool permissions (file edits, commands)")
-def jira_new(ctx: click.Context, issue_type: str, parent: Optional[str], goal: str, goal_file: str, name: str, path: str, branch: str, workspace: str, projects: str, temp_clone: bool, affects_versions: Optional[str], headless: bool, auto_approve: bool) -> None:
+@click.option("--agent", default=None, help="AI agent backend to use (e.g., claude, opencode, cursor, windsurf, ollama)")
+def jira_new(ctx: click.Context, issue_type: str, parent: Optional[str], goal: str, goal_file: str, name: str, path: str, branch: str, workspace: str, projects: str, temp_clone: bool, affects_versions: Optional[str], headless: bool, auto_approve: bool, agent: str) -> None:
     """Create issue tracker ticket with analysis-only session.
 
     Creates a session with session_type="ticket_creation" that:
@@ -1704,7 +1719,12 @@ def jira_new(ctx: click.Context, issue_type: str, parent: Optional[str], goal: s
                 affects_versions = prompt_for_affected_version(field_mapper)
         # else: affects_versions stays None (field is optional for this issue type)
 
-    create_jira_ticket_session(issue_type, parent, goal, name, path, branch, workspace, affects_versions, projects=projects, temp_clone=temp_clone, headless=headless, auto_approve=auto_approve)
+    # Validate --agent if provided
+    if agent:
+        from devflow.agent.factory import validate_agent_backend
+        agent = validate_agent_backend(agent)
+
+    create_jira_ticket_session(issue_type, parent, goal, name, path, branch, workspace, affects_versions, projects=projects, temp_clone=temp_clone, headless=headless, auto_approve=auto_approve, agent=agent)
 
 
 @jira.command(name="open")
@@ -1869,7 +1889,8 @@ def git_open(ctx: click.Context, issue_key: str, repository: Optional[str], head
 @click.option("--repository", help="Repository in owner/repo format (optional, will auto-detect)")
 @click.option("--headless", is_flag=True, help="Run agent in headless mode (no interactive UI, exits after completion)")
 @click.option("--auto-approve", is_flag=True, help="Auto-approve all agent tool permissions (file edits, commands)")
-def git_new(ctx: click.Context, issue_type: Optional[str], goal: Optional[str], goal_file: Optional[str], name: str, path: str, branch: str, parent: Optional[str], workspace: str, projects: str, temp_clone: bool, repository: Optional[str], headless: bool, auto_approve: bool) -> None:
+@click.option("--agent", default=None, help="AI agent backend to use (e.g., claude, opencode, cursor, windsurf, ollama)")
+def git_new(ctx: click.Context, issue_type: Optional[str], goal: Optional[str], goal_file: Optional[str], name: str, path: str, branch: str, parent: Optional[str], workspace: str, projects: str, temp_clone: bool, repository: Optional[str], headless: bool, auto_approve: bool, agent: str) -> None:
     """Create GitHub/GitLab issue with analysis-only session.
 
     Creates a session with session_type="ticket_creation" that:
@@ -1898,7 +1919,12 @@ def git_new(ctx: click.Context, issue_type: Optional[str], goal: Optional[str], 
     # Process --goal and --goal-file options (mutual exclusion and resolution)
     goal = process_goal_options(goal, goal_file)
 
-    create_git_issue_session(goal, issue_type, name, path, branch, parent, workspace, repository, projects=projects, temp_clone=temp_clone, headless=headless, auto_approve=auto_approve)
+    # Validate --agent if provided
+    if agent:
+        from devflow.agent.factory import validate_agent_backend
+        agent = validate_agent_backend(agent)
+
+    create_git_issue_session(goal, issue_type, name, path, branch, parent, workspace, repository, projects=projects, temp_clone=temp_clone, headless=headless, auto_approve=auto_approve, agent=agent)
 
 
 @git.command(name="check-auth")
@@ -1932,7 +1958,8 @@ def git_check_auth(ctx: click.Context, repository: Optional[str]) -> None:
 @click.option("--model-profile", help="Model provider profile to use (e.g., 'vertex', 'llama-cpp')")
 @click.option("--headless", is_flag=True, help="Run agent in headless mode (no interactive UI, exits after completion)")
 @click.option("--auto-approve", is_flag=True, help="Auto-approve all agent tool permissions (file edits, commands)")
-def investigate(ctx: click.Context, issue_key: Optional[str], goal: str, goal_file: str, parent: Optional[str], name: str, path: str, workspace: str, projects: str, temp_clone: bool, model_profile: str, headless: bool, auto_approve: bool) -> None:
+@click.option("--agent", default=None, help="AI agent backend to use (e.g., claude, opencode, cursor, windsurf, ollama)")
+def investigate(ctx: click.Context, issue_key: Optional[str], goal: str, goal_file: str, parent: Optional[str], name: str, path: str, workspace: str, projects: str, temp_clone: bool, model_profile: str, headless: bool, auto_approve: bool, agent: str) -> None:
     """Create investigation-only session without ticket creation.
 
     Creates a session with session_type="investigation" that:
@@ -1961,10 +1988,15 @@ def investigate(ctx: click.Context, issue_key: Optional[str], goal: str, goal_fi
     from devflow.cli.commands.investigate_command import create_investigation_session
     from devflow.cli.utils import process_goal_options
 
+    # Validate --agent if provided
+    if agent:
+        from devflow.agent.factory import validate_agent_backend
+        agent = validate_agent_backend(agent)
+
     # If issue_key provided, fetch issue details and delegate to command
     if issue_key:
         from devflow.cli.commands.investigate_command import create_investigation_from_issue
-        create_investigation_from_issue(issue_key, goal, parent, name, path, workspace, model_profile, projects, temp_clone)
+        create_investigation_from_issue(issue_key, goal, parent, name, path, workspace, model_profile, projects, temp_clone, agent=agent)
         return
 
     # Prompt for goal if not provided
@@ -1974,7 +2006,7 @@ def investigate(ctx: click.Context, issue_key: Optional[str], goal: str, goal_fi
     # Process --goal and --goal-file options (mutual exclusion and resolution)
     goal = process_goal_options(goal, goal_file)
 
-    create_investigation_session(goal, parent, name, path, workspace, model_profile, projects=projects, temp_clone=temp_clone, headless=headless, auto_approve=auto_approve)
+    create_investigation_session(goal, parent, name, path, workspace, model_profile, projects=projects, temp_clone=temp_clone, headless=headless, auto_approve=auto_approve, agent=agent)
 
 
 @cli.group()

--- a/tests/test_agent_flag.py
+++ b/tests/test_agent_flag.py
@@ -10,6 +10,7 @@ Tests cover:
 - List command shows agent column
 """
 
+import os
 from datetime import datetime
 from unittest.mock import Mock, patch, MagicMock
 
@@ -354,8 +355,10 @@ class TestInvalidAgentRejected:
 class TestListShowsAgent:
     """Tests that daf list shows agent_backend column."""
 
-    def test_list_shows_agent_column_header(self, temp_daf_home):
-        """daf list table includes Agent column header."""
+    def test_list_json_shows_agent_backend(self, temp_daf_home):
+        """daf list --json includes agent_backend in session data."""
+        import json
+
         config_loader = ConfigLoader()
         session_manager = SessionManager(config_loader)
         session_manager.create_session(
@@ -366,30 +369,19 @@ class TestListShowsAgent:
             agent_backend="opencode",
         )
 
-        runner = CliRunner(env={"COLUMNS": "200"})
-        result = runner.invoke(cli, ["list"])
+        runner = CliRunner()
+        result = runner.invoke(cli, ["list", "--json"])
         assert result.exit_code == 0
-        assert "Agent" in result.output
+        data = json.loads(result.output)
+        assert data["success"] is True
+        sessions = data["data"]["sessions"]
+        assert len(sessions) == 1
+        assert sessions[0]["agent_backend"] == "opencode"
 
-    def test_list_shows_agent_value(self, temp_daf_home):
-        """daf list shows the stored agent_backend value."""
-        config_loader = ConfigLoader()
-        session_manager = SessionManager(config_loader)
-        session_manager.create_session(
-            name="test-list-value",
-            goal="Test",
-            working_directory="test-dir",
-            project_path="/tmp/test",
-            agent_backend="opencode",
-        )
+    def test_list_json_agent_backend_none(self, temp_daf_home):
+        """daf list --json shows null agent_backend when not set."""
+        import json
 
-        runner = CliRunner(env={"COLUMNS": "200"})
-        result = runner.invoke(cli, ["list"])
-        assert result.exit_code == 0
-        assert "opencode" in result.output
-
-    def test_list_shows_dash_when_no_agent(self, temp_daf_home):
-        """daf list shows '-' when agent_backend is not set."""
         config_loader = ConfigLoader()
         session_manager = SessionManager(config_loader)
         session_manager.create_session(
@@ -399,13 +391,35 @@ class TestListShowsAgent:
             project_path="/tmp/test",
         )
 
-        runner = CliRunner(env={"COLUMNS": "200"})
+        runner = CliRunner()
+        result = runner.invoke(cli, ["list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        sessions = data["data"]["sessions"]
+        assert len(sessions) == 1
+        assert sessions[0]["agent_backend"] is None
+
+    def test_list_table_has_agent_column(self, temp_daf_home, monkeypatch):
+        """daf list table includes Agent column header (wide terminal)."""
+        from devflow.cli.commands import list_command
+        list_command.console._width = 200
+        list_command.console._height = 24
+
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session_manager.create_session(
+            name="test-list-col",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+            agent_backend="opencode",
+        )
+
+        runner = CliRunner()
         result = runner.invoke(cli, ["list"])
         assert result.exit_code == 0
-        # The Agent column should show "-" for sessions without agent_backend
-        # We check that the table header exists and the session is listed
         assert "Agent" in result.output
-        assert "test-list-none" in result.output
+        assert "opencode" in result.output
 
 
 # ───────────────────────────────────────────────────────────────────────────────

--- a/tests/test_agent_flag.py
+++ b/tests/test_agent_flag.py
@@ -1,0 +1,450 @@
+"""Tests for --agent flag on daf open/new/investigate/jira new/git new.
+
+Tests cover:
+- Agent backend validation (SUPPORTED_BACKENDS, validate_agent_backend)
+- Priority resolution for daf open: flag > session > config > default
+- Priority resolution for daf new: flag > config > default
+- Agent stored in session metadata for future reopens
+- --agent flag accepted by all 5 commands
+- Invalid agent names rejected with clear error
+- List command shows agent column
+"""
+
+from datetime import datetime
+from unittest.mock import Mock, patch, MagicMock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from devflow.agent.factory import (
+    SUPPORTED_BACKENDS,
+    validate_agent_backend,
+    create_agent_client,
+)
+from devflow.cli.main import cli
+from devflow.config.loader import ConfigLoader
+from devflow.session.manager import SessionManager
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# SUPPORTED_BACKENDS constant
+# ───────────────────────────────────────────────────────────────────────────────
+
+class TestSupportedBackends:
+    """Tests for SUPPORTED_BACKENDS constant."""
+
+    def test_contains_claude(self):
+        assert "claude" in SUPPORTED_BACKENDS
+
+    def test_contains_opencode(self):
+        assert "opencode" in SUPPORTED_BACKENDS
+
+    def test_contains_cursor(self):
+        assert "cursor" in SUPPORTED_BACKENDS
+
+    def test_contains_windsurf(self):
+        assert "windsurf" in SUPPORTED_BACKENDS
+
+    def test_contains_ollama(self):
+        assert "ollama" in SUPPORTED_BACKENDS
+
+    def test_contains_github_copilot(self):
+        assert "github-copilot" in SUPPORTED_BACKENDS
+
+    def test_contains_copilot_alias(self):
+        assert "copilot" in SUPPORTED_BACKENDS
+
+    def test_contains_aider(self):
+        assert "aider" in SUPPORTED_BACKENDS
+
+    def test_contains_continue(self):
+        assert "continue" in SUPPORTED_BACKENDS
+
+    def test_contains_crush(self):
+        assert "crush" in SUPPORTED_BACKENDS
+
+    def test_contains_opencode_ai_alias(self):
+        assert "opencode-ai" in SUPPORTED_BACKENDS
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# validate_agent_backend
+# ───────────────────────────────────────────────────────────────────────────────
+
+class TestValidateAgentBackend:
+    """Tests for validate_agent_backend function."""
+
+    def test_valid_claude(self):
+        assert validate_agent_backend("claude") == "claude"
+
+    def test_valid_opencode(self):
+        assert validate_agent_backend("opencode") == "opencode"
+
+    def test_valid_cursor(self):
+        assert validate_agent_backend("cursor") == "cursor"
+
+    def test_case_insensitive(self):
+        assert validate_agent_backend("Claude") == "claude"
+        assert validate_agent_backend("OPENCODE") == "opencode"
+        assert validate_agent_backend("Cursor") == "cursor"
+
+    def test_invalid_raises_bad_parameter(self):
+        with pytest.raises(click.BadParameter, match="Unsupported agent backend"):
+            validate_agent_backend("nonexistent")
+
+    def test_invalid_shows_supported_list(self):
+        with pytest.raises(click.BadParameter, match="Supported:"):
+            validate_agent_backend("invalid-agent")
+
+    def test_aliases_accepted(self):
+        assert validate_agent_backend("copilot") == "copilot"
+        assert validate_agent_backend("opencode-ai") == "opencode-ai"
+        assert validate_agent_backend("ollama-claude") == "ollama-claude"
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Priority resolution for daf open (flag > session > config > default)
+# ───────────────────────────────────────────────────────────────────────────────
+
+class TestOpenAgentPriority:
+    """Tests for agent backend priority resolution in daf open."""
+
+    def test_flag_overrides_session_and_config(self, temp_daf_home):
+        """--agent flag takes highest priority."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session = session_manager.create_session(
+            name="test-open-flag",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+            agent_backend="cursor",  # session stored agent
+        )
+
+        # Mock config with agent_backend="windsurf"
+        mock_config = Mock()
+        mock_config.agent_backend = "windsurf"
+
+        # Simulate resolution: agent or session.agent_backend or config.agent_backend or "claude"
+        agent_flag = "opencode"
+        effective = agent_flag or session.agent_backend or mock_config.agent_backend or "claude"
+        assert effective == "opencode"
+
+    def test_session_overrides_config(self, temp_daf_home):
+        """Session stored agent wins over config when no flag."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session = session_manager.create_session(
+            name="test-open-session",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+            agent_backend="cursor",  # session stored
+        )
+
+        mock_config = Mock()
+        mock_config.agent_backend = "windsurf"
+
+        agent_flag = None
+        effective = agent_flag or session.agent_backend or mock_config.agent_backend or "claude"
+        assert effective == "cursor"
+
+    def test_config_used_when_no_flag_no_session(self, temp_daf_home):
+        """Config agent_backend used when no flag and no session stored agent."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session = session_manager.create_session(
+            name="test-open-config",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+            agent_backend=None,  # no session stored agent
+        )
+
+        mock_config = Mock()
+        mock_config.agent_backend = "windsurf"
+
+        agent_flag = None
+        effective = agent_flag or session.agent_backend or mock_config.agent_backend or "claude"
+        assert effective == "windsurf"
+
+    def test_default_claude_when_nothing_set(self, temp_daf_home):
+        """Default to claude when no flag, no session, no config."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session = session_manager.create_session(
+            name="test-open-default",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+            agent_backend=None,
+        )
+
+        agent_flag = None
+        config_agent = None
+        effective = agent_flag or session.agent_backend or config_agent or "claude"
+        assert effective == "claude"
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Priority resolution for daf new (flag > config > default)
+# ───────────────────────────────────────────────────────────────────────────────
+
+class TestNewAgentPriority:
+    """Tests for agent backend priority resolution in daf new."""
+
+    def test_flag_overrides_config(self):
+        """--agent flag takes highest priority for new sessions."""
+        agent_flag = "opencode"
+        config_agent = "cursor"
+        effective = agent_flag or config_agent or "claude"
+        assert effective == "opencode"
+
+    def test_config_used_when_no_flag(self):
+        """Config agent_backend used when no flag."""
+        agent_flag = None
+        config_agent = "cursor"
+        effective = agent_flag or config_agent or "claude"
+        assert effective == "cursor"
+
+    def test_default_claude_when_nothing(self):
+        """Default to claude when no flag and no config."""
+        agent_flag = None
+        config_agent = None
+        effective = agent_flag or config_agent or "claude"
+        assert effective == "claude"
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Agent stored in session metadata
+# ───────────────────────────────────────────────────────────────────────────────
+
+class TestAgentStoredInSession:
+    """Tests for agent_backend persistence in session metadata."""
+
+    def test_agent_stored_on_create(self, temp_daf_home):
+        """Agent backend is stored when session is created."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session = session_manager.create_session(
+            name="test-stored",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+            agent_backend="opencode",
+        )
+        assert session.agent_backend == "opencode"
+
+    def test_agent_persisted_and_loaded(self, temp_daf_home):
+        """Agent backend survives save/load cycle."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session_manager.create_session(
+            name="test-persist",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+            agent_backend="cursor",
+        )
+
+        # Reload from disk
+        session_manager2 = SessionManager(ConfigLoader())
+        loaded = session_manager2.get_session("test-persist")
+        assert loaded is not None
+        assert loaded.agent_backend == "cursor"
+
+    def test_agent_none_by_default(self, temp_daf_home):
+        """Agent backend is None when not specified."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session = session_manager.create_session(
+            name="test-default",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+        )
+        assert session.agent_backend is None
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# CLI --agent flag acceptance on all 5 commands
+# ───────────────────────────────────────────────────────────────────────────────
+
+class TestAgentFlagAccepted:
+    """Tests that --agent flag is accepted by all 5 commands."""
+
+    def test_new_accepts_agent_flag(self, temp_daf_home):
+        """daf new --help shows --agent option."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["new", "--help"])
+        assert result.exit_code == 0
+        assert "--agent" in result.output
+
+    def test_open_accepts_agent_flag(self, temp_daf_home):
+        """daf open --help shows --agent option."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["open", "--help"])
+        assert result.exit_code == 0
+        assert "--agent" in result.output
+
+    def test_investigate_accepts_agent_flag(self, temp_daf_home):
+        """daf investigate --help shows --agent option."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["investigate", "--help"])
+        assert result.exit_code == 0
+        assert "--agent" in result.output
+
+    def test_jira_new_accepts_agent_flag(self, temp_daf_home):
+        """daf jira new --help shows --agent option."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["jira", "new", "--help"])
+        assert result.exit_code == 0
+        assert "--agent" in result.output
+
+    def test_git_new_accepts_agent_flag(self, temp_daf_home):
+        """daf git new --help shows --agent option."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["git", "new", "--help"])
+        assert result.exit_code == 0
+        assert "--agent" in result.output
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Invalid agent names rejected
+# ───────────────────────────────────────────────────────────────────────────────
+
+class TestInvalidAgentRejected:
+    """Tests that invalid agent names are rejected."""
+
+    def test_new_rejects_invalid_agent(self, temp_daf_home):
+        """daf new --agent invalid-agent exits with error."""
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "new", "--name", "test", "--goal", "test", "--agent", "invalid-agent"
+        ], input="n\n")  # Answer no to any prompt
+        # Should fail with BadParameter
+        assert result.exit_code != 0
+        assert "Unsupported agent backend" in result.output
+
+    def test_open_rejects_invalid_agent(self, temp_daf_home):
+        """daf open --agent invalid-agent exits with error."""
+        # Create a session first
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session_manager.create_session(
+            name="test-reject",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "open", "test-reject", "--agent", "nonexistent-agent"
+        ])
+        assert result.exit_code != 0
+        assert "Unsupported agent backend" in result.output
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# List command shows agent column
+# ───────────────────────────────────────────────────────────────────────────────
+
+class TestListShowsAgent:
+    """Tests that daf list shows agent_backend column."""
+
+    def test_list_shows_agent_column_header(self, temp_daf_home):
+        """daf list table includes Agent column header."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session_manager.create_session(
+            name="test-list",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+            agent_backend="opencode",
+        )
+
+        runner = CliRunner(env={"COLUMNS": "200"})
+        result = runner.invoke(cli, ["list"])
+        assert result.exit_code == 0
+        assert "Agent" in result.output
+
+    def test_list_shows_agent_value(self, temp_daf_home):
+        """daf list shows the stored agent_backend value."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session_manager.create_session(
+            name="test-list-value",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+            agent_backend="opencode",
+        )
+
+        runner = CliRunner(env={"COLUMNS": "200"})
+        result = runner.invoke(cli, ["list"])
+        assert result.exit_code == 0
+        assert "opencode" in result.output
+
+    def test_list_shows_dash_when_no_agent(self, temp_daf_home):
+        """daf list shows '-' when agent_backend is not set."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session_manager.create_session(
+            name="test-list-none",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+        )
+
+        runner = CliRunner(env={"COLUMNS": "200"})
+        result = runner.invoke(cli, ["list"])
+        assert result.exit_code == 0
+        # The Agent column should show "-" for sessions without agent_backend
+        # We check that the table header exists and the session is listed
+        assert "Agent" in result.output
+        assert "test-list-none" in result.output
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Info command shows agent
+# ───────────────────────────────────────────────────────────────────────────────
+
+class TestInfoShowsAgent:
+    """Tests that daf info shows agent_backend."""
+
+    def test_info_shows_agent_backend(self, temp_daf_home):
+        """daf info displays agent backend when set."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session_manager.create_session(
+            name="test-info-agent",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+            agent_backend="opencode",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["info", "test-info-agent"])
+        # exit_code may be 1 if no conversations exist, but output still shows agent
+        assert "Agent Backend" in result.output
+        assert "opencode" in result.output
+
+    def test_info_no_agent_line_when_none(self, temp_daf_home):
+        """daf info does not show agent backend line when not set."""
+        config_loader = ConfigLoader()
+        session_manager = SessionManager(config_loader)
+        session_manager.create_session(
+            name="test-info-no-agent",
+            goal="Test",
+            working_directory="test-dir",
+            project_path="/tmp/test",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["info", "test-info-no-agent"])
+        # exit_code may be 1 if no conversations exist, but output still shows session info
+        assert "Agent Backend" not in result.output

--- a/tests/test_list_command.py
+++ b/tests/test_list_command.py
@@ -1,5 +1,6 @@
 """Tests for daf list command."""
 
+import os
 from datetime import datetime, timedelta
 
 import pytest
@@ -10,9 +11,22 @@ from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
 
 
+@pytest.fixture(autouse=True)
+def wide_terminal(monkeypatch):
+    """Force Rich Console to use 200-char width for all list command tests.
+
+    In CI (NO_COLOR=1, TERM=dumb), Rich Console hardcodes 80-char width
+    via is_dumb_terminal check. The only way to override is to set BOTH
+    _width AND _height, which bypasses the dumb terminal check entirely.
+    """
+    from devflow.cli.commands import list_command
+    list_command.console._width = 200
+    list_command.console._height = 24
+
+
 def test_list_empty(temp_daf_home):
     """Test listing sessions when none exist."""
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -34,7 +48,7 @@ def test_list_single_session(temp_daf_home):
         issue_key="PROJ-12345",
     )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -69,7 +83,7 @@ def test_list_multiple_sessions(temp_daf_home):
         issue_key="PROJ-222",
     )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -105,7 +119,7 @@ def test_list_filter_by_status(temp_daf_home):
     session2.status = "complete"
     session_manager.update_session(session2)
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--status", "complete"])
 
     assert result.exit_code == 0
@@ -136,7 +150,7 @@ def test_list_filter_by_working_directory(temp_daf_home):
         ai_agent_session_id="uuid-2",
     )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--working-directory", "backend-service"])
 
     assert result.exit_code == 0
@@ -166,7 +180,7 @@ def test_list_with_work_sessions(temp_daf_home):
     session.work_sessions = [WorkSession(start=start_time, end=end_time)]
     session_manager.update_session(session)
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -187,7 +201,7 @@ def test_list_no_sessions_with_filters(temp_daf_home):
         ai_agent_session_id="uuid-1",
     )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--status", "complete"])
 
     assert result.exit_code == 0
@@ -211,7 +225,7 @@ def test_list_displays_status_colors(temp_daf_home):
     session.status = "in_progress"
     session_manager.update_session(session)
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -234,7 +248,7 @@ def test_list_shows_session_summary(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -262,7 +276,7 @@ def test_list_with_jira_summary(temp_daf_home):
     session.issue_metadata["summary"] = "Implement backup feature"
     session_manager.update_session(session)
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -289,7 +303,7 @@ def test_list_pagination_default_limit(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     # In interactive mode, EOF will stop pagination after first page
     result = runner.invoke(cli, ["list"], input="")
 
@@ -316,7 +330,7 @@ def test_list_pagination_custom_limit(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     # In interactive mode, EOF will stop pagination after first page
     result = runner.invoke(cli, ["list", "--limit", "5"], input="")
 
@@ -343,7 +357,7 @@ def test_list_pagination_specific_page(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--limit", "5", "--page", "2"])
 
     assert result.exit_code == 0
@@ -367,7 +381,7 @@ def test_list_pagination_last_page_partial(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--limit", "5", "--page", "3"])
 
     assert result.exit_code == 0
@@ -391,7 +405,7 @@ def test_list_pagination_page_out_of_range(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--limit", "5", "--page", "10"])
 
     assert result.exit_code == 0
@@ -415,7 +429,7 @@ def test_list_pagination_show_all_flag(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--all"])
 
     assert result.exit_code == 0
@@ -444,7 +458,7 @@ def test_list_pagination_with_filters(temp_daf_home):
             session.status = "complete"
             session_manager.update_session(session)
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     # In interactive mode, EOF will stop pagination after first page
     result = runner.invoke(cli, ["list", "--status", "complete", "--limit", "3"], input="")
 
@@ -471,7 +485,7 @@ def test_list_pagination_few_sessions_no_pagination_info(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -495,7 +509,7 @@ def test_list_pagination_invalid_page_number(temp_daf_home):
         ai_agent_session_id="uuid-1",
     )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--page", "0"])
 
     assert result.exit_code == 0
@@ -516,7 +530,7 @@ def test_list_pagination_invalid_limit(temp_daf_home):
         ai_agent_session_id="uuid-1",
     )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--limit", "0"])
 
     assert result.exit_code == 0
@@ -539,7 +553,7 @@ def test_list_pagination_navigation_hints(temp_daf_home):
         )
 
     # Test page 1 - should show "next page" hint
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--limit", "5", "--page", "1"])
     assert result.exit_code == 0
     assert "--page 2" in result.output  # Next page hint
@@ -574,7 +588,7 @@ def test_list_interactive_mode_first_page_quit(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     # Simulate user pressing 'q' at the first prompt
     result = runner.invoke(cli, ["list"], input="q\n")
 
@@ -601,7 +615,7 @@ def test_list_interactive_mode_continue_to_next_page(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     # Simulate user pressing Enter at the first prompt (continue to page 2)
     result = runner.invoke(cli, ["list"], input="\n")
 
@@ -628,7 +642,7 @@ def test_list_interactive_mode_multiple_pages(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     # Simulate user pressing Enter twice to view all pages
     result = runner.invoke(cli, ["list", "--limit", "5"], input="\n\n")
 
@@ -657,7 +671,7 @@ def test_list_interactive_mode_quit_on_second_page(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     # Simulate user pressing Enter once, then 'q'
     result = runner.invoke(cli, ["list", "--limit", "5"], input="\nq\n")
 
@@ -687,7 +701,7 @@ def test_list_interactive_mode_single_page_no_prompt(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -712,7 +726,7 @@ def test_list_non_interactive_mode_with_page_flag(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--page", "1"])
 
     assert result.exit_code == 0
@@ -744,7 +758,7 @@ def test_list_interactive_mode_with_filters(temp_daf_home):
             session.status = "complete"
             session_manager.update_session(session)
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     # Filter by complete status, should get 5 sessions (2 pages with limit 3)
     result = runner.invoke(cli, ["list", "--status", "complete", "--limit", "3"], input="\n")
 
@@ -788,7 +802,7 @@ def test_list_last_activity_column(temp_daf_home):
         old_session.active_conversation.last_active = now - timedelta(days=3)
         session_manager.update_session(old_session)
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--all"])
 
     assert result.exit_code == 0
@@ -838,7 +852,7 @@ def test_list_last_activity_multi_conversation(temp_daf_home):
 
     session_manager.update_session(session)
 
-    runner = CliRunner(env={"COLUMNS": "200"})
+    runner = CliRunner()
     result = runner.invoke(cli, ["list", "--all"])
 
     assert result.exit_code == 0

--- a/tests/test_list_command.py
+++ b/tests/test_list_command.py
@@ -12,7 +12,7 @@ from devflow.session.manager import SessionManager
 
 def test_list_empty(temp_daf_home):
     """Test listing sessions when none exist."""
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -34,7 +34,7 @@ def test_list_single_session(temp_daf_home):
         issue_key="PROJ-12345",
     )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -69,7 +69,7 @@ def test_list_multiple_sessions(temp_daf_home):
         issue_key="PROJ-222",
     )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -105,7 +105,7 @@ def test_list_filter_by_status(temp_daf_home):
     session2.status = "complete"
     session_manager.update_session(session2)
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--status", "complete"])
 
     assert result.exit_code == 0
@@ -136,7 +136,7 @@ def test_list_filter_by_working_directory(temp_daf_home):
         ai_agent_session_id="uuid-2",
     )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--working-directory", "backend-service"])
 
     assert result.exit_code == 0
@@ -166,7 +166,7 @@ def test_list_with_work_sessions(temp_daf_home):
     session.work_sessions = [WorkSession(start=start_time, end=end_time)]
     session_manager.update_session(session)
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -187,7 +187,7 @@ def test_list_no_sessions_with_filters(temp_daf_home):
         ai_agent_session_id="uuid-1",
     )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--status", "complete"])
 
     assert result.exit_code == 0
@@ -211,7 +211,7 @@ def test_list_displays_status_colors(temp_daf_home):
     session.status = "in_progress"
     session_manager.update_session(session)
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -234,7 +234,7 @@ def test_list_shows_session_summary(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -262,7 +262,7 @@ def test_list_with_jira_summary(temp_daf_home):
     session.issue_metadata["summary"] = "Implement backup feature"
     session_manager.update_session(session)
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -289,7 +289,7 @@ def test_list_pagination_default_limit(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     # In interactive mode, EOF will stop pagination after first page
     result = runner.invoke(cli, ["list"], input="")
 
@@ -316,7 +316,7 @@ def test_list_pagination_custom_limit(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     # In interactive mode, EOF will stop pagination after first page
     result = runner.invoke(cli, ["list", "--limit", "5"], input="")
 
@@ -343,7 +343,7 @@ def test_list_pagination_specific_page(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--limit", "5", "--page", "2"])
 
     assert result.exit_code == 0
@@ -367,7 +367,7 @@ def test_list_pagination_last_page_partial(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--limit", "5", "--page", "3"])
 
     assert result.exit_code == 0
@@ -391,7 +391,7 @@ def test_list_pagination_page_out_of_range(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--limit", "5", "--page", "10"])
 
     assert result.exit_code == 0
@@ -415,7 +415,7 @@ def test_list_pagination_show_all_flag(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--all"])
 
     assert result.exit_code == 0
@@ -444,7 +444,7 @@ def test_list_pagination_with_filters(temp_daf_home):
             session.status = "complete"
             session_manager.update_session(session)
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     # In interactive mode, EOF will stop pagination after first page
     result = runner.invoke(cli, ["list", "--status", "complete", "--limit", "3"], input="")
 
@@ -471,7 +471,7 @@ def test_list_pagination_few_sessions_no_pagination_info(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -495,7 +495,7 @@ def test_list_pagination_invalid_page_number(temp_daf_home):
         ai_agent_session_id="uuid-1",
     )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--page", "0"])
 
     assert result.exit_code == 0
@@ -516,7 +516,7 @@ def test_list_pagination_invalid_limit(temp_daf_home):
         ai_agent_session_id="uuid-1",
     )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--limit", "0"])
 
     assert result.exit_code == 0
@@ -539,7 +539,7 @@ def test_list_pagination_navigation_hints(temp_daf_home):
         )
 
     # Test page 1 - should show "next page" hint
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--limit", "5", "--page", "1"])
     assert result.exit_code == 0
     assert "--page 2" in result.output  # Next page hint
@@ -574,7 +574,7 @@ def test_list_interactive_mode_first_page_quit(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     # Simulate user pressing 'q' at the first prompt
     result = runner.invoke(cli, ["list"], input="q\n")
 
@@ -601,7 +601,7 @@ def test_list_interactive_mode_continue_to_next_page(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     # Simulate user pressing Enter at the first prompt (continue to page 2)
     result = runner.invoke(cli, ["list"], input="\n")
 
@@ -628,7 +628,7 @@ def test_list_interactive_mode_multiple_pages(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     # Simulate user pressing Enter twice to view all pages
     result = runner.invoke(cli, ["list", "--limit", "5"], input="\n\n")
 
@@ -657,7 +657,7 @@ def test_list_interactive_mode_quit_on_second_page(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     # Simulate user pressing Enter once, then 'q'
     result = runner.invoke(cli, ["list", "--limit", "5"], input="\nq\n")
 
@@ -687,7 +687,7 @@ def test_list_interactive_mode_single_page_no_prompt(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list"])
 
     assert result.exit_code == 0
@@ -712,7 +712,7 @@ def test_list_non_interactive_mode_with_page_flag(temp_daf_home):
             ai_agent_session_id=f"uuid-{i}",
         )
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--page", "1"])
 
     assert result.exit_code == 0
@@ -744,7 +744,7 @@ def test_list_interactive_mode_with_filters(temp_daf_home):
             session.status = "complete"
             session_manager.update_session(session)
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     # Filter by complete status, should get 5 sessions (2 pages with limit 3)
     result = runner.invoke(cli, ["list", "--status", "complete", "--limit", "3"], input="\n")
 
@@ -788,7 +788,7 @@ def test_list_last_activity_column(temp_daf_home):
         old_session.active_conversation.last_active = now - timedelta(days=3)
         session_manager.update_session(old_session)
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--all"])
 
     assert result.exit_code == 0
@@ -838,7 +838,7 @@ def test_list_last_activity_multi_conversation(temp_daf_home):
 
     session_manager.update_session(session)
 
-    runner = CliRunner()
+    runner = CliRunner(env={"COLUMNS": "200"})
     result = runner.invoke(cli, ["list", "--all"])
 
     assert result.exit_code == 0


### PR DESCRIPTION
Jira Issue: This PR does not need a corresponding Jira item.
<!-- GitHub Issue: https://github.com/itdove/devaiflow/issues/445 -->

## Description

Add `--agent` flag to `daf open`, `daf new`, `daf investigate`, `daf git new`, and `daf jira new` commands, allowing per-command override of the AI backend agent. Previously the agent was set globally; this flag lets operators switch agents on individual invocations without changing configuration.

Changes:
- Extended agent factory (`devflow/agent/factory.py`, `devflow/agent/__init__.py`) to accept runtime agent override
- Added `--agent` option to `open_command.py`, `new_command.py`, `investigate_command.py`, `git_new_command.py`, `jira_new_command.py`
- Updated CLI main entry point (`main.py`) and list command to support the new flag
- Added dedicated test suite (`tests/test_agent_flag.py`) and updated existing list command tests

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `daf open --agent claude-code` on an existing session and verify it uses the specified agent backend
3. Run `daf new --agent <agent-name>` to create a new session with a non-default agent
4. Run `daf investigate --agent <agent-name>` and confirm the agent override is applied
5. Run `daf git new --agent <agent-name>` and `daf jira new --agent <agent-name>` to verify flag works on sub-commands
6. Run without `--agent` flag and confirm default agent behavior is unchanged
7. Run `python -m pytest tests/test_agent_flag.py tests/test_list_command.py -v` to execute unit tests

### Scenarios tested
- Per-command agent override via `--agent` flag on each supported command
- Default behavior preserved when `--agent` is omitted
- Invalid agent name handling
- Unit tests pass for new flag logic and existing list command functionality

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: