### PR TITLE
itdove/devaiflow#444: Follow XDG Base Directory Specification for default data location

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,8 +491,40 @@ See [Troubleshooting Guide](docs/guides/troubleshooting.md#githubd-authenticatio
 DevAIFlow supports the following environment variables for customization:
 
 ### DEVAIFLOW_HOME
-- **Purpose**: Customize where DevAIFlow stores session data and configuration
-- **Default**: `~/.daf-sessions`
+- **Purpose**: Override where DevAIFlow stores all data (unified mode)
+- **Default**: When not set, DevAIFlow follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
+
+**XDG Directory Layout** (new installs):
+
+| Category | XDG Variable | Default Path | Contents |
+|----------|-------------|--------------|----------|
+| Data | `XDG_DATA_HOME` | `~/.local/share/devaiflow` | sessions, backups, logs, features |
+| Config | `XDG_CONFIG_HOME` | `~/.config/devaiflow` | config.json, backends/, templates/, skills, context .md files |
+| State | `XDG_STATE_HOME` | `~/.local/state/devaiflow` | audit.log, cache, dashboard state |
+
+**Resolution priority**:
+  1. `DEVAIFLOW_HOME` env var → all files in one directory (highest priority)
+  2. `~/.daf-sessions` exists → all files in one directory (legacy compatibility)
+  3. XDG env vars → split across XDG directories
+  4. XDG defaults → split across `~/.local/share`, `~/.config`, `~/.local/state`
+
+- **Migration from legacy path**:
+  ```bash
+  mkdir -p ~/.local/share/devaiflow ~/.config/devaiflow ~/.local/state/devaiflow
+  # Move data
+  cp -a ~/.daf-sessions/sessions* ~/.local/share/devaiflow/
+  cp -a ~/.daf-sessions/backups ~/.daf-sessions/logs ~/.local/share/devaiflow/ 2>/dev/null
+  # Move config
+  cp -a ~/.daf-sessions/config.json ~/.daf-sessions/enterprise.json ~/.config/devaiflow/ 2>/dev/null
+  cp -a ~/.daf-sessions/organization.json ~/.daf-sessions/team.json ~/.config/devaiflow/ 2>/dev/null
+  cp -a ~/.daf-sessions/backends ~/.daf-sessions/templates ~/.config/devaiflow/ 2>/dev/null
+  cp -a ~/.daf-sessions/.claude ~/.daf-sessions/*.md ~/.config/devaiflow/ 2>/dev/null
+  # Move state
+  cp -a ~/.daf-sessions/audit.log ~/.daf-sessions/version_check_cache.json ~/.local/state/devaiflow/ 2>/dev/null
+  cp -a ~/.daf-sessions/suggestions.json ~/.daf-sessions/state ~/.local/state/devaiflow/ 2>/dev/null
+  # Remove legacy dir
+  rm -rf ~/.daf-sessions
+  ```
 - **Example**:
   ```bash
   export DEVAIFLOW_HOME="~/custom/devaiflow-data"

--- a/devflow/agent/claude_agent.py
+++ b/devflow/agent/claude_agent.py
@@ -515,8 +515,8 @@ class ClaudeAgent(AgentInterface):
                 skills_dirs.append(str(workspace_skills))
 
         # 3. Hierarchical skills: $DEVAIFLOW_HOME/.claude/skills/
-        from devflow.utils.paths import get_cs_home
-        cs_home = get_cs_home()
+        from devflow.utils.paths import get_cs_config_home
+        cs_home = get_cs_config_home()
         hierarchical_skills = cs_home / ".claude" / "skills"
         if hierarchical_skills.exists():
             skills_dirs.append(str(hierarchical_skills))

--- a/devflow/cli/commands/config_export_command.py
+++ b/devflow/cli/commands/config_export_command.py
@@ -7,7 +7,7 @@ from rich.console import Console
 
 from devflow.cli.utils import require_outside_claude
 from devflow.config.exporter import ConfigExporter
-from devflow.utils.paths import get_cs_home
+from devflow.utils.paths import get_cs_config_home
 
 console = Console()
 
@@ -23,7 +23,7 @@ def export_config(
         output: Output file path (default: ~/config-export.tar.gz)
         force: Skip confirmation prompts
     """
-    config_dir = get_cs_home()
+    config_dir = get_cs_config_home()
     exporter = ConfigExporter(config_dir)
 
     output_path = Path(output) if output else None

--- a/devflow/cli/commands/config_import_command.py
+++ b/devflow/cli/commands/config_import_command.py
@@ -6,7 +6,7 @@ from rich.console import Console
 
 from devflow.cli.utils import require_outside_claude
 from devflow.config.importer import ConfigImporter
-from devflow.utils.paths import get_cs_home
+from devflow.utils.paths import get_cs_config_home
 
 console = Console()
 
@@ -36,7 +36,7 @@ def import_config(
         console.print(f"[red]✗[/red] Export file not found: {export_path}")
         return
 
-    config_dir = get_cs_home()
+    config_dir = get_cs_config_home()
     importer = ConfigImporter(config_dir)
 
     try:

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -1225,12 +1225,12 @@ def open_session(
 
                 # Add DEVAIFLOW_HOME to allowed paths if hierarchical context files exist
                 # This allows Claude Code to read ENTERPRISE.md, ORGANIZATION.md, TEAM.md, USER.md
-                from devflow.utils.paths import get_cs_home
-                cs_home = get_cs_home()
-                if cs_home.exists():
+                from devflow.utils.paths import get_cs_config_home
+                cs_config = get_cs_config_home()
+                if cs_config.exists():
                     hierarchical_files = load_hierarchical_context_files(config)
                     if hierarchical_files:
-                        cmd.extend(["--add-dir", str(cs_home)])
+                        cmd.extend(["--add-dir", str(cs_config)])
             elif agent_backend in ("opencode", "opencode-ai"):
                 # OpenCode supports session resume via --session flag
                 from devflow.agent.factory import snapshot_agent_sessions as _snap_resume

--- a/devflow/cli/commands/skills_command.py
+++ b/devflow/cli/commands/skills_command.py
@@ -791,9 +791,9 @@ def _list_config_backups() -> None:
 def _restore_config_backup(backup_filename: str) -> None:
     """Restore a config file from backup."""
     from devflow.utils.hierarchical_skills import restore_backup, list_backups
-    from devflow.utils.paths import get_cs_home
+    from devflow.utils.paths import get_cs_config_home
 
-    cs_home = get_cs_home()
+    cs_home = get_cs_config_home()
     backup_dir = cs_home / "backups"
     backup_path = backup_dir / backup_filename
 

--- a/devflow/cli/commands/skills_discovery_command.py
+++ b/devflow/cli/commands/skills_discovery_command.py
@@ -11,7 +11,7 @@ from rich.table import Table
 from rich.panel import Panel
 
 from devflow.config.loader import ConfigLoader
-from devflow.utils.paths import get_claude_config_dir, get_cs_home
+from devflow.utils.paths import get_claude_config_dir, get_cs_config_home
 
 console = Console()
 
@@ -88,7 +88,7 @@ def _discover_all_skills(workspace_path: Optional[str] = None) -> Dict[str, List
             skills_by_level["workspace"] = _discover_skills_in_dir(workspace_skills_dir, "workspace")
 
     # 3. Hierarchical skills: $DEVAIFLOW_HOME/.claude/skills/
-    cs_home = get_cs_home()
+    cs_home = get_cs_config_home()
     hierarchical_skills_dir = cs_home / ".claude" / "skills"
     if hierarchical_skills_dir.exists():
         skills_by_level["hierarchical"] = _discover_skills_in_dir(hierarchical_skills_dir, "hierarchical")
@@ -255,7 +255,7 @@ def _list_skills_table(skills_by_level: Dict[str, List[Dict]]) -> None:
     level_display = {
         "user": f"User-level ({get_claude_config_dir() / 'skills'}):",
         "workspace": "Workspace-level (<workspace>/.claude/skills/):",
-        "hierarchical": f"Hierarchical ({get_cs_home() / '.claude/skills'}):",
+        "hierarchical": f"Hierarchical ({get_cs_config_home() / '.claude/skills'}):",
         "project": "Project-level (<project>/.claude/skills/):"
     }
 

--- a/devflow/cli/commands/upgrade_command.py
+++ b/devflow/cli/commands/upgrade_command.py
@@ -187,8 +187,8 @@ def upgrade_all(
                 console.print(f"  Locations: ~/.agent/skills/ AND {project_path_obj}/.agent/skills/")
 
         if upgrade_hierarchical_skills:
-            from devflow.utils.paths import get_cs_home
-            hierarchical_skills_dir = get_cs_home() / ".claude" / "skills"
+            from devflow.utils.paths import get_cs_config_home
+            hierarchical_skills_dir = get_cs_config_home() / ".claude" / "skills"
             console.print(f"\n[dim]Hierarchical skills: {hierarchical_skills_dir}[/dim]")
 
 

--- a/devflow/cli/skills_discovery.py
+++ b/devflow/cli/skills_discovery.py
@@ -81,8 +81,8 @@ def discover_skills(
     # 3. Hierarchical skills: $DEVAIFLOW_HOME/.claude/skills/ (organization-specific skills that extend generic ones)
     # These are numbered (01-enterprise, 02-organization, 03-team, 04-user) to guarantee order
     if include_levels is None or "hierarchical" in include_levels:
-        from devflow.utils.paths import get_cs_home
-        cs_home = get_cs_home()
+        from devflow.utils.paths import get_cs_config_home
+        cs_home = get_cs_config_home()
         hierarchical_skills_dir = cs_home / ".claude" / "skills"
         if hierarchical_skills_dir.exists():
             # Sort to ensure numbered order (01-, 02-, 03-, 04-)

--- a/devflow/config/loader.py
+++ b/devflow/config/loader.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional, Tuple
 from pydantic import ValidationError
 from rich.console import Console
 
-from devflow.utils.paths import get_cs_home
+from devflow.utils.paths import get_cs_home, get_cs_config_home
 
 from .models import Config, SessionIndex
 
@@ -24,15 +24,20 @@ class ConfigLoader:
         """Initialize the config loader.
 
         Args:
-            config_dir: Directory for config files. Defaults to DEVAIFLOW_HOME or ~/.daf-sessions
+            config_dir: Directory for config files. When None, uses XDG paths:
+                config files → get_cs_config_home(), session data → get_cs_home().
+                When explicit, all paths use the given directory (test compat).
         """
         if config_dir is None:
-            config_dir = get_cs_home()
-        self.config_dir = config_dir
-        self.config_file = config_dir / "config.json"
-        self.sessions_file = config_dir / "sessions.json"
-        self.sessions_dir = config_dir / "sessions"
-        self.session_home = config_dir  # Alias for compatibility
+            self.config_dir = get_cs_config_home()
+            session_home = get_cs_home()
+        else:
+            self.config_dir = config_dir
+            session_home = config_dir
+        self.config_file = self.config_dir / "config.json"
+        self.sessions_file = session_home / "sessions.json"
+        self.sessions_dir = session_home / "sessions"
+        self.session_home = session_home
 
         # Ensure directories exist
         self.config_dir.mkdir(parents=True, exist_ok=True)

--- a/devflow/jira/client.py
+++ b/devflow/jira/client.py
@@ -61,10 +61,10 @@ class JiraClient(IssueTrackerClient):
         if not self._jira_url:
             try:
                 from pathlib import Path
-                from devflow.utils.paths import get_cs_home
+                from devflow.utils.paths import get_cs_config_home
                 import json
 
-                backends_dir = get_cs_home() / "backends"
+                backends_dir = get_cs_config_home() / "backends"
                 jira_backend_config = backends_dir / "jira.json"
 
                 if jira_backend_config.exists():

--- a/devflow/suggestions/suggester.py
+++ b/devflow/suggestions/suggester.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
-from devflow.utils.paths import get_cs_home
+from devflow.utils.paths import get_cs_state_home
 
 from .models import RepositorySuggestion, SuggestionHistory
 
@@ -60,7 +60,7 @@ class RepositorySuggester:
             history_file: Path to suggestion history file. Defaults to DEVAIFLOW_HOME/suggestions.json
         """
         if history_file is None:
-            history_file = get_cs_home() / "suggestions.json"
+            history_file = get_cs_state_home() / "suggestions.json"
 
         self.history_file = history_file
         self.history = self._load_history()

--- a/devflow/templates/manager.py
+++ b/devflow/templates/manager.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from devflow.config.loader import ConfigLoader
 from devflow.templates.models import NameExtractionConfig, SessionTemplate, TemplateConfig, TemplateIndex
-from devflow.utils.paths import get_cs_home
+from devflow.utils.paths import get_cs_config_home
 
 
 class TemplateManager:
@@ -18,7 +18,7 @@ class TemplateManager:
         Args:
             cs_home: Path to DevAIFlow home directory (defaults to DEVAIFLOW_HOME or ~/.daf-sessions)
         """
-        self.cs_home = cs_home or get_cs_home()
+        self.cs_home = cs_home or get_cs_config_home()
         self.templates_dir = self.cs_home / "templates"
         self.templates_file = self.cs_home / "templates.json"
 

--- a/devflow/utils/__init__.py
+++ b/devflow/utils/__init__.py
@@ -1,9 +1,9 @@
 """Utility functions for DevAIFlow."""
 
-from devflow.utils.paths import get_cs_home, is_mock_mode
+from devflow.utils.paths import get_cs_home, get_cs_config_home, get_cs_state_home, is_mock_mode
 from devflow.utils.user import get_current_user
 
-__all__ = ["get_current_user", "get_cs_home", "is_mock_mode", "strip_code_fences"]
+__all__ = ["get_current_user", "get_cs_home", "get_cs_config_home", "get_cs_state_home", "is_mock_mode", "strip_code_fences"]
 
 
 def strip_code_fences(text: str) -> str:

--- a/devflow/utils/audit_log.py
+++ b/devflow/utils/audit_log.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional, Any
 
-from devflow.utils.paths import get_cs_home
+from devflow.utils.paths import get_cs_state_home
 
 # Configure audit logger with separate handler
 audit_logger = logging.getLogger("devaiflow.audit")
@@ -24,8 +24,8 @@ def _get_audit_log_path() -> Path:
     Returns:
         Path to audit.log in DEVAIFLOW_HOME
     """
-    cs_home = get_cs_home()
-    return cs_home / "audit.log"
+    state_home = get_cs_state_home()
+    return state_home / "audit.log"
 
 
 def _ensure_audit_log_handler():

--- a/devflow/utils/claude_commands.py
+++ b/devflow/utils/claude_commands.py
@@ -620,8 +620,8 @@ def build_claude_command(
             skills_dirs.append(str(workspace_skills))
 
     # 3. Hierarchical skills: $DEVAIFLOW_HOME/.claude/skills/ (organization-specific)
-    from devflow.utils.paths import get_cs_home
-    cs_home = get_cs_home()
+    from devflow.utils.paths import get_cs_config_home
+    cs_home = get_cs_config_home()
     hierarchical_skills = cs_home / ".claude" / "skills"
     if hierarchical_skills.exists():
         skills_dirs.append(str(hierarchical_skills))

--- a/devflow/utils/context_files.py
+++ b/devflow/utils/context_files.py
@@ -47,10 +47,10 @@ def load_hierarchical_context_files(config: Optional['Config'] = None) -> list[t
         DeprecationWarning,
         stacklevel=2
     )
-    from devflow.utils.paths import get_cs_home
+    from devflow.utils.paths import get_cs_config_home
 
     context_files = []
-    cs_home = get_cs_home()
+    cs_home = get_cs_config_home()
 
     # Backend context (JIRA backend specific)
     backend_path = cs_home / "backends" / "JIRA.md"

--- a/devflow/utils/daf_agents_validation.py
+++ b/devflow/utils/daf_agents_validation.py
@@ -252,8 +252,8 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
 
     if is_temp_session:
         # Check DEVAIFLOW_HOME first (centralized location)
-        from devflow.utils.paths import get_cs_home
-        cs_home = get_cs_home()
+        from devflow.utils.paths import get_cs_config_home
+        cs_home = get_cs_config_home()
         daf_agents_home = cs_home / "DAF_AGENTS.md"
 
         if daf_agents_home.exists():
@@ -289,8 +289,8 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
     # (Claude launches from workspace root for multi-project sessions)
     if active_conv and active_conv.is_multi_project:
         # Check DEVAIFLOW_HOME first (centralized location)
-        from devflow.utils.paths import get_cs_home
-        cs_home = get_cs_home()
+        from devflow.utils.paths import get_cs_config_home
+        cs_home = get_cs_config_home()
         daf_agents_home = cs_home / "DAF_AGENTS.md"
 
         if daf_agents_home.exists():
@@ -330,8 +330,8 @@ def validate_daf_agents_md(session: 'Session', config_loader: 'ConfigLoader') ->
         return False
 
     # Check DEVAIFLOW_HOME first (centralized location, recommended)
-    from devflow.utils.paths import get_cs_home
-    cs_home = get_cs_home()
+    from devflow.utils.paths import get_cs_config_home
+    cs_home = get_cs_config_home()
     daf_agents_home = cs_home / "DAF_AGENTS.md"
 
     if daf_agents_home.exists():

--- a/devflow/utils/hierarchical_skills.py
+++ b/devflow/utils/hierarchical_skills.py
@@ -267,8 +267,8 @@ def create_backup(file_path: Path, backup_dir: Optional[Path] = None) -> Optiona
 
     # Default backup directory
     if backup_dir is None:
-        from devflow.utils.paths import get_cs_home
-        backup_dir = get_cs_home() / "backups"
+        from devflow.utils.paths import get_cs_config_home
+        backup_dir = get_cs_config_home() / "backups"
 
     backup_dir.mkdir(parents=True, exist_ok=True)
 
@@ -297,8 +297,8 @@ def list_backups(filename: Optional[str] = None, backup_dir: Optional[Path] = No
     """
     # Default backup directory
     if backup_dir is None:
-        from devflow.utils.paths import get_cs_home
-        backup_dir = get_cs_home() / "backups"
+        from devflow.utils.paths import get_cs_config_home
+        backup_dir = get_cs_config_home() / "backups"
 
     if not backup_dir.exists():
         return []
@@ -361,8 +361,8 @@ def restore_backup(backup_path: Path, target_path: Optional[Path] = None) -> Pat
         original_filename = parts[0]
 
         # Restore to config directory
-        from devflow.utils.paths import get_cs_home
-        target_path = get_cs_home() / original_filename
+        from devflow.utils.paths import get_cs_config_home
+        target_path = get_cs_config_home() / original_filename
 
     # Copy backup to target location
     shutil.copy2(backup_path, target_path)
@@ -886,10 +886,10 @@ def install_hierarchical_skills(
         - failed: Items that failed to install
     """
     import json
-    from devflow.utils.paths import get_cs_home
+    from devflow.utils.paths import get_cs_config_home
     from devflow.config.loader import ConfigLoader
 
-    cs_home = get_cs_home()
+    cs_home = get_cs_config_home()
     skills_install_dir = cs_home / ".claude" / "skills"
 
     # Define hierarchy order (order number, config file, level name)
@@ -1264,9 +1264,9 @@ def get_hierarchical_skill_statuses() -> dict:
         - "no_url": Config file exists but has no skill_url (for skills only)
         - "no_config": Config file doesn't exist (for skills only)
     """
-    from devflow.utils.paths import get_cs_home
+    from devflow.utils.paths import get_cs_config_home
 
-    cs_home = get_cs_home()
+    cs_home = get_cs_config_home()
     skills_dir = cs_home / ".claude" / "skills"
 
     hierarchy = [

--- a/devflow/utils/paths.py
+++ b/devflow/utils/paths.py
@@ -7,34 +7,118 @@ from pathlib import Path
 def get_cs_home() -> Path:
     """Get the DevAIFlow home directory.
 
-    Returns the directory specified by DEVAIFLOW_HOME environment variable,
-    or defaults to ~/.daf-sessions.
+    Resolution priority:
+        1. DEVAIFLOW_HOME env var (explicit override, highest priority)
+        2. ~/.daf-sessions exists (legacy compatibility, no silent data loss)
+        3. XDG_DATA_HOME/devaiflow (XDG Base Directory Specification)
+        4. ~/.local/share/devaiflow (XDG default)
 
     The DEVAIFLOW_HOME variable supports:
     - Tilde expansion (e.g., ~/custom/path)
     - Absolute paths (e.g., /var/lib/devaiflow-sessions)
     - Relative paths (resolved to absolute)
 
+    Migration from legacy path:
+        1. Move ~/.daf-sessions/* to ~/.local/share/devaiflow/
+        2. Remove ~/.daf-sessions/
+        3. DevAIFlow picks up the XDG path automatically
+
     Returns:
         Path to DevAIFlow home directory
 
     Examples:
-        >>> # With DEVAIFLOW_HOME not set
+        >>> # New install (no legacy dir, no env vars)
         >>> get_cs_home()
-        PosixPath('/home/user/.daf-sessions')
+        PosixPath('/home/user/.local/share/devaiflow')
 
-        >>> # With DEVAIFLOW_HOME set to custom path
+        >>> # With DEVAIFLOW_HOME set
         >>> os.environ['DEVAIFLOW_HOME'] = '~/my-sessions'
         >>> get_cs_home()
         PosixPath('/home/user/my-sessions')
+
+        >>> # With XDG_DATA_HOME set (no legacy dir)
+        >>> os.environ['XDG_DATA_HOME'] = '/home/user/.data'
+        >>> get_cs_home()
+        PosixPath('/home/user/.data/devaiflow')
     """
-    # Check for environment variable
+    # 1. Explicit env var (highest priority)
     devaiflow_home = os.getenv("DEVAIFLOW_HOME")
     if devaiflow_home:
         return Path(devaiflow_home).expanduser().resolve()
 
-    # Default to ~/.daf-sessions
-    return Path.home() / ".daf-sessions"
+    # 2. Legacy path exists (migration compat — don't silently move data)
+    legacy_path = Path.home() / ".daf-sessions"
+    if legacy_path.exists():
+        return legacy_path
+
+    # 3. XDG compliant
+    xdg_data = os.getenv("XDG_DATA_HOME")
+    if xdg_data:
+        return Path(xdg_data).expanduser().resolve() / "devaiflow"
+
+    # 4. XDG default
+    return Path.home() / ".local" / "share" / "devaiflow"
+
+
+def _is_unified_mode() -> bool:
+    """Check if DevAIFlow should use a single unified directory.
+
+    Returns True when DEVAIFLOW_HOME is set or the legacy ~/.daf-sessions
+    directory exists. In unified mode, all XDG functions return the same path.
+    """
+    return bool(os.getenv("DEVAIFLOW_HOME")) or (Path.home() / ".daf-sessions").exists()
+
+
+def get_cs_config_home() -> Path:
+    """Get the DevAIFlow configuration directory.
+
+    In unified mode (DEVAIFLOW_HOME set or legacy ~/.daf-sessions exists),
+    returns the same path as get_cs_home() for backward compatibility.
+
+    In XDG mode (new installs):
+        1. XDG_CONFIG_HOME/devaiflow (if XDG_CONFIG_HOME is set)
+        2. ~/.config/devaiflow (XDG default)
+
+    Stores: config.json, enterprise.json, organization.json, team.json,
+    backends/, templates/, .claude/skills/, context .md files.
+
+    Returns:
+        Path to DevAIFlow configuration directory
+    """
+    if _is_unified_mode():
+        return get_cs_home()
+
+    xdg_config = os.getenv("XDG_CONFIG_HOME")
+    if xdg_config:
+        return Path(xdg_config).expanduser().resolve() / "devaiflow"
+
+    return Path.home() / ".config" / "devaiflow"
+
+
+def get_cs_state_home() -> Path:
+    """Get the DevAIFlow state directory.
+
+    In unified mode (DEVAIFLOW_HOME set or legacy ~/.daf-sessions exists),
+    returns the same path as get_cs_home() for backward compatibility.
+
+    In XDG mode (new installs):
+        1. XDG_STATE_HOME/devaiflow (if XDG_STATE_HOME is set)
+        2. ~/.local/state/devaiflow (XDG default)
+
+    Stores: audit.log, version_check_cache.json, suggestions.json,
+    state/ (dashboard pid/port).
+
+    Returns:
+        Path to DevAIFlow state directory
+    """
+    if _is_unified_mode():
+        return get_cs_home()
+
+    xdg_state = os.getenv("XDG_STATE_HOME")
+    if xdg_state:
+        return Path(xdg_state).expanduser().resolve() / "devaiflow"
+
+    return Path.home() / ".local" / "state" / "devaiflow"
 
 
 def get_claude_config_dir() -> Path:

--- a/devflow/utils/update_checker.py
+++ b/devflow/utils/update_checker.py
@@ -53,8 +53,8 @@ def _get_cache_file() -> Path:
         Path to cache file
     """
     # Use the same session home as devflow tool
-    from devflow.utils.paths import get_cs_home
-    cache_dir = get_cs_home()
+    from devflow.utils.paths import get_cs_state_home
+    cache_dir = get_cs_state_home()
 
     cache_dir.mkdir(parents=True, exist_ok=True)
     return cache_dir / "version_check_cache.json"

--- a/devflow/web/app.py
+++ b/devflow/web/app.py
@@ -14,7 +14,7 @@ import webbrowser
 from pathlib import Path
 from typing import Optional
 
-from devflow.utils.paths import get_cs_home
+from devflow.utils.paths import get_cs_state_home
 from devflow.web.utils.data_bridge import DataBridge
 
 logger = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 def _get_state_dir() -> Path:
     """Get the dashboard state directory, creating it if needed."""
-    state_dir = get_cs_home() / "state"
+    state_dir = get_cs_state_home() / "state"
     state_dir.mkdir(parents=True, exist_ok=True)
     return state_dir
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ In-depth guides for specific topics:
 - **[Hierarchical Skills](guides/hierarchical-skills.md)** - Custom Claude Code skills system
 - **[SSL Configuration](guides/ssl-configuration.md)** - SSL/TLS configuration for enterprise
 - **[Enterprise Model Provider Enforcement](guides/enterprise-model-provider-enforcement.md)** - Enforce model providers at enterprise level
+- **[XDG Directories](guides/xdg-directories.md)** - XDG Base Directory Specification support and migration
 
 ### 🎓 Tutorials
 Step-by-step tutorials for common tasks:

--- a/docs/guides/xdg-directories.md
+++ b/docs/guides/xdg-directories.md
@@ -1,0 +1,97 @@
+# XDG Base Directory Specification
+
+DevAIFlow follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) for storing data, configuration, and state files.
+
+## Directory Layout
+
+| Category | XDG Variable | Default Path | Contents |
+|----------|-------------|--------------|----------|
+| Data | `XDG_DATA_HOME` | `~/.local/share/devaiflow` | Sessions, backups, logs, features |
+| Config | `XDG_CONFIG_HOME` | `~/.config/devaiflow` | config.json, backends/, templates/, skills, context .md files |
+| State | `XDG_STATE_HOME` | `~/.local/state/devaiflow` | audit.log, cache, dashboard state, suggestions |
+
+## Resolution Priority
+
+DevAIFlow resolves its home directories in this order:
+
+1. **`DEVAIFLOW_HOME` env var** — All files stored in one directory (highest priority)
+2. **`~/.daf-sessions` exists** — All files stored in one directory (legacy compatibility)
+3. **XDG env vars set** — Files split across XDG directories
+4. **XDG defaults** — Files split across `~/.local/share`, `~/.config`, `~/.local/state`
+
+When `DEVAIFLOW_HOME` is set or the legacy `~/.daf-sessions` directory exists, DevAIFlow operates in **unified mode** — all three directory functions return the same path. This ensures zero behavior change for existing users.
+
+## New Installs
+
+New installations (no `~/.daf-sessions`, no `DEVAIFLOW_HOME`) automatically use XDG-compliant paths. No configuration needed.
+
+## Migrating from `~/.daf-sessions`
+
+If you have an existing `~/.daf-sessions` directory and want to adopt XDG layout:
+
+```bash
+# Create XDG directories
+mkdir -p ~/.local/share/devaiflow ~/.config/devaiflow ~/.local/state/devaiflow
+
+# DATA — sessions, backups, logs, features, mocks
+cp -a ~/.daf-sessions/sessions ~/.daf-sessions/sessions.json ~/.local/share/devaiflow/ 2>/dev/null
+cp -a ~/.daf-sessions/backups ~/.daf-sessions/logs ~/.daf-sessions/mocks ~/.local/share/devaiflow/ 2>/dev/null
+cp -a ~/.daf-sessions/features ~/.daf-sessions/features.json ~/.local/share/devaiflow/ 2>/dev/null
+
+# CONFIG — json configs, backends, templates, skills, context docs
+cp -a ~/.daf-sessions/config.json ~/.daf-sessions/enterprise.json ~/.config/devaiflow/ 2>/dev/null
+cp -a ~/.daf-sessions/organization.json ~/.daf-sessions/team.json ~/.config/devaiflow/ 2>/dev/null
+cp -a ~/.daf-sessions/backends ~/.daf-sessions/templates ~/.daf-sessions/templates.json ~/.config/devaiflow/ 2>/dev/null
+cp -a ~/.daf-sessions/.claude ~/.config/devaiflow/ 2>/dev/null
+cp -a ~/.daf-sessions/ENTERPRISE.md ~/.daf-sessions/ORGANIZATION.md ~/.config/devaiflow/ 2>/dev/null
+cp -a ~/.daf-sessions/TEAM.md ~/.daf-sessions/USER.md ~/.config/devaiflow/ 2>/dev/null
+
+# STATE — audit, cache, suggestions, dashboard
+cp -a ~/.daf-sessions/audit.log ~/.local/state/devaiflow/ 2>/dev/null
+cp -a ~/.daf-sessions/version_check_cache.json ~/.daf-sessions/suggestions.json ~/.local/state/devaiflow/ 2>/dev/null
+cp -a ~/.daf-sessions/state ~/.local/state/devaiflow/ 2>/dev/null
+
+# Remove legacy dir (triggers XDG mode)
+rm -rf ~/.daf-sessions
+```
+
+Migration is optional. DevAIFlow continues to work with `~/.daf-sessions` indefinitely.
+
+## Staying on Unified Mode
+
+If you prefer keeping everything in one directory, set `DEVAIFLOW_HOME`:
+
+```bash
+export DEVAIFLOW_HOME="~/.daf-sessions"
+```
+
+This overrides XDG and keeps the legacy behavior permanently.
+
+## Custom XDG Paths
+
+Override individual XDG directories:
+
+```bash
+# Store data on a separate drive
+export XDG_DATA_HOME="/mnt/data/.local/share"
+
+# Store config in a dotfiles-managed location
+export XDG_CONFIG_HOME="~/dotfiles/.config"
+
+# Store state on fast local storage
+export XDG_STATE_HOME="/tmp/state"
+```
+
+DevAIFlow appends `/devaiflow` to each XDG path automatically.
+
+## API Reference
+
+Three functions in `devflow.utils.paths`:
+
+| Function | Returns | Used for |
+|----------|---------|----------|
+| `get_cs_home()` | Data directory | Sessions, backups, logs |
+| `get_cs_config_home()` | Config directory | Configuration files, skills, templates |
+| `get_cs_state_home()` | State directory | Audit logs, caches, runtime state |
+
+In unified mode (legacy or `DEVAIFLOW_HOME`), all three return the same path.

--- a/tests/test_claude_commands.py
+++ b/tests/test_claude_commands.py
@@ -544,7 +544,7 @@ def test_build_claude_command_skills_load_order(temp_user_home, monkeypatch):
     hierarchical_skills.mkdir(parents=True)
 
     with patch('devflow.utils.claude_commands.Path.home', return_value=temp_user_home):
-        with patch('devflow.utils.paths.get_cs_home', return_value=cs_home):
+        with patch('devflow.utils.paths.get_cs_config_home', return_value=cs_home):
             cmd = build_claude_command(
                 session_id="test-session",
                 initial_prompt="Test",
@@ -584,7 +584,7 @@ def test_build_claude_command_with_config_hierarchical_files(temp_user_home, mon
     cs_home = temp_user_home / "daf-home"
     cs_home.mkdir(parents=True)
 
-    with patch('devflow.utils.paths.get_cs_home', return_value=cs_home):
+    with patch('devflow.utils.paths.get_cs_config_home', return_value=cs_home):
         with patch('devflow.utils.context_files.load_hierarchical_context_files', return_value=["ENTERPRISE.md"]):
             cmd = build_claude_command(
                 session_id="test-session",
@@ -600,8 +600,8 @@ def test_build_claude_command_no_duplicate_dirs(temp_user_home):
     """Test that duplicate directories are not added."""
     from unittest.mock import patch, MagicMock
 
-    # Mock get_cs_home to return same as user home
-    with patch('devflow.utils.paths.get_cs_home', return_value=temp_user_home):
+    # Mock get_cs_config_home to return same as user home
+    with patch('devflow.utils.paths.get_cs_config_home', return_value=temp_user_home):
         with patch('devflow.utils.context_files.load_hierarchical_context_files', return_value=["file.md"]):
             cmd = build_claude_command(
                 session_id="test-session",

--- a/tests/test_model_provider_enforcement.py
+++ b/tests/test_model_provider_enforcement.py
@@ -505,7 +505,7 @@ class TestAuditLogging:
         audit_logger.handlers.clear()
 
         # Set up audit log in temp directory
-        with patch("devflow.utils.audit_log.get_cs_home", return_value=tmp_path):
+        with patch("devflow.utils.audit_log.get_cs_state_home", return_value=tmp_path):
             log_model_provider_usage(
                 event_type="session_created",
                 session_name="TEST-123",
@@ -549,7 +549,7 @@ class TestAuditLogging:
         audit_logger.handlers.clear()
 
         # Test with enterprise enforcement
-        with patch("devflow.utils.audit_log.get_cs_home", return_value=tmp_path):
+        with patch("devflow.utils.audit_log.get_cs_state_home", return_value=tmp_path):
             log_model_provider_usage(
                 event_type="session_created",
                 session_name="TEST-456",

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -5,27 +5,80 @@ from pathlib import Path
 
 import pytest
 
-from devflow.utils.paths import get_cs_home, is_mock_mode, get_claude_config_dir
+from devflow.utils.paths import (
+    get_cs_home,
+    get_cs_config_home,
+    get_cs_state_home,
+    is_mock_mode,
+    get_claude_config_dir,
+)
 
 
-def test_get_cs_home_default(monkeypatch, tmp_path):
-    """Test get_cs_home returns ~/.daf-sessions by default."""
-    # Ensure environment variable is not set
+def test_get_cs_home_default_xdg(monkeypatch, tmp_path):
+    """Test get_cs_home returns XDG default when no env vars or legacy dir."""
     monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
-
-    # Mock Path.home() to use tmp_path to avoid side effects
-    import devflow.utils.paths
-    original_home = Path.home
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     result = get_cs_home()
-    expected = tmp_path / ".daf-sessions"
+    expected = tmp_path / ".local" / "share" / "devaiflow"
 
     assert result == expected
     assert isinstance(result, Path)
 
-    # Restore original
-    monkeypatch.setattr(Path, "home", original_home)
+
+def test_get_cs_home_legacy_compat(monkeypatch, tmp_path):
+    """Test get_cs_home uses legacy ~/.daf-sessions when it exists."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    legacy_dir = tmp_path / ".daf-sessions"
+    legacy_dir.mkdir()
+
+    result = get_cs_home()
+
+    assert result == legacy_dir
+
+
+def test_get_cs_home_legacy_overrides_xdg(monkeypatch, tmp_path):
+    """Test legacy ~/.daf-sessions takes priority over XDG_DATA_HOME."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg-data"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    legacy_dir = tmp_path / ".daf-sessions"
+    legacy_dir.mkdir()
+
+    result = get_cs_home()
+
+    assert result == legacy_dir
+
+
+def test_get_cs_home_xdg_data_home(monkeypatch, tmp_path):
+    """Test get_cs_home uses XDG_DATA_HOME when set (no legacy dir)."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    xdg_data = tmp_path / "xdg-data"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    result = get_cs_home()
+
+    assert result == xdg_data / "devaiflow"
+
+
+def test_get_cs_home_xdg_data_home_tilde(monkeypatch, tmp_path):
+    """Test XDG_DATA_HOME with tilde expansion."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", "~/.data")
+    # Use tmp_path as home to avoid real ~/.daf-sessions triggering legacy path
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    result = get_cs_home()
+    expected = Path("~/.data").expanduser().resolve() / "devaiflow"
+
+    assert result == expected
+    assert not str(result).startswith("~")
 
 
 def test_get_cs_home_with_devaiflow_home(monkeypatch, tmp_path):
@@ -39,14 +92,18 @@ def test_get_cs_home_with_devaiflow_home(monkeypatch, tmp_path):
     assert isinstance(result, Path)
 
 
-def test_get_cs_home_precedence_devaiflow_home_wins(monkeypatch, tmp_path):
-    """Test that DEVAIFLOW_HOME takes precedence over default paths."""
+def test_get_cs_home_devaiflow_home_overrides_all(monkeypatch, tmp_path):
+    """Test DEVAIFLOW_HOME takes precedence over legacy dir and XDG."""
     devaiflow_path = tmp_path / "devaiflow-sessions"
     monkeypatch.setenv("DEVAIFLOW_HOME", str(devaiflow_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg-data"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    # Create legacy dir — should still be ignored
+    (tmp_path / ".daf-sessions").mkdir()
 
     result = get_cs_home()
 
-    # Should use DEVAIFLOW_HOME
     assert result == devaiflow_path
 
 
@@ -91,8 +148,7 @@ def test_get_cs_home_with_absolute_path(monkeypatch, tmp_path):
 def test_get_cs_home_consistency(monkeypatch, tmp_path):
     """Test get_cs_home returns same value on multiple calls."""
     monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
-
-    # Mock Path.home() to use tmp_path to avoid side effects
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     result1 = get_cs_home()
@@ -110,6 +166,139 @@ def test_get_cs_home_with_complex_path(monkeypatch, tmp_path):
 
     assert result == complex_path
     assert isinstance(result, Path)
+
+
+# Tests for get_cs_config_home()
+
+
+def test_get_cs_config_home_xdg_default(monkeypatch, tmp_path):
+    """Test get_cs_config_home returns XDG default for new installs."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    result = get_cs_config_home()
+
+    assert result == tmp_path / ".config" / "devaiflow"
+
+
+def test_get_cs_config_home_xdg_env(monkeypatch, tmp_path):
+    """Test get_cs_config_home uses XDG_CONFIG_HOME when set."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    xdg_config = tmp_path / "custom-config"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    result = get_cs_config_home()
+
+    assert result == xdg_config / "devaiflow"
+
+
+def test_get_cs_config_home_unified_with_devaiflow_home(monkeypatch, tmp_path):
+    """Test get_cs_config_home returns same as get_cs_home when DEVAIFLOW_HOME set."""
+    custom = tmp_path / "unified"
+    monkeypatch.setenv("DEVAIFLOW_HOME", str(custom))
+
+    assert get_cs_config_home() == get_cs_home()
+
+
+def test_get_cs_config_home_unified_with_legacy(monkeypatch, tmp_path):
+    """Test get_cs_config_home returns same as get_cs_home when legacy dir exists."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".daf-sessions").mkdir()
+
+    assert get_cs_config_home() == get_cs_home()
+
+
+def test_get_cs_config_home_split_from_data(monkeypatch, tmp_path):
+    """Test config and data return different paths for new installs."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert get_cs_config_home() != get_cs_home()
+    assert get_cs_config_home() == tmp_path / ".config" / "devaiflow"
+    assert get_cs_home() == tmp_path / ".local" / "share" / "devaiflow"
+
+
+# Tests for get_cs_state_home()
+
+
+def test_get_cs_state_home_xdg_default(monkeypatch, tmp_path):
+    """Test get_cs_state_home returns XDG default for new installs."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    result = get_cs_state_home()
+
+    assert result == tmp_path / ".local" / "state" / "devaiflow"
+
+
+def test_get_cs_state_home_xdg_env(monkeypatch, tmp_path):
+    """Test get_cs_state_home uses XDG_STATE_HOME when set."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    xdg_state = tmp_path / "custom-state"
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg_state))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    result = get_cs_state_home()
+
+    assert result == xdg_state / "devaiflow"
+
+
+def test_get_cs_state_home_unified_with_devaiflow_home(monkeypatch, tmp_path):
+    """Test get_cs_state_home returns same as get_cs_home when DEVAIFLOW_HOME set."""
+    custom = tmp_path / "unified"
+    monkeypatch.setenv("DEVAIFLOW_HOME", str(custom))
+
+    assert get_cs_state_home() == get_cs_home()
+
+
+def test_get_cs_state_home_unified_with_legacy(monkeypatch, tmp_path):
+    """Test get_cs_state_home returns same as get_cs_home when legacy dir exists."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".daf-sessions").mkdir()
+
+    assert get_cs_state_home() == get_cs_home()
+
+
+def test_all_three_unified_when_devaiflow_home(monkeypatch, tmp_path):
+    """Test all three functions return same path in unified mode."""
+    custom = tmp_path / "unified"
+    monkeypatch.setenv("DEVAIFLOW_HOME", str(custom))
+
+    home = get_cs_home()
+    config = get_cs_config_home()
+    state = get_cs_state_home()
+
+    assert home == config == state
+
+
+def test_all_three_split_for_new_install(monkeypatch, tmp_path):
+    """Test all three functions return different paths for new installs."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    home = get_cs_home()
+    config = get_cs_config_home()
+    state = get_cs_state_home()
+
+    assert home != config
+    assert home != state
+    assert config != state
 
 
 # Tests for is_mock_mode()

--- a/tests/test_skills_discovery_command.py
+++ b/tests/test_skills_discovery_command.py
@@ -122,7 +122,7 @@ def test_discover_skills_in_dir_empty(tmp_path):
 def test_discover_all_skills_user_level(monkeypatch, mock_skill_dir):
     """Test discovering skills at user level."""
     with patch('devflow.cli.commands.skills_discovery_command.get_claude_config_dir', return_value=mock_skill_dir.parent):
-        with patch('devflow.cli.commands.skills_discovery_command.get_cs_home', return_value=Path("/nonexistent")):
+        with patch('devflow.cli.commands.skills_discovery_command.get_cs_config_home', return_value=Path("/nonexistent")):
             # Rename mock_skill_dir to match expected user skills path
             user_skills = mock_skill_dir.parent / "skills"
             if mock_skill_dir != user_skills:
@@ -177,7 +177,7 @@ def test_list_skills_table_output(monkeypatch, mock_skill_dir):
 
     with patch('devflow.cli.commands.skills_discovery_command.console') as mock_console:
         with patch('devflow.cli.commands.skills_discovery_command.get_claude_config_dir', return_value=mock_skill_dir.parent):
-            with patch('devflow.cli.commands.skills_discovery_command.get_cs_home', return_value=Path("/nonexistent")):
+            with patch('devflow.cli.commands.skills_discovery_command.get_cs_config_home', return_value=Path("/nonexistent")):
                 _list_skills_table(skills_by_level)
 
                 # Verify console.print was called (table was displayed)

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -55,17 +55,18 @@ def test_parse_version_invalid():
 
 
 def test_get_cache_file_default(monkeypatch, tmp_path):
-    """Test cache file path with default location (backward compat or new install)."""
+    """Test cache file path with default XDG location (new install, no legacy dir)."""
     monkeypatch.delenv("CLAUDE_SESSION_HOME", raising=False)
     monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
     monkeypatch.delenv("CS_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
 
-    # Mock Path.home() to use tmp_path to avoid existing ~/.daf-sessions
+    # Mock Path.home() to use tmp_path — no legacy .daf-sessions dir exists
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
 
     cache_file = _get_cache_file()
-    # Should use .daf-sessions for new installations (when neither directory exists)
-    assert cache_file == tmp_path / ".daf-sessions" / "version_check_cache.json"
+    # New installs use XDG state path
+    assert cache_file == tmp_path / ".local" / "state" / "devaiflow" / "version_check_cache.json"
 
 
 def test_get_cache_file_custom_home(monkeypatch, tmp_path):

--- a/tests/test_web_dashboard.py
+++ b/tests/test_web_dashboard.py
@@ -488,7 +488,7 @@ class TestPortFileManagement:
         """Test writing port to state file."""
         from devflow.web.app import _write_port, _get_port_file
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             _write_port(12345)
             port_file = _get_port_file()
             assert port_file.exists()
@@ -498,7 +498,7 @@ class TestPortFileManagement:
         """Test cleanup removes port file."""
         from devflow.web.app import _write_port, _cleanup_port_file
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             _write_port(12345)
             _cleanup_port_file()
             port_file = tmp_path / "state" / "dashboard.port"
@@ -508,7 +508,7 @@ class TestPortFileManagement:
         """Test cleanup doesn't fail when port file doesn't exist."""
         from devflow.web.app import _cleanup_port_file
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             # Should not raise
             _cleanup_port_file()
 
@@ -516,7 +516,7 @@ class TestPortFileManagement:
         """Test that _write_port creates the state directory if missing."""
         from devflow.web.app import _write_port
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             _write_port(9999)
             state_dir = tmp_path / "state"
             assert state_dir.is_dir()
@@ -1360,7 +1360,7 @@ class TestPidFileManagement:
         """Test writing and reading PID file."""
         from devflow.web.app import _write_pid, _read_pid
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             _write_pid(12345)
             result = _read_pid()
             assert result == 12345
@@ -1369,7 +1369,7 @@ class TestPidFileManagement:
         """Test reading PID when file doesn't exist."""
         from devflow.web.app import _read_pid
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             result = _read_pid()
             assert result is None
 
@@ -1377,7 +1377,7 @@ class TestPidFileManagement:
         """Test reading port from state file."""
         from devflow.web.app import _write_port, _read_port
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             _write_port(54321)
             result = _read_port()
             assert result == 54321
@@ -1386,7 +1386,7 @@ class TestPidFileManagement:
         """Test reading port when file doesn't exist."""
         from devflow.web.app import _read_port
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             result = _read_port()
             assert result is None
 
@@ -1394,7 +1394,7 @@ class TestPidFileManagement:
         """Test cleanup removes both port and PID files."""
         from devflow.web.app import _write_port, _write_pid, _cleanup_state_files
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             _write_port(8080)
             _write_pid(99999)
 
@@ -1424,7 +1424,7 @@ class TestPidFileManagement:
         """Test status when no dashboard is running."""
         from devflow.web.app import get_dashboard_status
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             result = get_dashboard_status()
             assert result is None
 
@@ -1432,7 +1432,7 @@ class TestPidFileManagement:
         """Test status with stale PID file (process not running)."""
         from devflow.web.app import get_dashboard_status, _write_pid, _write_port
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             _write_pid(4_000_000)  # non-existent process
             _write_port(8080)
             result = get_dashboard_status()
@@ -1442,7 +1442,7 @@ class TestPidFileManagement:
         """Test status when a real process is running (use our own PID)."""
         from devflow.web.app import get_dashboard_status, _write_pid, _write_port
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             _write_pid(os.getpid())  # our own process
             _write_port(9090)
             result = get_dashboard_status()
@@ -1454,7 +1454,7 @@ class TestPidFileManagement:
         """Test stop when nothing is running."""
         from devflow.web.app import stop_dashboard
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             result = stop_dashboard()
             assert result is False
 
@@ -1462,7 +1462,7 @@ class TestPidFileManagement:
         """Test stop with stale PID file cleans up state files."""
         from devflow.web.app import stop_dashboard, _write_pid, _write_port
 
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             _write_pid(4_000_000)
             _write_port(8080)
             result = stop_dashboard()
@@ -1528,7 +1528,7 @@ class TestDashboardCLIGroup:
         from devflow.cli.main import cli
 
         runner = CliRunner()
-        with patch("devflow.web.app.get_cs_home", return_value=tmp_path):
+        with patch("devflow.web.app.get_cs_state_home", return_value=tmp_path):
             with patch("devflow.cli.main.console"):
                 result = runner.invoke(cli, ["dashboard", "stop"])
 


### PR DESCRIPTION
Now I have enough context. Here's the filled PR template:

Jira Issue: <!-- This PR does not need a corresponding Jira item. -->
<!-- This PR does not need a corresponding Jira item. -->

## Description

Follow XDG Base Directory Specification for default data location (resolves #444).

Previously DevAIFlow hardcoded `~/.daf-sessions` as the sole data directory. This change adopts the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) to separate data, config, and state into standard locations:

- **Data** (`get_cs_home`): `~/.local/share/devaiflow` (sessions, session index)
- **Config** (`get_cs_config_home`): `~/.config/devaiflow` (config.json, templates, skills)
- **State** (`get_cs_state_home`): `~/.local/state/devaiflow` (audit.log, version cache, dashboard pid)

Resolution priority for `get_cs_home()`:
1. `DEVAIFLOW_HOME` env var (explicit override)
2. `~/.daf-sessions` exists (legacy compatibility — no silent data loss)
3. `XDG_DATA_HOME/devaiflow`
4. `~/.local/share/devaiflow` (XDG default)

When `DEVAIFLOW_HOME` is set or legacy `~/.daf-sessions` exists, all three XDG functions return the same unified path for full backward compatibility.

Key changes:
- `devflow/utils/paths.py`: Added `get_cs_config_home()`, `get_cs_state_home()`, and `_is_unified_mode()` helper
- `devflow/config/loader.py`: Split config and session paths — config files use `get_cs_config_home()`, session data uses `get_cs_home()`
- 18 module files updated to import from correct path function based on what they store (config vs data vs state)
- `tests/test_paths.py`: Expanded from ~10 to ~30 tests covering XDG, legacy compat, env var precedence, and unified mode
- `docs/guides/xdg-directories.md`: New documentation with migration guide

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. **New install (no legacy dir):** Ensure `~/.daf-sessions` does not exist, unset `DEVAIFLOW_HOME`, run `daf open` — verify data goes to `~/.local/share/devaiflow/`
3. **Legacy compat:** Create `~/.daf-sessions/` directory, run `daf open` — verify it still uses `~/.daf-sessions/`
4. **DEVAIFLOW_HOME override:** Set `DEVAIFLOW_HOME=/tmp/test-daf`, run `daf open` — verify it uses `/tmp/test-daf/`
5. **XDG_DATA_HOME:** Remove `~/.daf-sessions`, set `XDG_DATA_HOME=~/.data`, run `daf open` — verify data goes to `~/.data/devaiflow/`
6. Run `python -m pytest tests/test_paths.py tests/test_update_checker.py tests/test_claude_commands.py tests/test_web_dashboard.py -v` — all tests pass

### Scenarios tested
- New install defaults to XDG paths (`~/.local/share/devaiflow`)
- Legacy `~/.daf-sessions` detected and used automatically (no data loss)
- `DEVAIFLOW_HOME` overrides both legacy and XDG
- `XDG_DATA_HOME` with tilde expansion
- Legacy dir takes priority over `XDG_DATA_HOME`
- Unified mode: all three path functions return same dir when legacy or `DEVAIFLOW_HOME` active
- Config loader correctly splits config vs session paths

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: