### PR TITLE
itdove/devaiflow#443: daf setup: configure OpenCode permissions for daf integration

### DIFF
--- a/devflow/cli/commands/setup_command.py
+++ b/devflow/cli/commands/setup_command.py
@@ -1,0 +1,272 @@
+"""Implementation of 'daf setup' command."""
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+BACKEND_ALIASES = {
+    "opencode-ai": "opencode",
+    "ollama-claude": "ollama",
+    "copilot": "github-copilot",
+}
+
+
+def strip_jsonc_comments(text: str) -> str:
+    """Strip // and /* */ comments from JSONC text, preserving strings."""
+    result: List[str] = []
+    i = 0
+    length = len(text)
+    while i < length:
+        if text[i] == '"':
+            j = i + 1
+            while j < length:
+                if text[j] == '\\':
+                    j += 2
+                    continue
+                if text[j] == '"':
+                    j += 1
+                    break
+                j += 1
+            result.append(text[i:j])
+            i = j
+        elif text[i:i+2] == '//':
+            while i < length and text[i] != '\n':
+                i += 1
+        elif text[i:i+2] == '/*':
+            end = text.find('*/', i + 2)
+            i = end + 2 if end != -1 else length
+        else:
+            result.append(text[i])
+            i += 1
+    return ''.join(result)
+
+
+def load_overlay(backend: str) -> Optional[Dict[str, Any]]:
+    """Load JSONC overlay template for a backend.
+
+    Args:
+        backend: Canonical backend name (after alias resolution).
+
+    Returns:
+        Parsed overlay dict, or None if no overlay exists.
+    """
+    overlays_dir = Path(__file__).parent.parent.parent / "templates" / "overlays"
+    overlay_path = overlays_dir / f"{backend}.jsonc"
+
+    if not overlay_path.exists():
+        return None
+
+    raw = overlay_path.read_text(encoding="utf-8")
+    stripped = strip_jsonc_comments(raw)
+
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError as e:
+        console.print(f"[red]Error parsing overlay template {overlay_path}: {e}[/red]")
+        return None
+
+
+def deep_merge(base: Dict[str, Any], overlay: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+    """Deep-merge overlay into base without overwriting existing keys.
+
+    Args:
+        base: Existing config dict (modified in place).
+        overlay: Overlay dict to merge in.
+
+    Returns:
+        Tuple of (merged dict, list of added key paths).
+    """
+    added: List[str] = []
+    _deep_merge_recursive(base, overlay, "", added)
+    return base, added
+
+
+def _deep_merge_recursive(
+    base: Dict[str, Any], overlay: Dict[str, Any], prefix: str, added: List[str]
+) -> None:
+    for key, value in overlay.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if key not in base:
+            base[key] = value
+            added.append(path)
+        elif isinstance(value, dict) and isinstance(base[key], dict):
+            _deep_merge_recursive(base[key], value, path, added)
+
+
+def resolve_target_path(backend: str, scope: str) -> Path:
+    """Determine target config file path for a backend.
+
+    Args:
+        backend: Canonical backend name.
+        scope: 'project' or 'global'.
+
+    Returns:
+        Path to the target config file.
+    """
+    if backend == "opencode":
+        if scope == "global":
+            xdg = os.environ.get("XDG_CONFIG_HOME")
+            if xdg:
+                return Path(xdg) / "opencode" / "opencode.json"
+            return Path.home() / ".config" / "opencode" / "opencode.json"
+        return Path.cwd() / "opencode.json"
+
+    if backend == "claude":
+        if scope == "global":
+            claude_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+            if claude_dir:
+                return Path(claude_dir) / "settings.json"
+            return Path.home() / ".claude" / "settings.json"
+        return Path.cwd() / ".claude" / "settings.json"
+
+    return Path.cwd() / f"{backend}.json"
+
+
+def setup_agent_config(
+    dry_run: bool = False,
+    scope: str = "project",
+    output_json: bool = False,
+) -> int:
+    """Configure agent integration by merging overlay template into agent config.
+
+    Args:
+        dry_run: Preview changes without writing.
+        scope: 'project' or 'global'.
+        output_json: Output JSON format.
+
+    Returns:
+        Exit code: 0 on success, 1 on error.
+    """
+    from devflow.config.loader import ConfigLoader
+
+    try:
+        config_loader = ConfigLoader()
+        config = config_loader.load_config(validate=False)
+        backend = config.agent_backend or "claude"
+    except Exception:
+        backend = "claude"
+
+    canonical = BACKEND_ALIASES.get(backend, backend)
+    overlay = load_overlay(canonical)
+
+    if overlay is None:
+        if output_json:
+            print(json.dumps({
+                "success": False,
+                "message": f"No overlay template for backend '{canonical}'",
+            }, indent=2))
+        else:
+            console.print(
+                f"[yellow]No overlay template available for agent backend "
+                f"'[cyan]{canonical}[/cyan]'[/yellow]"
+            )
+            console.print(
+                "[dim]Overlay templates are in devflow/templates/overlays/[/dim]"
+            )
+        return 0
+
+    target_path = resolve_target_path(canonical, scope)
+
+    existing: Dict[str, Any] = {}
+    if target_path.exists():
+        try:
+            raw = target_path.read_text(encoding="utf-8")
+            stripped = strip_jsonc_comments(raw)
+            existing = json.loads(stripped)
+        except (json.JSONDecodeError, OSError) as e:
+            if output_json:
+                print(json.dumps({
+                    "success": False,
+                    "error": f"Failed to read {target_path}: {e}",
+                }, indent=2))
+            else:
+                console.print(f"[red]Failed to read {target_path}: {e}[/red]")
+            return 1
+
+    skip_keys = {"$schema"}
+    overlay_filtered = {k: v for k, v in overlay.items() if k not in skip_keys}
+
+    if "$schema" in overlay and "$schema" not in existing:
+        existing["$schema"] = overlay["$schema"]
+
+    merged, added = deep_merge(existing, overlay_filtered)
+
+    if output_json:
+        print(json.dumps({
+            "success": True,
+            "backend": canonical,
+            "target": str(target_path),
+            "scope": scope,
+            "dry_run": dry_run,
+            "added": added,
+            "skipped": _count_skipped(overlay_filtered, added),
+        }, indent=2))
+        if not dry_run and added:
+            _write_config(target_path, merged)
+        return 0
+
+    from devflow.agent.factory import AGENT_DISPLAY_NAMES
+    display_name = AGENT_DISPLAY_NAMES.get(backend, canonical)
+    console.print(f"\n[bold]Setting up {display_name} integration[/bold]")
+    console.print(f"  Backend: [cyan]{canonical}[/cyan]")
+    console.print(f"  Scope:   [cyan]{scope}[/cyan]")
+    console.print(f"  Target:  [cyan]{target_path}[/cyan]")
+
+    if not added:
+        console.print("\n[green]All overlay rules already present. Nothing to do.[/green]")
+        return 0
+
+    table = Table(title="Rules to add", show_header=True, header_style="bold")
+    table.add_column("Path", style="cyan")
+    table.add_column("Status", width=10)
+
+    for path in added:
+        table.add_row(path, "[green]+ add[/green]")
+
+    console.print()
+    console.print(table)
+
+    if dry_run:
+        console.print("\n[yellow]Dry run — no changes written.[/yellow]")
+        return 0
+
+    if _write_config(target_path, merged):
+        console.print(f"\n[green]Wrote {len(added)} rule(s) to {target_path}[/green]")
+        return 0
+
+    return 1
+
+
+def _count_skipped(overlay: Dict[str, Any], added: List[str]) -> int:
+    """Count leaf keys in overlay that were skipped (already existed)."""
+    total = _count_leaves(overlay, "")
+    return total - len(added)
+
+
+def _count_leaves(d: Dict[str, Any], prefix: str) -> int:
+    count = 0
+    for key, value in d.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            count += _count_leaves(value, path)
+        else:
+            count += 1
+    return count
+
+
+def _write_config(path: Path, data: Dict[str, Any]) -> bool:
+    """Write config JSON to file, creating parent directories if needed."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        return True
+    except OSError as e:
+        console.print(f"[red]Failed to write {path}: {e}[/red]")
+        return False

--- a/devflow/cli/main.py
+++ b/devflow/cli/main.py
@@ -3283,6 +3283,34 @@ def provider_test(ctx: click.Context, name: str) -> None:
 
 
 @cli.command()
+@click.option("--dry-run", is_flag=True, help="Preview changes without writing")
+@click.option("--scope", type=click.Choice(["project", "global"]), default="project",
+              help="Config scope: project-level (default) or global")
+@json_option
+def setup(ctx: click.Context, dry_run: bool, scope: str) -> None:
+    """Configure agent integration for the current backend.
+
+    Merges a JSONC overlay template into the agent's config file,
+    adding DevAIFlow permission rules without overwriting existing settings.
+
+    Examples:
+        daf setup                    # Apply overlay to project config
+        daf setup --scope global     # Apply to global agent config
+        daf setup --dry-run          # Preview what would be added
+        daf setup --json             # JSON output
+    """
+    from devflow.cli.commands.setup_command import setup_agent_config
+
+    output_json = ctx.obj.get('output_json', False) if ctx.obj else False
+    exit_code = setup_agent_config(
+        dry_run=dry_run,
+        scope=scope,
+        output_json=output_json,
+    )
+    raise SystemExit(exit_code)
+
+
+@cli.command()
 @click.option("--check", is_flag=True, help="Check external tool dependencies instead of initializing")
 @click.option("--refresh", is_flag=True, help="Refresh automatically discovered data (custom field mappings)")
 @click.option("--reset", is_flag=True, help="Re-prompt for all configuration values")

--- a/devflow/cli_skills/daf-cli/SKILL.md
+++ b/devflow/cli_skills/daf-cli/SKILL.md
@@ -37,6 +37,11 @@ user-invocable: false
 - **`daf-status` skill**: Progress dashboard
 - **`daf-list` skill**: List all sessions
 
+### Agent Setup
+- Configure agent permissions: `daf setup`
+- Preview changes: `daf setup --dry-run`
+- Global scope: `daf setup --scope global`
+
 ### Configuration
 **See `daf-config` skill** for configuration commands:
 - View config: `daf config show`

--- a/devflow/templates/overlays/claude.jsonc
+++ b/devflow/templates/overlays/claude.jsonc
@@ -1,0 +1,4 @@
+{
+  // Claude Code permissions managed via .claude/settings.json — see daf init
+  // This overlay is a placeholder for future Claude-specific config
+}

--- a/devflow/templates/overlays/opencode.jsonc
+++ b/devflow/templates/overlays/opencode.jsonc
@@ -1,0 +1,35 @@
+{
+  // DevAIFlow integration overlay for OpenCode
+  // Merged into opencode.json by `daf setup`
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      // DAF/DEVAIFLOW env var access (future-proof wildcards)
+      "echo \"${DAF_*": "allow",
+      "echo \"${DEVAIFLOW_*": "allow",
+      // All daf CLI commands (read-safe from agent perspective)
+      "daf active *": "allow",
+      "daf info *": "allow",
+      "daf * view *": "allow",
+      // Issue tracker view-only commands
+      "gh * view *": "allow",
+      "glab * view *": "allow",
+      // Git read-only operations
+      "git status *": "allow",
+      "git diff *": "allow",
+      "git log *": "allow",
+      "git fetch *": "allow"
+    },
+    "external_directory": {
+      // Allow reading daf config, session metadata, skills
+      "~/.config/devaiflow/**": "allow"
+    },
+    "read": {
+      "~/.config/devaiflow/**": "allow"
+    },
+    "edit": {
+      // Prevent accidental modification of daf config
+      "~/.config/devaiflow/**": "deny"
+    }
+  }
+}

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -1,0 +1,295 @@
+"""Tests for daf setup command."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from devflow.cli.commands.setup_command import (
+    strip_jsonc_comments,
+    load_overlay,
+    deep_merge,
+    resolve_target_path,
+    setup_agent_config,
+)
+
+
+class TestStripJsoncComments:
+    def test_line_comments(self):
+        text = '{\n  // this is a comment\n  "key": "value"\n}'
+        result = strip_jsonc_comments(text)
+        assert "//" not in result
+        parsed = json.loads(result)
+        assert parsed["key"] == "value"
+
+    def test_block_comments(self):
+        text = '{\n  /* block\n  comment */\n  "key": "value"\n}'
+        result = strip_jsonc_comments(text)
+        assert "/*" not in result
+        assert "*/" not in result
+        parsed = json.loads(result)
+        assert parsed["key"] == "value"
+
+    def test_inline_comment_after_value(self):
+        text = '{\n  "key": "value" // inline comment\n}'
+        result = strip_jsonc_comments(text)
+        parsed = json.loads(result)
+        assert parsed["key"] == "value"
+
+    def test_no_comments(self):
+        text = '{"key": "value"}'
+        result = strip_jsonc_comments(text)
+        assert json.loads(result) == {"key": "value"}
+
+    def test_url_in_string_not_stripped(self):
+        text = '{"url": "https://example.com"}'
+        result = strip_jsonc_comments(text)
+        parsed = json.loads(result)
+        assert parsed["url"] == "https://example.com"
+
+
+class TestDeepMerge:
+    def test_empty_base(self):
+        base = {}
+        overlay = {"a": {"b": "c"}}
+        merged, added = deep_merge(base, overlay)
+        assert merged == {"a": {"b": "c"}}
+        assert "a" in added
+
+    def test_no_overwrite(self):
+        base = {"a": {"b": "existing"}}
+        overlay = {"a": {"b": "new", "c": "added"}}
+        merged, added = deep_merge(base, overlay)
+        assert merged["a"]["b"] == "existing"
+        assert merged["a"]["c"] == "added"
+        assert "a.c" in added
+        assert "a.b" not in added
+
+    def test_idempotent(self):
+        base = {"a": {"b": "c"}}
+        overlay = {"a": {"b": "c"}}
+        _, added = deep_merge(base, overlay)
+        assert added == []
+
+    def test_nested_merge(self):
+        base = {"permission": {"bash": {"daf *": "allow"}}}
+        overlay = {
+            "permission": {
+                "bash": {"daf *": "allow", "gh * view *": "allow"},
+                "read": {"~/.daf-sessions/**": "allow"},
+            }
+        }
+        merged, added = deep_merge(base, overlay)
+        assert merged["permission"]["bash"]["daf *"] == "allow"
+        assert merged["permission"]["bash"]["gh * view *"] == "allow"
+        assert merged["permission"]["read"]["~/.daf-sessions/**"] == "allow"
+        assert "permission.bash.gh * view *" in added
+        assert "permission.read" in added
+
+    def test_preserves_extra_keys_in_base(self):
+        base = {"custom": "user_setting", "permission": {"bash": {"my_cmd *": "allow"}}}
+        overlay = {"permission": {"bash": {"daf *": "allow"}}}
+        merged, _ = deep_merge(base, overlay)
+        assert merged["custom"] == "user_setting"
+        assert merged["permission"]["bash"]["my_cmd *"] == "allow"
+        assert merged["permission"]["bash"]["daf *"] == "allow"
+
+
+class TestResolveTargetPath:
+    def test_opencode_project(self):
+        path = resolve_target_path("opencode", "project")
+        assert path.name == "opencode.json"
+        assert path.parent == Path.cwd()
+
+    def test_opencode_global_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("XDG_CONFIG_HOME", None)
+            path = resolve_target_path("opencode", "global")
+            assert path == Path.home() / ".config" / "opencode" / "opencode.json"
+
+    def test_opencode_global_xdg(self):
+        with patch.dict(os.environ, {"XDG_CONFIG_HOME": "/custom/config"}):
+            path = resolve_target_path("opencode", "global")
+            assert path == Path("/custom/config/opencode/opencode.json")
+
+    def test_claude_project(self):
+        path = resolve_target_path("claude", "project")
+        assert path.name == "settings.json"
+        assert ".claude" in str(path)
+
+
+class TestLoadOverlay:
+    def test_load_opencode_overlay(self):
+        overlay = load_overlay("opencode")
+        assert overlay is not None
+        assert "permission" in overlay
+        assert "bash" in overlay["permission"]
+        assert "daf *" in overlay["permission"]["bash"]
+
+    def test_load_claude_overlay(self):
+        overlay = load_overlay("claude")
+        assert overlay is not None
+
+    def test_load_nonexistent_overlay(self):
+        overlay = load_overlay("nonexistent-backend")
+        assert overlay is None
+
+
+class TestSetupAgentConfig:
+    def test_opencode_fresh_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"agent_backend": "opencode"}))
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "opencode"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(dry_run=False, scope="project")
+
+        assert exit_code == 0
+        target = tmp_path / "opencode.json"
+        assert target.exists()
+        data = json.loads(target.read_text())
+        assert "permission" in data
+        assert data["permission"]["bash"]["daf *"] == "allow"
+
+    def test_opencode_merge_existing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        existing = {
+            "permission": {
+                "bash": {
+                    "*": "ask",
+                    "my_custom *": "allow",
+                }
+            }
+        }
+        (tmp_path / "opencode.json").write_text(json.dumps(existing, indent=2))
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "opencode"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(dry_run=False, scope="project")
+
+        assert exit_code == 0
+        data = json.loads((tmp_path / "opencode.json").read_text())
+        assert data["permission"]["bash"]["*"] == "ask"
+        assert data["permission"]["bash"]["my_custom *"] == "allow"
+        assert data["permission"]["bash"]["daf *"] == "allow"
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "opencode"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            setup_agent_config(dry_run=False, scope="project")
+            first_content = (tmp_path / "opencode.json").read_text()
+
+            setup_agent_config(dry_run=False, scope="project")
+            second_content = (tmp_path / "opencode.json").read_text()
+
+        assert first_content == second_content
+
+    def test_dry_run_no_write(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "opencode"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(dry_run=True, scope="project")
+
+        assert exit_code == 0
+        assert not (tmp_path / "opencode.json").exists()
+
+    def test_non_opencode_backend(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "cursor"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(dry_run=False, scope="project")
+
+        assert exit_code == 0
+        assert not (tmp_path / "opencode.json").exists()
+
+    def test_backend_alias(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "opencode-ai"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(dry_run=False, scope="project")
+
+        assert exit_code == 0
+        assert (tmp_path / "opencode.json").exists()
+
+    def test_json_output(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "opencode"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(
+                dry_run=False, scope="project", output_json=True
+            )
+
+        assert exit_code == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["success"] is True
+        assert output["backend"] == "opencode"
+        assert len(output["added"]) > 0
+
+    def test_global_scope(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        global_dir = tmp_path / "xdg_config" / "opencode"
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg_config"))
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "opencode"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(dry_run=False, scope="global")
+
+        assert exit_code == 0
+        target = global_dir / "opencode.json"
+        assert target.exists()
+
+    def test_edit_deny_for_daf_sessions(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "opencode"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            setup_agent_config(dry_run=False, scope="project")
+
+        data = json.loads((tmp_path / "opencode.json").read_text())
+        assert data["permission"]["edit"]["~/.daf-sessions/**"] == "deny"
+
+    def test_config_load_failure_defaults_to_claude(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_loader.return_value.load_config.side_effect = Exception("no config")
+
+            exit_code = setup_agent_config(dry_run=False, scope="project")
+
+        assert exit_code == 0

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -74,27 +74,27 @@ class TestDeepMerge:
         assert added == []
 
     def test_nested_merge(self):
-        base = {"permission": {"bash": {"daf *": "allow"}}}
+        base = {"permission": {"bash": {"daf info *": "allow"}}}
         overlay = {
             "permission": {
-                "bash": {"daf *": "allow", "gh * view *": "allow"},
-                "read": {"~/.daf-sessions/**": "allow"},
+                "bash": {"daf info *": "allow", "gh * view *": "allow"},
+                "read": {"~/.config/devaiflow/**": "allow"},
             }
         }
         merged, added = deep_merge(base, overlay)
-        assert merged["permission"]["bash"]["daf *"] == "allow"
+        assert merged["permission"]["bash"]["daf info *"] == "allow"
         assert merged["permission"]["bash"]["gh * view *"] == "allow"
-        assert merged["permission"]["read"]["~/.daf-sessions/**"] == "allow"
+        assert merged["permission"]["read"]["~/.config/devaiflow/**"] == "allow"
         assert "permission.bash.gh * view *" in added
         assert "permission.read" in added
 
     def test_preserves_extra_keys_in_base(self):
         base = {"custom": "user_setting", "permission": {"bash": {"my_cmd *": "allow"}}}
-        overlay = {"permission": {"bash": {"daf *": "allow"}}}
+        overlay = {"permission": {"bash": {"daf info *": "allow"}}}
         merged, _ = deep_merge(base, overlay)
         assert merged["custom"] == "user_setting"
         assert merged["permission"]["bash"]["my_cmd *"] == "allow"
-        assert merged["permission"]["bash"]["daf *"] == "allow"
+        assert merged["permission"]["bash"]["daf info *"] == "allow"
 
 
 class TestResolveTargetPath:
@@ -126,7 +126,7 @@ class TestLoadOverlay:
         assert overlay is not None
         assert "permission" in overlay
         assert "bash" in overlay["permission"]
-        assert "daf *" in overlay["permission"]["bash"]
+        assert "daf info *" in overlay["permission"]["bash"]
 
     def test_load_claude_overlay(self):
         overlay = load_overlay("claude")
@@ -155,7 +155,7 @@ class TestSetupAgentConfig:
         assert target.exists()
         data = json.loads(target.read_text())
         assert "permission" in data
-        assert data["permission"]["bash"]["daf *"] == "allow"
+        assert data["permission"]["bash"]["daf info *"] == "allow"
 
     def test_opencode_merge_existing(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -180,7 +180,7 @@ class TestSetupAgentConfig:
         data = json.loads((tmp_path / "opencode.json").read_text())
         assert data["permission"]["bash"]["*"] == "ask"
         assert data["permission"]["bash"]["my_custom *"] == "allow"
-        assert data["permission"]["bash"]["daf *"] == "allow"
+        assert data["permission"]["bash"]["daf info *"] == "allow"
 
     def test_idempotent(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -282,7 +282,7 @@ class TestSetupAgentConfig:
             setup_agent_config(dry_run=False, scope="project")
 
         data = json.loads((tmp_path / "opencode.json").read_text())
-        assert data["permission"]["edit"]["~/.daf-sessions/**"] == "deny"
+        assert data["permission"]["edit"]["~/.config/devaiflow/**"] == "deny"
 
     def test_config_load_failure_defaults_to_claude(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
Got the full picture. Here's the filled template:

Jira Issue: https://github.com/itdove/devaiflow/issues/443
<!-- This PR does not need a corresponding Jira item. -->

## Description

Add `daf setup` command that configures AI agent permissions for DevAIFlow integration. The command loads a JSONC overlay template matching the active backend (e.g., OpenCode, Claude) and deep-merges it into the agent's config file, adding DevAIFlow-specific permission rules without overwriting existing settings.

Key changes:
- New `setup_command.py` with JSONC comment stripping, deep-merge logic, backend alias resolution, and target path resolution for both project and global scope
- JSONC overlay templates: `opencode.jsonc` grants read-only access to daf CLI, env vars, git operations, and `~/.config/devaiflow/`; `claude.jsonc` is a placeholder (Claude permissions are managed via `daf init`)
- CLI wiring in `main.py` with `--dry-run`, `--scope`, and `--json` options
- Updated `daf-cli` skill docs with setup commands
- 295-line test suite covering JSONC parsing, deep-merge semantics, path resolution, and end-to-end setup scenarios

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `daf setup --dry-run` with OpenCode as active backend — verify it previews permission additions without writing
3. Run `daf setup` — verify `opencode.json` is created/updated with permission entries from the overlay
4. Run `daf setup` again — verify idempotent (no duplicate keys, reports "no changes needed")
5. Run `daf setup --scope global` — verify it targets the global config path (`~/.config/opencode/config.json`)
6. Run `daf setup --json` — verify JSON-formatted output
7. Run `pytest tests/test_setup_command.py -v` — all tests should pass

### Scenarios tested
- Fresh config (no existing file) — creates new file with overlay content
- Existing config with no overlap — adds all overlay keys
- Existing config with overlapping keys — preserves existing values, adds only new keys
- Dry-run mode — previews diff without writing
- JSONC comment stripping — handles `//`, `/* */`, and URLs-in-strings correctly
- Backend alias resolution (e.g., `opencode-ai` → `opencode`)
- Missing overlay template — graceful error for unsupported backends

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: