### PR TITLE
itdove/devaiflow#441: daf dashboard doesn't auto-open browser when already running

### DIFF
--- a/devflow/cli/main.py
+++ b/devflow/cli/main.py
@@ -4056,11 +4056,15 @@ def dashboard(ctx: click.Context, port: int, no_open: bool, reload: bool, host: 
     from devflow.web.app import get_dashboard_status
     status = get_dashboard_status()
     if status:
+        url = f"http://127.0.0.1:{status['port']}"
         console.print(
             f"[yellow]Dashboard already running[/yellow] (pid={status['pid']}, port={status['port']})"
         )
-        console.print(f"  Open: [bold]http://127.0.0.1:{status['port']}[/bold]")
+        console.print(f"  Open: [bold]{url}[/bold]")
         console.print("  Stop: [bold]daf dashboard stop[/bold]")
+        if not no_open:
+            import webbrowser
+            webbrowser.open(url)
         return
 
     if background:

--- a/tests/test_web_dashboard.py
+++ b/tests/test_web_dashboard.py
@@ -1535,6 +1535,36 @@ class TestDashboardCLIGroup:
         # Should not crash
         assert result.exit_code == 0
 
+    def test_already_running_opens_browser(self):
+        """Test that 'daf dashboard' opens browser when already running."""
+        from devflow.cli.main import cli
+
+        runner = CliRunner()
+        mock_status = {"pid": 12345, "port": 8080}
+
+        with patch("devflow.web.app.get_dashboard_status", return_value=mock_status):
+            with patch("devflow.cli.main.console"):
+                with patch("webbrowser.open") as mock_open:
+                    result = runner.invoke(cli, ["dashboard"])
+
+        assert result.exit_code == 0
+        mock_open.assert_called_once_with("http://127.0.0.1:8080")
+
+    def test_already_running_no_open_skips_browser(self):
+        """Test that 'daf dashboard --no-open' does not open browser when already running."""
+        from devflow.cli.main import cli
+
+        runner = CliRunner()
+        mock_status = {"pid": 12345, "port": 8080}
+
+        with patch("devflow.web.app.get_dashboard_status", return_value=mock_status):
+            with patch("devflow.cli.main.console"):
+                with patch("webbrowser.open") as mock_open:
+                    result = runner.invoke(cli, ["dashboard", "--no-open"])
+
+        assert result.exit_code == 0
+        mock_open.assert_not_called()
+
 
 # ============================================================================
 # DataBridge Organization Config Tests


### PR DESCRIPTION
Jira Issue: N/A
<!-- This PR does not need a corresponding Jira item. -->

## Description

When `daf dashboard` is invoked and the dashboard server is already running, the command previously exited without opening the browser. This fix detects the already-running state and opens the browser to the existing dashboard URL instead of silently returning.

Fixes: itdove/devaiflow#441

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `daf dashboard` to start the dashboard server
3. In another terminal, run `daf dashboard` again
4. Verify the browser opens to the existing dashboard URL on the second invocation
5. Stop the dashboard and run `daf dashboard` — verify it starts normally and opens browser
6. Run `python -m pytest tests/test_web_dashboard.py` to execute unit tests

### Scenarios tested
- Dashboard not running — starts server and opens browser (existing behavior preserved)
- Dashboard already running — detects running instance and opens browser to existing URL (new behavior)
- Unit tests pass covering both scenarios

## Deployment considerations

- [x] This code change is ready for deployment on its own