### PR TITLE
itdove/devaiflow#446: daf setup: configure Claude Code permissions for daf integration (mirror OpenCode #443)

### DIFF
--- a/devflow/cli/commands/setup_command.py
+++ b/devflow/cli/commands/setup_command.py
@@ -98,6 +98,16 @@ def _deep_merge_recursive(
             added.append(path)
         elif isinstance(value, dict) and isinstance(base[key], dict):
             _deep_merge_recursive(base[key], value, path, added)
+        elif isinstance(value, list) and isinstance(base[key], list):
+            for item in value:
+                if item not in base[key]:
+                    base[key].append(item)
+                    added.append(f"{path}[]")
+        elif isinstance(value, list) and isinstance(base[key], list):
+            for item in value:
+                if item not in base[key]:
+                    base[key].append(item)
+                    added.append(f"{path}[]")
 
 
 def resolve_target_path(backend: str, scope: str) -> Path:
@@ -124,26 +134,43 @@ def resolve_target_path(backend: str, scope: str) -> Path:
             if claude_dir:
                 return Path(claude_dir) / "settings.json"
             return Path.home() / ".claude" / "settings.json"
+        if scope == "local":
+            return Path.cwd() / ".claude" / "settings.local.json"
         return Path.cwd() / ".claude" / "settings.json"
 
     return Path.cwd() / f"{backend}.json"
 
 
+SUPPORTED_OVERLAY_BACKENDS = ["claude", "opencode"]
+
+
 def setup_agent_config(
     dry_run: bool = False,
     scope: str = "project",
+    all_agents: bool = False,
     output_json: bool = False,
 ) -> int:
     """Configure agent integration by merging overlay template into agent config.
 
     Args:
         dry_run: Preview changes without writing.
-        scope: 'project' or 'global'.
+        scope: 'project', 'local', or 'global'.
+        all_agents: Configure all supported agents at once.
         output_json: Output JSON format.
 
     Returns:
         Exit code: 0 on success, 1 on error.
     """
+    if all_agents:
+        worst = 0
+        for agent_backend in SUPPORTED_OVERLAY_BACKENDS:
+            result = _setup_single_backend(
+                agent_backend, dry_run=dry_run, scope=scope, output_json=output_json
+            )
+            if result > worst:
+                worst = result
+        return worst
+
     from devflow.config.loader import ConfigLoader
 
     try:
@@ -154,6 +181,18 @@ def setup_agent_config(
         backend = "claude"
 
     canonical = BACKEND_ALIASES.get(backend, backend)
+    return _setup_single_backend(
+        canonical, dry_run=dry_run, scope=scope, output_json=output_json
+    )
+
+
+def _setup_single_backend(
+    canonical: str,
+    dry_run: bool = False,
+    scope: str = "project",
+    output_json: bool = False,
+) -> int:
+    """Configure a single agent backend."""
     overlay = load_overlay(canonical)
 
     if overlay is None:
@@ -213,7 +252,7 @@ def setup_agent_config(
         return 0
 
     from devflow.agent.factory import AGENT_DISPLAY_NAMES
-    display_name = AGENT_DISPLAY_NAMES.get(backend, canonical)
+    display_name = AGENT_DISPLAY_NAMES.get(canonical, canonical)
     console.print(f"\n[bold]Setting up {display_name} integration[/bold]")
     console.print(f"  Backend: [cyan]{canonical}[/cyan]")
     console.print(f"  Scope:   [cyan]{scope}[/cyan]")

--- a/devflow/cli/main.py
+++ b/devflow/cli/main.py
@@ -3284,10 +3284,11 @@ def provider_test(ctx: click.Context, name: str) -> None:
 
 @cli.command()
 @click.option("--dry-run", is_flag=True, help="Preview changes without writing")
-@click.option("--scope", type=click.Choice(["project", "global"]), default="project",
-              help="Config scope: project-level (default) or global")
+@click.option("--scope", type=click.Choice(["project", "local", "global"]), default="project",
+              help="Config scope: project (default), local (gitignored), or global")
+@click.option("--all-agents", is_flag=True, help="Configure all supported agents at once")
 @json_option
-def setup(ctx: click.Context, dry_run: bool, scope: str) -> None:
+def setup(ctx: click.Context, dry_run: bool, scope: str, all_agents: bool) -> None:
     """Configure agent integration for the current backend.
 
     Merges a JSONC overlay template into the agent's config file,
@@ -3295,7 +3296,9 @@ def setup(ctx: click.Context, dry_run: bool, scope: str) -> None:
 
     Examples:
         daf setup                    # Apply overlay to project config
+        daf setup --scope local      # Apply to .claude/settings.local.json
         daf setup --scope global     # Apply to global agent config
+        daf setup --all-agents       # Configure all agents at once
         daf setup --dry-run          # Preview what would be added
         daf setup --json             # JSON output
     """
@@ -3305,6 +3308,7 @@ def setup(ctx: click.Context, dry_run: bool, scope: str) -> None:
     exit_code = setup_agent_config(
         dry_run=dry_run,
         scope=scope,
+        all_agents=all_agents,
         output_json=output_json,
     )
     raise SystemExit(exit_code)

--- a/devflow/templates/overlays/claude.jsonc
+++ b/devflow/templates/overlays/claude.jsonc
@@ -1,4 +1,29 @@
 {
-  // Claude Code permissions managed via .claude/settings.json — see daf init
-  // This overlay is a placeholder for future Claude-specific config
+  // DevAIFlow integration overlay for Claude Code
+  // Merged into .claude/settings.json by `daf setup`
+  "permissions": {
+    "allow": [
+      // DAF/DEVAIFLOW env var access (future-proof wildcards)
+      "Bash(echo \"${DAF_*)",
+      "Bash(echo \"${DEVAIFLOW_*)",
+      // All daf CLI commands (read-safe from agent perspective)
+      "Bash(daf active *)",
+      "Bash(daf info *)",
+      "Bash(daf * view *)",
+      // Issue tracker view-only commands
+      "Bash(gh * view *)",
+      "Bash(glab * view *)",
+      // Git read-only operations
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git fetch *)",
+      // Allow reading daf config, session metadata, skills
+      "Read(~/.config/devaiflow/**)"
+    ],
+    "deny": [
+      // Prevent accidental modification of daf config
+      "Edit(~/.config/devaiflow/**)"
+    ]
+  }
 }

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -13,6 +13,7 @@ from devflow.cli.commands.setup_command import (
     deep_merge,
     resolve_target_path,
     setup_agent_config,
+    SUPPORTED_OVERLAY_BACKENDS,
 )
 
 
@@ -96,6 +97,28 @@ class TestDeepMerge:
         assert merged["permission"]["bash"]["my_cmd *"] == "allow"
         assert merged["permission"]["bash"]["daf info *"] == "allow"
 
+    def test_array_union_merge(self):
+        base = {"permissions": {"allow": ["Bash(pytest:*)", "Bash(daf info *)"]}}
+        overlay = {"permissions": {"allow": ["Bash(daf info *)", "Bash(gh * view *)"]}}
+        merged, added = deep_merge(base, overlay)
+        assert "Bash(gh * view *)" in merged["permissions"]["allow"]
+        assert merged["permissions"]["allow"].count("Bash(daf info *)") == 1
+        assert any("permissions.allow[]" in a for a in added)
+
+    def test_array_idempotent(self):
+        base = {"permissions": {"allow": ["Bash(daf info *)", "Bash(gh * view *)"]}}
+        overlay = {"permissions": {"allow": ["Bash(daf info *)", "Bash(gh * view *)"]}}
+        _, added = deep_merge(base, overlay)
+        assert added == []
+
+    def test_array_into_empty(self):
+        base = {"permissions": {"allow": [], "deny": []}}
+        overlay = {"permissions": {"allow": ["Bash(daf *)"], "deny": ["Edit(~/.config/devaiflow/**)"]}}
+        merged, added = deep_merge(base, overlay)
+        assert "Bash(daf *)" in merged["permissions"]["allow"]
+        assert "Edit(~/.config/devaiflow/**)" in merged["permissions"]["deny"]
+        assert len(added) == 2
+
 
 class TestResolveTargetPath:
     def test_opencode_project(self):
@@ -118,6 +141,22 @@ class TestResolveTargetPath:
         path = resolve_target_path("claude", "project")
         assert path.name == "settings.json"
         assert ".claude" in str(path)
+
+    def test_claude_local(self):
+        path = resolve_target_path("claude", "local")
+        assert path.name == "settings.local.json"
+        assert ".claude" in str(path)
+
+    def test_claude_global_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            path = resolve_target_path("claude", "global")
+            assert path == Path.home() / ".claude" / "settings.json"
+
+    def test_claude_global_custom(self):
+        with patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": "/custom/claude"}):
+            path = resolve_target_path("claude", "global")
+            assert path == Path("/custom/claude/settings.json")
 
 
 class TestLoadOverlay:
@@ -293,3 +332,110 @@ class TestSetupAgentConfig:
             exit_code = setup_agent_config(dry_run=False, scope="project")
 
         assert exit_code == 0
+
+    def test_claude_fresh_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "claude"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(dry_run=False, scope="project")
+
+        assert exit_code == 0
+        target = tmp_path / ".claude" / "settings.json"
+        assert target.exists()
+        data = json.loads(target.read_text())
+        assert "permissions" in data
+        assert isinstance(data["permissions"]["allow"], list)
+        assert "Bash(daf info *)" in data["permissions"]["allow"]
+        assert "Read(~/.config/devaiflow/**)" in data["permissions"]["allow"]
+        assert "Edit(~/.config/devaiflow/**)" in data["permissions"]["deny"]
+
+    def test_claude_merge_existing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        existing = {
+            "permissions": {
+                "allow": ["Bash(pytest:*)", "Bash(daf info *)"],
+                "deny": [],
+            }
+        }
+        (claude_dir / "settings.json").write_text(json.dumps(existing, indent=2))
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "claude"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(dry_run=False, scope="project")
+
+        assert exit_code == 0
+        data = json.loads((claude_dir / "settings.json").read_text())
+        assert "Bash(pytest:*)" in data["permissions"]["allow"]
+        assert "Bash(daf info *)" in data["permissions"]["allow"]
+        assert "Bash(daf active *)" in data["permissions"]["allow"]
+        assert data["permissions"]["allow"].count("Bash(daf info *)") == 1
+
+    def test_claude_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "claude"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            setup_agent_config(dry_run=False, scope="project")
+            first = (tmp_path / ".claude" / "settings.json").read_text()
+
+            setup_agent_config(dry_run=False, scope="project")
+            second = (tmp_path / ".claude" / "settings.json").read_text()
+
+        assert first == second
+
+    def test_claude_local_scope(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "claude"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(dry_run=False, scope="local")
+
+        assert exit_code == 0
+        target = tmp_path / ".claude" / "settings.local.json"
+        assert target.exists()
+        data = json.loads(target.read_text())
+        assert "Bash(daf info *)" in data["permissions"]["allow"]
+
+    def test_claude_edit_deny(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "claude"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            setup_agent_config(dry_run=False, scope="project")
+
+        data = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+        assert "Edit(~/.config/devaiflow/**)" in data["permissions"]["deny"]
+
+    def test_all_agents(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "claude"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(
+                dry_run=False, scope="project", all_agents=True
+            )
+
+        assert exit_code == 0
+        assert (tmp_path / ".claude" / "settings.json").exists()
+        assert (tmp_path / "opencode.json").exists()


### PR DESCRIPTION
Jira Issue: <https://github.com/itdove/devaiflow/issues/446>
<!-- This PR does not need a corresponding Jira item. -->

## Description

Configure Claude Code permissions for daf integration, mirroring the OpenCode setup from #443.

Changes:
- **Claude overlay template** (`devflow/templates/overlays/claude.jsonc`): Replace placeholder with real permissions — allow daf CLI commands, issue tracker view operations (gh/glab), git read-only commands, and reading daf config files. Deny editing daf config to prevent accidental modification.
- **Setup command** (`devflow/cli/commands/setup_command.py`): Add `--all-agents` flag to configure all supported backends (claude, opencode) in one invocation. Add `--scope local` option targeting `.claude/settings.local.json`. Fix deep merge to handle list values (append new items without duplicates). Refactor into `_setup_single_backend()` for reuse across backends.
- **CLI main** (`devflow/cli/main.py`): Wire up new `--all-agents` and `--scope local` options with updated help text and examples.
- **Tests** (`tests/test_setup_command.py`): Add tests covering `--all-agents` iteration, `--scope local` path resolution, and list merge behavior.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run `daf setup --dry-run` — verify Claude overlay permissions shown without writing
3. Run `daf setup --scope local --dry-run` — verify target is `.claude/settings.local.json`
4. Run `daf setup --all-agents --dry-run` — verify both claude and opencode backends processed
5. Run `daf setup` in a project — verify `.claude/settings.json` updated with permissions (allow/deny blocks merged, no duplicates on re-run)
6. Run `pytest tests/test_setup_command.py -v` — all tests pass

### Scenarios tested
- Dry-run mode for all scope/backend combinations
- Re-running setup on already-configured project (idempotent list merge)
- `--all-agents` processes both claude and opencode backends
- `--scope local` resolves to correct path

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: