### PR TITLE
itdove/devaiflow#461: OpenCode exit splash art garbles daf post-session output

### DIFF
--- a/devflow/agent/interface.py
+++ b/devflow/agent/interface.py
@@ -235,6 +235,40 @@ class AgentInterface(ABC):
         """
         return False
 
+    def cleanup_after_exit(self, headless: bool = False) -> None:
+        """Clean up terminal immediately after the agent process exits.
+
+        This is the single place where terminal cleanup happens. It must
+        be called right after the agent subprocess ends — before any other
+        output is printed.
+
+        For TUI agents (OpenCode, Crush), this clears the screen so their
+        exit splash art does not garble daf's post-session messages.
+
+        Args:
+            headless: If True, skip terminal cleanup (no TTY interaction)
+        """
+        if headless:
+            return
+        from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
+        reset_terminal_after_tui()
+        if self.uses_tui():
+            clear_screen_after_tui()
+
+    def wait_for_exit(self, process: subprocess.Popen, headless: bool = False) -> None:
+        """Wait for the agent process to exit, then immediately clean up.
+
+        Convenience wrapper: calls ``process.wait()`` then
+        ``cleanup_after_exit()``. Use this instead of calling
+        ``process.wait()`` directly.
+
+        Args:
+            process: The subprocess.Popen handle for the agent
+            headless: If True, skip terminal cleanup (no TTY interaction)
+        """
+        process.wait()
+        self.cleanup_after_exit(headless)
+
     def supports_permission_prompts(self) -> bool:
         """Whether this agent prompts the user before modifying files or running commands.
 

--- a/devflow/cli/commands/git_new_command.py
+++ b/devflow/cli/commands/git_new_command.py
@@ -776,13 +776,7 @@ def create_git_issue_session(
             headless=headless,
             auto_approve=auto_approve,
         )
-        # Wait for the agent process to complete
-        process.wait()
-        if not headless:
-            from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
-            reset_terminal_after_tui()
-            if agent_client.uses_tui():
-                clear_screen_after_tui()
+        agent_client.wait_for_exit(process, headless)
     finally:
         if not is_cleanup_done():
             console_print(f"\n[green]✓[/green] {agent_name} session completed")

--- a/devflow/cli/commands/investigate_command.py
+++ b/devflow/cli/commands/investigate_command.py
@@ -746,13 +746,7 @@ def create_investigation_session(
             headless=headless,
             auto_approve=auto_approve,
         )
-        # Wait for the agent process to complete
-        process.wait()
-        if not headless:
-            from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
-            reset_terminal_after_tui()
-            if agent_client.uses_tui():
-                clear_screen_after_tui()
+        agent_client.wait_for_exit(process, headless)
 
         # Keep env reference for finally block
         _ = env
@@ -1210,13 +1204,7 @@ def _create_multi_project_investigation_session(
             headless=headless,
             auto_approve=auto_approve,
         )
-        # Wait for the agent process to complete
-        process.wait()
-        if not headless:
-            from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
-            reset_terminal_after_tui()
-            if agent_client.uses_tui():
-                clear_screen_after_tui()
+        agent_client.wait_for_exit(process, headless)
 
         # Keep env reference for finally block
         _ = env

--- a/devflow/cli/commands/jira_new_command.py
+++ b/devflow/cli/commands/jira_new_command.py
@@ -669,13 +669,7 @@ def create_jira_ticket_session(
             headless=headless,
             auto_approve=auto_approve,
         )
-        # Wait for the agent process to complete
-        process.wait()
-        if not headless:
-            from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
-            reset_terminal_after_tui()
-            if agent_client.uses_tui():
-                clear_screen_after_tui()
+        agent_client.wait_for_exit(process, headless)
     finally:
         if not is_cleanup_done():
             console_print(f"\n[green]✓[/green] {agent_name} session completed")

--- a/devflow/cli/commands/new_command.py
+++ b/devflow/cli/commands/new_command.py
@@ -913,13 +913,7 @@ def create_new_session(
                 headless=headless,
                 auto_approve=auto_approve
             )
-            # Wait for the agent process to complete
-            process.wait()
-            if not headless:
-                from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
-                reset_terminal_after_tui()
-                if agent_client.uses_tui():
-                    clear_screen_after_tui()
+            agent_client.wait_for_exit(process, headless)
         finally:
             if not is_cleanup_done():
                 console.print(f"\n[green]✓[/green] {agent_name} session completed")

--- a/devflow/cli/commands/new_command_multiproject.py
+++ b/devflow/cli/commands/new_command_multiproject.py
@@ -379,12 +379,7 @@ def create_multi_project_session(
                 headless=headless,
                 auto_approve=auto_approve,
             )
-            process.wait()
-            if not headless:
-                from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
-                reset_terminal_after_tui()
-                if agent.uses_tui():
-                    clear_screen_after_tui()
+            agent.wait_for_exit(process, headless)
         finally:
             if not is_cleanup_done():
                 console.print(f"\n[green]✓[/green] {agent_name} session completed")

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -1124,12 +1124,7 @@ def open_session(
                         headless=headless,
                         auto_approve=auto_approve
                     )
-                    process.wait()
-                    if not headless:
-                        from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
-                        reset_terminal_after_tui()
-                        if agent.uses_tui():
-                            clear_screen_after_tui()
+                    agent.wait_for_exit(process, headless)
             finally:
                 if not is_cleanup_done():
                     console.print(f"\n[green]✓[/green] {_display_agent_name} session completed")
@@ -1297,15 +1292,10 @@ def open_session(
                         cwd=launch_dir,
                         env=env,
                     )
+                    agent.cleanup_after_exit(headless)
                 elif not cmd and 'process' in locals():
-                    # For non-resumable agents, wait for the launched process
-                    process.wait()
+                    agent.wait_for_exit(process, headless)
             finally:
-                if not headless:
-                    from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
-                    reset_terminal_after_tui()
-                    if agent.uses_tui():
-                        clear_screen_after_tui()
                 if not is_cleanup_done():
                     console.print(f"\n[green]✓[/green] {_display_agent_name} session completed")
 

--- a/devflow/cli/utils.py
+++ b/devflow/cli/utils.py
@@ -56,25 +56,25 @@ def reset_terminal_after_tui() -> None:
 
 
 def clear_screen_after_tui() -> None:
-    """Scroll past TUI splash art so daf output prints on clean lines.
+    """Move cursor below the TUI exit splash so daf output prints cleanly.
 
-    TUI agents (e.g. OpenCode, Crush) may leave exit splash art on the
-    screen that garbles subsequent CLI output. Instead of clearing the
-    screen (which destroys useful context), this scrolls the terminal
-    down by one screenful so the splash art moves into scrollback and
-    daf's post-session messages appear on clean lines.
+    TUI agents (e.g. OpenCode, Crush) print exit splash art (logo,
+    session info). The cursor may end up in the middle of that splash.
+    If daf prints from there, the output overlaps and looks garbled.
+
+    Instead of clearing the screen (which destroys the nice-looking
+    splash), this moves the cursor to the bottom of the terminal and
+    starts a new line so daf's messages appear cleanly below.
 
     Only call this for agents where ``agent.uses_tui()`` returns True.
-    Non-TUI agents (Claude Code, Aider) do not leave splash art.
 
     Silently skipped in non-TTY environments (CI, tests, pipes).
     """
     try:
         if not sys.stdout.isatty():
             return
-        import shutil
-        rows = shutil.get_terminal_size().lines
-        sys.stdout.write("\n" * rows)
+        sys.stdout.write("\033[999B")  # move cursor to bottom of screen
+        sys.stdout.write("\n")         # start a fresh line
         sys.stdout.flush()
     except (OSError, ValueError):
         pass

--- a/devflow/orchestration/feature.py
+++ b/devflow/orchestration/feature.py
@@ -533,11 +533,7 @@ class FeatureManager:
 
             # Wait for agent to complete
             # Note: This blocks until user exits the agent
-            process.wait()
-            from devflow.cli.utils import reset_terminal_after_tui, clear_screen_after_tui
-            reset_terminal_after_tui()
-            if agent.uses_tui():
-                clear_screen_after_tui()
+            agent.wait_for_exit(process)
 
             # Parse agent's session to check verification results
             # Look for checked boxes [x] in the conversation

--- a/tests/test_agent_interface.py
+++ b/tests/test_agent_interface.py
@@ -1825,6 +1825,55 @@ class TestUsesTui:
         assert agent.uses_tui() is False
 
 
+class TestWaitForExit:
+    """Test wait_for_exit() and cleanup_after_exit() (#461)."""
+
+    def test_wait_for_exit_calls_process_wait_then_cleanup(self):
+        """wait_for_exit() calls process.wait() then cleanup."""
+        agent = ClaudeAgent()
+        mock_process = Mock()
+        with patch.object(agent, "cleanup_after_exit") as mock_cleanup:
+            agent.wait_for_exit(mock_process, headless=False)
+        mock_process.wait.assert_called_once()
+        mock_cleanup.assert_called_once_with(False)
+
+    def test_wait_for_exit_headless_skips_cleanup(self):
+        """In headless mode, cleanup_after_exit is still called but returns early."""
+        agent = ClaudeAgent()
+        mock_process = Mock()
+        with patch.object(agent, "cleanup_after_exit") as mock_cleanup:
+            agent.wait_for_exit(mock_process, headless=True)
+        mock_process.wait.assert_called_once()
+        mock_cleanup.assert_called_once_with(True)
+
+    @patch("devflow.cli.utils.clear_screen_after_tui")
+    @patch("devflow.cli.utils.reset_terminal_after_tui")
+    def test_cleanup_tui_agent_clears_screen(self, mock_reset, mock_clear):
+        """TUI agents reset terminal AND clear screen."""
+        agent = OpenCodeAgent()
+        agent.cleanup_after_exit(headless=False)
+        mock_reset.assert_called_once()
+        mock_clear.assert_called_once()
+
+    @patch("devflow.cli.utils.clear_screen_after_tui")
+    @patch("devflow.cli.utils.reset_terminal_after_tui")
+    def test_cleanup_non_tui_agent_resets_but_no_clear(self, mock_reset, mock_clear):
+        """Non-TUI agents reset terminal but do NOT clear screen."""
+        agent = ClaudeAgent()
+        agent.cleanup_after_exit(headless=False)
+        mock_reset.assert_called_once()
+        mock_clear.assert_not_called()
+
+    @patch("devflow.cli.utils.clear_screen_after_tui")
+    @patch("devflow.cli.utils.reset_terminal_after_tui")
+    def test_cleanup_headless_does_nothing(self, mock_reset, mock_clear):
+        """Headless mode skips all terminal cleanup."""
+        agent = OpenCodeAgent()
+        agent.cleanup_after_exit(headless=True)
+        mock_reset.assert_not_called()
+        mock_clear.assert_not_called()
+
+
 class TestGetAgentDisplayName:
     """Tests for get_agent_display_name helper function (#448)."""
 

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1027,19 +1027,19 @@ class TestResetTerminalAfterTui:
 class TestClearScreenAfterTui:
     """Tests for clear_screen_after_tui (#461)."""
 
-    def test_scrolls_past_splash_art(self):
-        """Verify newlines are written to scroll past TUI splash art."""
+    def test_moves_cursor_below_splash(self):
+        """Verify cursor moves to bottom of screen and starts new line."""
         import io
         import sys
 
         fake_stdout = io.StringIO()
         fake_stdout.isatty = lambda: True
-        with patch.object(sys, "stdout", fake_stdout), \
-             patch("shutil.get_terminal_size", return_value=Mock(lines=24)):
+        with patch.object(sys, "stdout", fake_stdout):
             clear_screen_after_tui()
 
         written = fake_stdout.getvalue()
-        assert written == "\n" * 24, "Should write one newline per terminal row"
+        assert "\033[999B" in written, "Should move cursor to bottom"
+        assert "\n" in written, "Should start a fresh line"
 
     def test_skipped_when_not_tty(self):
         """No output when stdout is not a TTY."""

--- a/tests/test_open_multiproject_workspace_fallback.py
+++ b/tests/test_open_multiproject_workspace_fallback.py
@@ -221,8 +221,8 @@ def test_open_multiproject_session_first_launch_with_none_workspace_path(temp_da
         # Verify agent.launch_with_prompt was called (Claude was launched)
         assert mock_agent.launch_with_prompt.called, "agent.launch_with_prompt should have been called"
 
-        # Verify process.wait was called
-        assert mock_process.wait.called, "process.wait should have been called"
+        # Verify agent.wait_for_exit was called (which calls process.wait internally)
+        assert mock_agent.wait_for_exit.called, "agent.wait_for_exit should have been called"
 
         # Verify the project_path parameter was set correctly (workspace_path)
         call_kwargs = mock_agent.launch_with_prompt.call_args[1]


### PR DESCRIPTION
Jira Issue: <!-- This PR does not need a corresponding Jira item. -->
<!-- This PR does not need a corresponding Jira item. -->

## Description

Fixes [itdove/devaiflow#461](https://github.com/itdove/devaiflow/issues/461): OpenCode exit splash art garbles daf post-session output.

When OpenCode exits, it renders splash art/ANSI escape sequences that intermingle with daf's post-session summary output, making it unreadable. This PR fixes terminal output handling across the agent interface, CLI commands, and orchestration layer to ensure clean post-session output regardless of agent exit behavior.

**Changes span 12 files:**
- `devflow/agent/interface.py` — Fix agent interface to handle exit output cleanly
- `devflow/cli/utils.py` — Add/update utility functions for terminal output management
- `devflow/cli/commands/` — Update all command entry points (`open`, `new`, `git_new`, `jira_new`, `investigate`, `new_command_multiproject`) to use corrected output handling
- `devflow/orchestration/feature.py` — Fix orchestration layer post-session output
- Tests updated to cover new behavior (`test_agent_interface.py`, `test_cli_utils.py`, `test_open_multiproject_workspace_fallback.py`)

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `daf open` with OpenCode as the configured agent
3. Perform some work inside the session, then exit OpenCode
4. Verify post-session output (session summary, notes prompt, etc.) renders cleanly without garbled characters or interleaved splash art
5. Repeat with other commands: `daf new`, `daf git new`, `daf jira new`, `daf investigate`
6. Run `python -m pytest tests/test_agent_interface.py tests/test_cli_utils.py tests/test_open_multiproject_workspace_fallback.py`

### Scenarios tested
- OpenCode session exit with splash art enabled — post-session output renders cleanly
- Claude Code session exit — no regression, output still clean
- Multi-project workspace session exit
- All affected CLI commands produce correct post-session output

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: