### PR TITLE
itdove/devaiflow#451: daf info without args shows wrong session inside agent — fix skill and command

### DIFF
--- a/devflow/cli/commands/info_command.py
+++ b/devflow/cli/commands/info_command.py
@@ -38,8 +38,19 @@ def session_info(
     session_manager = SessionManager(config_loader)
 
     # Get session
-    if not identifier or latest:
-        # Get most recent session
+    # Priority: explicit identifier > DAF_SESSION_NAME env var > --latest > most recent
+    session = None
+    if identifier:
+        session = session_manager.get_session(identifier)
+    elif not latest:
+        # Check DAF_SESSION_NAME env var when no identifier given
+        from devflow.cli.utils import get_active_session_name
+        active_name = get_active_session_name()
+        if active_name:
+            session = session_manager.get_session(active_name)
+
+    # Fall back to most recent session if needed
+    if session is None and not identifier:
         sessions = session_manager.list_sessions()
         if not sessions:
             if output_json:
@@ -53,8 +64,6 @@ def session_info(
             import sys
             sys.exit(1)
         session = max(sessions, key=lambda s: s.last_active or s.created)
-    else:
-        session = session_manager.get_session(identifier)
 
     if not session:
         if output_json:

--- a/devflow/cli/commands/note_command.py
+++ b/devflow/cli/commands/note_command.py
@@ -45,18 +45,27 @@ def add_note(identifier: Optional[str] = None, note: Optional[str] = None, sync_
             console.print(f"[dim]Using active session: {identifier}{issue_display}[/dim]")
         # else: not in active session, keep identifier as session name (old behavior)
 
-    # If no identifier or --latest flag, use most recent active session
-    if not identifier or latest:
-        all_sessions = session_manager.list_sessions()
-        if not all_sessions:
-            console.print("[red]No sessions found[/red]")
-            import sys
-            sys.exit(1)
+    # Priority: explicit identifier > DAF_SESSION_NAME env var > --latest > most recent
+    if not identifier:
+        if not latest:
+            # Check DAF_SESSION_NAME env var when no identifier given
+            from devflow.cli.utils import get_active_session_name
+            active_name = get_active_session_name()
+            if active_name:
+                identifier = active_name
 
-        # Use the name of the most recent session
-        identifier = all_sessions[0].name
-        issue_display = f" ({all_sessions[0].issue_key})" if all_sessions[0].issue_key else ""
-        console.print(f"[dim]Using session: {identifier}{issue_display}[/dim]")
+        if not identifier:
+            # Fall back to most recent session
+            all_sessions = session_manager.list_sessions()
+            if not all_sessions:
+                console.print("[red]No sessions found[/red]")
+                import sys
+                sys.exit(1)
+
+            # Use the name of the most recent session
+            identifier = all_sessions[0].name
+            issue_display = f" ({all_sessions[0].issue_key})" if all_sessions[0].issue_key else ""
+            console.print(f"[dim]Using session: {identifier}{issue_display}[/dim]")
 
     # Get session using common utility (handles multi-session selection)
     session = get_session_with_prompt(session_manager, identifier, error_if_not_found=False)
@@ -116,18 +125,27 @@ def view_notes(identifier: Optional[str] = None, latest: bool = False) -> None:
     config_loader = ConfigLoader()
     session_manager = SessionManager(config_loader)
 
-    # If no identifier or --latest flag, use most recent active session
-    if not identifier or latest:
-        all_sessions = session_manager.list_sessions()
-        if not all_sessions:
-            console.print("[red]No sessions found[/red]")
-            import sys
-            sys.exit(1)
+    # Priority: explicit identifier > DAF_SESSION_NAME env var > --latest > most recent
+    if not identifier:
+        if not latest:
+            # Check DAF_SESSION_NAME env var when no identifier given
+            from devflow.cli.utils import get_active_session_name
+            active_name = get_active_session_name()
+            if active_name:
+                identifier = active_name
 
-        # Use the name of the most recent session
-        identifier = all_sessions[0].name
-        issue_display = f" ({all_sessions[0].issue_key})" if all_sessions[0].issue_key else ""
-        console.print(f"[dim]Viewing notes for: {identifier}{issue_display}[/dim]")
+        if not identifier:
+            # Fall back to most recent session
+            all_sessions = session_manager.list_sessions()
+            if not all_sessions:
+                console.print("[red]No sessions found[/red]")
+                import sys
+                sys.exit(1)
+
+            # Use the name of the most recent session
+            identifier = all_sessions[0].name
+            issue_display = f" ({all_sessions[0].issue_key})" if all_sessions[0].issue_key else ""
+            console.print(f"[dim]Viewing notes for: {identifier}{issue_display}[/dim]")
 
     # Get session using common utility (handles multi-session selection)
     session = get_session_with_prompt(session_manager, identifier)

--- a/devflow/cli_skills/daf-workflow/SKILL.md
+++ b/devflow/cli_skills/daf-workflow/SKILL.md
@@ -17,7 +17,7 @@ When `DAF_SESSION_NAME` is set, perform these steps **before doing any other wor
 ### 1. Read Session Metadata
 
 ```bash
-daf info
+daf info $DAF_SESSION_NAME
 ```
 
 This shows: session name, goal, issue key, status, working directory, branch, workspace, session type, and conversation history.

--- a/tests/test_info_command.py
+++ b/tests/test_info_command.py
@@ -735,3 +735,178 @@ def test_session_info_with_conversation_summary(temp_daf_home, capsys):
     captured = capsys.readouterr()
     assert "Summary:" in captured.out
     assert "This is a test summary" in captured.out
+
+
+def test_session_info_uses_daf_session_name_env_var(temp_daf_home, capsys, monkeypatch):
+    """Test that daf info (no args) uses DAF_SESSION_NAME env var inside agent session."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    # Create two sessions
+    session1 = session_manager.create_session(
+        name="old-session",
+        goal="Older session",
+        working_directory="dir1",
+        project_path="/path1",
+        ai_agent_session_id="uuid-old",
+    )
+    session1.last_active = datetime.now() - timedelta(hours=2)
+    session_manager.index.sessions["old-session"] = session1
+    session_manager._save_index()
+
+    session2 = session_manager.create_session(
+        name="recent-session",
+        goal="Most recent session",
+        working_directory="dir2",
+        project_path="/path2",
+        ai_agent_session_id="uuid-recent",
+    )
+    session2.last_active = datetime.now()
+    session_manager.index.sessions["recent-session"] = session2
+    session_manager._save_index()
+
+    # Set DAF_SESSION_NAME to the OLD session
+    monkeypatch.setenv("DAF_SESSION_NAME", "old-session")
+
+    session_info(identifier=None, uuid_only=False, conversation_id=None)
+    captured = capsys.readouterr()
+
+    # Should show old-session (from env var), NOT recent-session
+    assert "old-session" in captured.out
+    assert "uuid-old" in captured.out
+
+
+def test_session_info_latest_overrides_daf_session_name(temp_daf_home, capsys, monkeypatch):
+    """Test that --latest flag overrides DAF_SESSION_NAME env var."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session1 = session_manager.create_session(
+        name="env-session",
+        goal="Session from env",
+        working_directory="dir1",
+        project_path="/path1",
+        ai_agent_session_id="uuid-env",
+    )
+    session1.last_active = datetime.now() - timedelta(hours=2)
+    session_manager.index.sessions["env-session"] = session1
+    session_manager._save_index()
+
+    session2 = session_manager.create_session(
+        name="latest-session",
+        goal="Most recent session",
+        working_directory="dir2",
+        project_path="/path2",
+        ai_agent_session_id="uuid-latest",
+    )
+    session2.last_active = datetime.now()
+    session_manager.index.sessions["latest-session"] = session2
+    session_manager._save_index()
+
+    # Set DAF_SESSION_NAME to old session
+    monkeypatch.setenv("DAF_SESSION_NAME", "env-session")
+
+    # Use --latest flag - should override env var
+    session_info(identifier=None, uuid_only=False, conversation_id=None, latest=True)
+    captured = capsys.readouterr()
+
+    # Should show latest-session, NOT env-session
+    assert "latest-session" in captured.out
+    assert "uuid-latest" in captured.out
+
+
+def test_session_info_falls_back_without_daf_session_name(temp_daf_home, capsys, monkeypatch):
+    """Test that daf info (no args) falls back to most recent when DAF_SESSION_NAME not set."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session1 = session_manager.create_session(
+        name="old-session",
+        goal="Older session",
+        working_directory="dir1",
+        project_path="/path1",
+        ai_agent_session_id="uuid-old",
+    )
+    session1.last_active = datetime.now() - timedelta(hours=2)
+    session_manager.index.sessions["old-session"] = session1
+    session_manager._save_index()
+
+    session2 = session_manager.create_session(
+        name="recent-session",
+        goal="Most recent session",
+        working_directory="dir2",
+        project_path="/path2",
+        ai_agent_session_id="uuid-recent",
+    )
+    session2.last_active = datetime.now()
+    session_manager.index.sessions["recent-session"] = session2
+    session_manager._save_index()
+
+    # Ensure DAF_SESSION_NAME is NOT set
+    monkeypatch.delenv("DAF_SESSION_NAME", raising=False)
+    monkeypatch.delenv("CS_SESSION_NAME", raising=False)
+    monkeypatch.delenv("AI_AGENT_SESSION_ID", raising=False)
+
+    session_info(identifier=None, uuid_only=False, conversation_id=None)
+    captured = capsys.readouterr()
+
+    # Should show most recent session
+    assert "recent-session" in captured.out
+    assert "uuid-recent" in captured.out
+
+
+def test_session_info_daf_session_name_not_found_falls_back(temp_daf_home, capsys, monkeypatch):
+    """Test that daf info falls back to most recent when DAF_SESSION_NAME refers to non-existent session."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session = session_manager.create_session(
+        name="existing-session",
+        goal="Existing session",
+        working_directory="dir1",
+        project_path="/path1",
+        ai_agent_session_id="uuid-existing",
+    )
+
+    # Set DAF_SESSION_NAME to a non-existent session
+    monkeypatch.setenv("DAF_SESSION_NAME", "non-existent-session")
+
+    session_info(identifier=None, uuid_only=False, conversation_id=None)
+    captured = capsys.readouterr()
+
+    # Should fall back to existing session (most recent)
+    assert "existing-session" in captured.out
+    assert "uuid-existing" in captured.out
+
+
+def test_session_info_explicit_identifier_overrides_daf_session_name(temp_daf_home, capsys, monkeypatch):
+    """Test that explicit identifier takes priority over DAF_SESSION_NAME."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session1 = session_manager.create_session(
+        name="env-session",
+        goal="Session from env",
+        working_directory="dir1",
+        project_path="/path1",
+        ai_agent_session_id="uuid-env",
+    )
+
+    session2 = session_manager.create_session(
+        name="explicit-session",
+        goal="Explicit session",
+        working_directory="dir2",
+        project_path="/path2",
+        ai_agent_session_id="uuid-explicit",
+    )
+
+    # Set DAF_SESSION_NAME to one session
+    monkeypatch.setenv("DAF_SESSION_NAME", "env-session")
+
+    # But pass a different identifier explicitly
+    session_info(identifier="explicit-session", uuid_only=False, conversation_id=None)
+    captured = capsys.readouterr()
+
+    # Should show explicit-session, NOT env-session
+    assert "explicit-session" in captured.out
+    assert "uuid-explicit" in captured.out

--- a/tests/test_note_command.py
+++ b/tests/test_note_command.py
@@ -544,3 +544,155 @@ def test_add_note_message_only_outside_active_session_fails(temp_daf_home, monke
         add_note(identifier="My note message", note=None)
     assert exc_info.value.code == 1
     # Should show error that session "My note message" was not found
+
+
+def test_view_notes_uses_daf_session_name_env_var(temp_daf_home, monkeypatch, capsys):
+    """Test that daf notes (no args) uses DAF_SESSION_NAME env var inside agent session."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    # Create two sessions with notes
+    session1 = session_manager.create_session(
+        name="env-session",
+        goal="Session from env",
+        working_directory="dir1",
+        project_path="/path1",
+        ai_agent_session_id="uuid-env",
+    )
+    session_manager.add_note("env-session", "Note for env session")
+
+    import time
+    time.sleep(0.05)
+
+    session2 = session_manager.create_session(
+        name="recent-session",
+        goal="Most recent session",
+        working_directory="dir2",
+        project_path="/path2",
+        ai_agent_session_id="uuid-recent",
+    )
+    session_manager.add_note("recent-session", "Note for recent session")
+
+    # Set DAF_SESSION_NAME to the older session
+    monkeypatch.setenv("DAF_SESSION_NAME", "env-session")
+
+    view_notes(identifier=None, latest=False)
+    captured = capsys.readouterr()
+
+    # Should show notes for env-session (from env var), NOT recent-session
+    assert "Note for env session" in captured.out
+
+
+def test_view_notes_latest_overrides_daf_session_name(temp_daf_home, monkeypatch, capsys):
+    """Test that --latest flag overrides DAF_SESSION_NAME for view_notes."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session1 = session_manager.create_session(
+        name="env-session",
+        goal="Session from env",
+        working_directory="dir1",
+        project_path="/path1",
+        ai_agent_session_id="uuid-env",
+    )
+    session_manager.add_note("env-session", "Note for env session")
+
+    import time
+    time.sleep(0.05)
+
+    session2 = session_manager.create_session(
+        name="recent-session",
+        goal="Most recent session",
+        working_directory="dir2",
+        project_path="/path2",
+        ai_agent_session_id="uuid-recent",
+    )
+    session_manager.add_note("recent-session", "Note for recent session")
+
+    # Set DAF_SESSION_NAME to older session
+    monkeypatch.setenv("DAF_SESSION_NAME", "env-session")
+
+    # Use --latest flag - should override env var
+    view_notes(identifier=None, latest=True)
+    captured = capsys.readouterr()
+
+    # Should show notes for recent-session (latest), NOT env-session
+    assert "Note for recent session" in captured.out
+
+
+def test_view_notes_falls_back_without_daf_session_name(temp_daf_home, monkeypatch, capsys):
+    """Test that daf notes falls back to most recent when DAF_SESSION_NAME not set."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session1 = session_manager.create_session(
+        name="old-session",
+        goal="Older session",
+        working_directory="dir1",
+        project_path="/path1",
+        ai_agent_session_id="uuid-old",
+    )
+    session_manager.add_note("old-session", "Note for old session")
+
+    import time
+    time.sleep(0.05)
+
+    session2 = session_manager.create_session(
+        name="recent-session",
+        goal="Most recent session",
+        working_directory="dir2",
+        project_path="/path2",
+        ai_agent_session_id="uuid-recent",
+    )
+    session_manager.add_note("recent-session", "Note for recent session")
+
+    # Ensure DAF_SESSION_NAME is NOT set
+    monkeypatch.delenv("DAF_SESSION_NAME", raising=False)
+    monkeypatch.delenv("CS_SESSION_NAME", raising=False)
+    monkeypatch.delenv("AI_AGENT_SESSION_ID", raising=False)
+
+    view_notes(identifier=None, latest=False)
+    captured = capsys.readouterr()
+
+    # Should show notes for most recent session
+    assert "Note for recent session" in captured.out
+
+
+def test_add_note_uses_daf_session_name_env_var(temp_daf_home, monkeypatch, capsys):
+    """Test that daf note (no identifier, no active conversation) uses DAF_SESSION_NAME."""
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    import time
+
+    session1 = session_manager.create_session(
+        name="env-session",
+        goal="Session from env",
+        working_directory="dir1",
+        project_path="/path1",
+        ai_agent_session_id="uuid-env",
+    )
+
+    time.sleep(0.05)
+
+    session2 = session_manager.create_session(
+        name="recent-session",
+        goal="Most recent session",
+        working_directory="dir2",
+        project_path="/path2",
+        ai_agent_session_id="uuid-recent",
+    )
+
+    # Set DAF_SESSION_NAME to the older session
+    monkeypatch.setenv("DAF_SESSION_NAME", "env-session")
+    # Ensure not detected as active conversation
+    monkeypatch.delenv("AI_AGENT_SESSION_ID", raising=False)
+
+    add_note(identifier=None, note="Note from agent session")
+
+    # Verify note was added to env-session (from env var), NOT recent-session
+    env_notes = config_loader.get_session_dir("env-session") / "notes.md"
+    recent_notes = config_loader.get_session_dir("recent-session") / "notes.md"
+    assert env_notes.exists()
+    assert not recent_notes.exists()
+    assert "Note from agent session" in env_notes.read_text()


### PR DESCRIPTION
Jira Issue: https://github.com/itdove/devaiflow/issues/451
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

When running `daf info` without arguments inside a Claude Code agent session, the command resolved the wrong session because it fell back to directory-based lookup instead of using the `DAF_SESSION_NAME` environment variable that is set in the agent context.

This PR fixes implicit session resolution in `info_command.py` and `note_command.py` to check `DAF_SESSION_NAME` env var before falling back to directory-based resolution. The `daf-workflow` skill definition (`SKILL.md`) is also updated to align with this behavior.

Changes:
- `devflow/cli/commands/info_command.py` — prioritize `DAF_SESSION_NAME` env var for session lookup when no explicit session arg is provided
- `devflow/cli/commands/note_command.py` — same implicit resolution fix for note commands
- `devflow/cli_skills/daf-workflow/SKILL.md` — update skill documentation to reflect env-var-based resolution
- `tests/test_info_command.py` — add/update tests covering env-var-based session resolution
- `tests/test_note_command.py` — add/update tests covering env-var-based session resolution

<!-- If you use any AI tool then provide that information here. The code assistant that you used, elaborating on how it was used.  -->
Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run existing tests: `pytest tests/test_info_command.py tests/test_note_command.py`
3. Start a DevAIFlow session: `daf open <session>`
4. Inside a Claude Code agent context (where `DAF_SESSION_NAME` is set), run `daf info` without arguments and verify it resolves the correct active session
5. Run `daf info` outside an agent context (no `DAF_SESSION_NAME` set) and verify directory-based fallback still works
6. Repeat steps 4-5 for `daf notes`

### Scenarios tested
- `daf info` with no args inside agent context — resolves via `DAF_SESSION_NAME`
- `daf info` with no args outside agent context — falls back to directory-based resolution
- `daf info` with explicit session arg — uses provided arg regardless of env var
- `daf notes` commands with same scenarios as above

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: