### PR TITLE
itdove/devaiflow#461: OpenCode exit splash art garbles daf post-session output

### DIFF
--- a/devflow/agent/crush_agent.py
+++ b/devflow/agent/crush_agent.py
@@ -358,6 +358,18 @@ class CrushAgent(AgentInterface):
         """
         return self.crush_dir
 
+    def uses_tui(self) -> bool:
+        """Crush uses a full-screen TUI (Bubble Tea).
+
+        Crush renders a full-screen terminal interface using the alternate
+        screen buffer. On exit it may leave splash art that garbles subsequent
+        CLI output unless the screen is explicitly cleared.
+
+        Returns:
+            True
+        """
+        return True
+
     def get_agent_name(self) -> str:
         """Get the name of the agent backend.
 

--- a/devflow/agent/interface.py
+++ b/devflow/agent/interface.py
@@ -215,6 +215,26 @@ class AgentInterface(ABC):
         """
         pass
 
+    def uses_tui(self) -> bool:
+        """Whether this agent uses a full-screen TUI (alternate screen buffer).
+
+        TUI agents (e.g. OpenCode, Crush) take over the entire terminal with a
+        full-screen interface built on frameworks like Bubble Tea. When they
+        exit, they may leave splash art or residual output on the screen that
+        garbles subsequent CLI output.
+
+        Non-TUI agents (e.g. Claude Code, Aider) use a standard terminal REPL
+        and do not leave splash art on exit.
+
+        GUI/IDE agents (e.g. Cursor, Windsurf) open a separate window and do
+        not interact with the terminal at all.
+
+        Returns:
+            True if the agent uses a full-screen TUI.
+            False otherwise (default).
+        """
+        return False
+
     def supports_permission_prompts(self) -> bool:
         """Whether this agent prompts the user before modifying files or running commands.
 

--- a/devflow/agent/opencode_agent.py
+++ b/devflow/agent/opencode_agent.py
@@ -353,6 +353,18 @@ class OpenCodeAgent(AgentInterface):
         """
         return "opencode"
 
+    def uses_tui(self) -> bool:
+        """OpenCode uses a full-screen TUI (Bubble Tea).
+
+        OpenCode renders a full-screen terminal interface using the alternate
+        screen buffer. On exit it may leave splash art that garbles subsequent
+        CLI output unless the screen is explicitly cleared.
+
+        Returns:
+            True
+        """
+        return True
+
     def supports_permission_prompts(self) -> bool:
         """OpenCode supports permission prompts when configured.
 

--- a/devflow/cli/commands/git_new_command.py
+++ b/devflow/cli/commands/git_new_command.py
@@ -773,8 +773,10 @@ def create_git_issue_session(
         # Wait for the agent process to complete
         process.wait()
         if not headless:
-            from devflow.cli.utils import reset_terminal_after_tui
+            from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
             reset_terminal_after_tui()
+            if agent_client.uses_tui():
+                clear_screen_after_tui()
     finally:
         if not is_cleanup_done():
             console_print(f"\n[green]✓[/green] {agent_name} session completed")

--- a/devflow/cli/commands/investigate_command.py
+++ b/devflow/cli/commands/investigate_command.py
@@ -743,6 +743,11 @@ def create_investigation_session(
         )
         # Wait for the agent process to complete
         process.wait()
+        if not headless:
+            from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
+            reset_terminal_after_tui()
+            if agent_client.uses_tui():
+                clear_screen_after_tui()
 
         # Keep env reference for finally block
         _ = env
@@ -1192,6 +1197,11 @@ def _create_multi_project_investigation_session(
         )
         # Wait for the agent process to complete
         process.wait()
+        if not headless:
+            from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
+            reset_terminal_after_tui()
+            if agent_client.uses_tui():
+                clear_screen_after_tui()
 
         # Keep env reference for finally block
         _ = env

--- a/devflow/cli/commands/jira_new_command.py
+++ b/devflow/cli/commands/jira_new_command.py
@@ -666,8 +666,10 @@ def create_jira_ticket_session(
         # Wait for the agent process to complete
         process.wait()
         if not headless:
-            from devflow.cli.utils import reset_terminal_after_tui
+            from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
             reset_terminal_after_tui()
+            if agent_client.uses_tui():
+                clear_screen_after_tui()
     finally:
         if not is_cleanup_done():
             console_print(f"\n[green]✓[/green] {agent_name} session completed")

--- a/devflow/cli/commands/new_command.py
+++ b/devflow/cli/commands/new_command.py
@@ -910,8 +910,10 @@ def create_new_session(
             # Wait for the agent process to complete
             process.wait()
             if not headless:
-                from devflow.cli.utils import reset_terminal_after_tui
+                from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
                 reset_terminal_after_tui()
+                if agent_client.uses_tui():
+                    clear_screen_after_tui()
         finally:
             if not is_cleanup_done():
                 console.print(f"\n[green]✓[/green] {agent_name} session completed")

--- a/devflow/cli/commands/new_command_multiproject.py
+++ b/devflow/cli/commands/new_command_multiproject.py
@@ -374,6 +374,11 @@ def create_multi_project_session(
                 auto_approve=auto_approve,
             )
             process.wait()
+            if not headless:
+                from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
+                reset_terminal_after_tui()
+                if agent.uses_tui():
+                    clear_screen_after_tui()
         finally:
             if not is_cleanup_done():
                 console.print(f"\n[green]✓[/green] {agent_name} session completed")

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -1123,8 +1123,10 @@ def open_session(
                     )
                     process.wait()
                     if not headless:
-                        from devflow.cli.utils import reset_terminal_after_tui
+                        from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
                         reset_terminal_after_tui()
+                        if agent.uses_tui():
+                            clear_screen_after_tui()
             finally:
                 if not is_cleanup_done():
                     console.print(f"\n[green]✓[/green] {_display_agent_name} session completed")
@@ -1294,8 +1296,10 @@ def open_session(
                     process.wait()
             finally:
                 if not headless:
-                    from devflow.cli.utils import reset_terminal_after_tui
+                    from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
                     reset_terminal_after_tui()
+                    if agent.uses_tui():
+                        clear_screen_after_tui()
                 if not is_cleanup_done():
                     console.print(f"\n[green]✓[/green] {_display_agent_name} session completed")
 

--- a/devflow/cli/utils.py
+++ b/devflow/cli/utils.py
@@ -55,6 +55,31 @@ def reset_terminal_after_tui() -> None:
         pass
 
 
+def clear_screen_after_tui() -> None:
+    """Scroll past TUI splash art so daf output prints on clean lines.
+
+    TUI agents (e.g. OpenCode, Crush) may leave exit splash art on the
+    screen that garbles subsequent CLI output. Instead of clearing the
+    screen (which destroys useful context), this scrolls the terminal
+    down by one screenful so the splash art moves into scrollback and
+    daf's post-session messages appear on clean lines.
+
+    Only call this for agents where ``agent.uses_tui()`` returns True.
+    Non-TUI agents (Claude Code, Aider) do not leave splash art.
+
+    Silently skipped in non-TTY environments (CI, tests, pipes).
+    """
+    try:
+        if not sys.stdout.isatty():
+            return
+        import shutil
+        rows = shutil.get_terminal_size().lines
+        sys.stdout.write("\n" * rows)
+        sys.stdout.flush()
+    except (OSError, ValueError):
+        pass
+
+
 def check_outside_ai_session() -> None:
     """Check if running inside an AI agent session and exit with error if so.
 

--- a/devflow/orchestration/feature.py
+++ b/devflow/orchestration/feature.py
@@ -534,6 +534,10 @@ class FeatureManager:
             # Wait for agent to complete
             # Note: This blocks until user exits the agent
             process.wait()
+            from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
+            reset_terminal_after_tui()
+            if agent.uses_tui():
+                clear_screen_after_tui()
 
             # Parse agent's session to check verification results
             # Look for checked boxes [x] in the conversation

--- a/tests/test_agent_interface.py
+++ b/tests/test_agent_interface.py
@@ -1776,6 +1776,55 @@ class TestSupportsPermissionPrompts:
         assert agent.supports_permission_prompts() is True
 
 
+class TestUsesTui:
+    """Test uses_tui() across all agent implementations (#461)."""
+
+    def test_opencode_uses_tui(self):
+        """OpenCode uses a full-screen TUI (Bubble Tea)."""
+        agent = OpenCodeAgent()
+        assert agent.uses_tui() is True
+
+    def test_crush_uses_tui(self):
+        """Crush uses a full-screen TUI (Bubble Tea)."""
+        agent = CrushAgent()
+        assert agent.uses_tui() is True
+
+    def test_claude_does_not_use_tui(self):
+        """Claude Code uses a standard terminal REPL, not a TUI."""
+        agent = ClaudeAgent()
+        assert agent.uses_tui() is False
+
+    def test_ollama_does_not_use_tui(self):
+        """OllamaClaude uses a standard terminal REPL."""
+        agent = OllamaClaudeAgent()
+        assert agent.uses_tui() is False
+
+    def test_aider_does_not_use_tui(self):
+        """Aider uses a standard terminal REPL."""
+        agent = AiderAgent()
+        assert agent.uses_tui() is False
+
+    def test_copilot_does_not_use_tui(self):
+        """GitHub Copilot is a GUI/IDE, not a TUI."""
+        agent = GitHubCopilotAgent()
+        assert agent.uses_tui() is False
+
+    def test_cursor_does_not_use_tui(self):
+        """Cursor is a GUI/IDE, not a TUI."""
+        agent = CursorAgent()
+        assert agent.uses_tui() is False
+
+    def test_windsurf_does_not_use_tui(self):
+        """Windsurf is a GUI/IDE, not a TUI."""
+        agent = WindsurfAgent()
+        assert agent.uses_tui() is False
+
+    def test_continue_does_not_use_tui(self):
+        """Continue is a GUI/IDE extension, not a TUI."""
+        agent = ContinueAgent()
+        assert agent.uses_tui() is False
+
+
 class TestGetAgentDisplayName:
     """Tests for get_agent_display_name helper function (#448)."""
 

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -19,6 +19,7 @@ from devflow.cli.utils import (
     resolve_goal_input,
     process_goal_options,
     reset_terminal_after_tui,
+    clear_screen_after_tui,
     _is_valid_file_or_url,
     _resolve_file_or_url,
     require_outside_claude,
@@ -1021,6 +1022,58 @@ class TestResetTerminalAfterTui:
 
         assert fake_stdout.getvalue() == ""
         mock_run.assert_not_called()
+
+
+class TestClearScreenAfterTui:
+    """Tests for clear_screen_after_tui (#461)."""
+
+    def test_scrolls_past_splash_art(self):
+        """Verify newlines are written to scroll past TUI splash art."""
+        import io
+        import sys
+
+        fake_stdout = io.StringIO()
+        fake_stdout.isatty = lambda: True
+        with patch.object(sys, "stdout", fake_stdout), \
+             patch("shutil.get_terminal_size", return_value=Mock(lines=24)):
+            clear_screen_after_tui()
+
+        written = fake_stdout.getvalue()
+        assert written == "\n" * 24, "Should write one newline per terminal row"
+
+    def test_skipped_when_not_tty(self):
+        """No output when stdout is not a TTY."""
+        import io
+        import sys
+
+        fake_stdout = io.StringIO()
+        fake_stdout.isatty = lambda: False
+        with patch.object(sys, "stdout", fake_stdout):
+            clear_screen_after_tui()
+
+        assert fake_stdout.getvalue() == ""
+
+    def test_silences_os_errors(self):
+        """OSError during write is silently caught."""
+        import sys
+
+        mock_stdout = Mock()
+        mock_stdout.isatty.return_value = True
+        mock_stdout.write.side_effect = OSError("broken pipe")
+        with patch.object(sys, "stdout", mock_stdout):
+            # Should not raise
+            clear_screen_after_tui()
+
+    def test_silences_value_errors(self):
+        """ValueError during write is silently caught."""
+        import sys
+
+        mock_stdout = Mock()
+        mock_stdout.isatty.return_value = True
+        mock_stdout.write.side_effect = ValueError("closed")
+        with patch.object(sys, "stdout", mock_stdout):
+            # Should not raise
+            clear_screen_after_tui()
 
 
 class TestGetActiveSessionName:


### PR DESCRIPTION
Jira Issue: <!-- This PR does not need a corresponding Jira item. -->

## Description

Fixes [#461](https://github.com/itdove/devaiflow/issues/461): OpenCode's exit splash art was garbling daf post-session output, making session summaries and status information unreadable.

The root cause was that OpenCode writes decorative terminal output on exit that interferes with daf's post-session rendering. This PR refactors the agent interface and CLI command layer to properly handle terminal output sequencing after agent exit, ensuring clean rendering of post-session output across all agent types (OpenCode, Crush).

**Changes:**
- Refactored `devflow/agent/interface.py` to manage terminal state around agent exit
- Updated `devflow/agent/opencode_agent.py` and `devflow/agent/crush_agent.py` to use the new interface
- Propagated the fix through all CLI commands that invoke agents (`open`, `new`, `investigate`, `git_new`, `jira_new`, `new_command_multiproject`)
- Updated `devflow/cli/utils.py` with terminal output handling utilities
- Updated `devflow/orchestration/feature.py` for consistent post-session behavior
- Added tests in `test_agent_interface.py` and `test_cli_utils.py`

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `daf open` with OpenCode as the configured agent — complete a task and exit the agent session
3. Verify the post-session output (session summary, status info) renders cleanly without garbled characters or overwritten lines
4. Repeat with `daf new`, `daf investigate`, `daf git new`, and `daf jira new` commands
5. Run with Crush agent to confirm no regression: `daf open` with crush configured
6. Run the test suite: `pytest tests/test_agent_interface.py tests/test_cli_utils.py`

### Scenarios tested
- OpenCode agent exit followed by daf post-session summary
- Crush agent exit followed by daf post-session summary
- All CLI command paths that invoke agents
- Unit tests for agent interface and CLI utils

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: