### PR TITLE
itdove/devaiflow#478: daf-workflow skill: add exact permission for DAF env check command

### DIFF
--- a/devflow/cli_skills/daf-workflow/SKILL.md
+++ b/devflow/cli_skills/daf-workflow/SKILL.md
@@ -6,7 +6,13 @@ user-invocable: true
 
 # DevAIFlow Session Context
 
-Check the `DAF_SESSION_NAME` environment variable. If set, this is a managed DevAIFlow session — follow the initialization steps below. If not set, skip to the **Standalone Workflow Guide** section at the bottom.
+Run this command to check the session environment:
+
+```bash
+echo "DAF_SESSION_NAME=$DAF_SESSION_NAME" "DAF_COMMAND=$DAF_COMMAND"
+```
+
+If `DAF_SESSION_NAME` is set (non-empty), this is a managed DevAIFlow session — follow the initialization steps below. If empty, skip to the **Standalone Workflow Guide** section at the bottom.
 
 ---
 
@@ -77,7 +83,7 @@ git fetch origin && git rebase origin/main
 
 ### 6. Follow Command-Specific Workflow
 
-Check `DAF_COMMAND` environment variable and follow the matching section below.
+Use the `DAF_COMMAND` value from the output above and follow the matching section below.
 
 ---
 

--- a/devflow/templates/overlays/claude.jsonc
+++ b/devflow/templates/overlays/claude.jsonc
@@ -3,9 +3,8 @@
   // Merged into .claude/settings.json by `daf setup`
   "permissions": {
     "allow": [
-      // DAF/DEVAIFLOW env var access (future-proof wildcards)
-      "Bash(echo \"${DAF_*)",
-      "Bash(echo \"${DEVAIFLOW_*)",
+      // DAF env var check (exact command from daf-workflow skill)
+      "Bash(echo \"DAF_SESSION_NAME=$DAF_SESSION_NAME\" \"DAF_COMMAND=$DAF_COMMAND\")",
       // All daf CLI commands (read-safe from agent perspective)
       "Bash(daf active *)",
       "Bash(daf info *)",

--- a/devflow/templates/overlays/opencode.jsonc
+++ b/devflow/templates/overlays/opencode.jsonc
@@ -4,9 +4,8 @@
   "$schema": "https://opencode.ai/config.json",
   "permission": {
     "bash": {
-      // DAF/DEVAIFLOW env var access (future-proof wildcards)
-      "echo \"${DAF_*": "allow",
-      "echo \"${DEVAIFLOW_*": "allow",
+      // DAF env var check (exact command from daf-workflow skill)
+      "echo \"DAF_SESSION_NAME=$DAF_SESSION_NAME\" \"DAF_COMMAND=$DAF_COMMAND\"": "allow",
       // All daf CLI commands (read-safe from agent perspective)
       "daf active *": "allow",
       "daf info *": "allow",


### PR DESCRIPTION
Here's the filled PR template:

---

<!-- This PR does not need a corresponding Jira item. -->

## Description

The daf-workflow skill previously checked DAF environment variables by reading `$DAF_SESSION_NAME` and `$DAF_COMMAND` individually, with wildcard-based permissions (`Bash(echo "${DAF_*")`) in the agent overlay templates. This was overly broad and didn't match any actual command the skill issued.

This change:
- Updates the skill to use a single explicit `echo` command that outputs both `DAF_SESSION_NAME` and `DAF_COMMAND` in one call
- Replaces the two wildcard permission entries in both `claude.jsonc` and `opencode.jsonc` overlays with a single exact-match permission for that command
- Updates the skill text to reference the command output instead of telling agents to "check the environment variable" directly

This tightens the permission surface from wildcard patterns to an exact command match.

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `daf setup` on a test project to verify the new overlay templates apply correctly to `.claude/settings.json` or `opencode.json`
3. Run `daf open` or `daf new` to start a session — confirm the agent can execute the env check command without a permission prompt
4. Verify the skill output correctly shows both `DAF_SESSION_NAME` and `DAF_COMMAND` values
5. Confirm no other `echo "${DAF_*"` wildcard permissions remain in the generated config

### Scenarios tested
- Session startup with `daf open` — env vars detected without permission prompt
- Standalone mode (no `DAF_SESSION_NAME` set) — skill correctly skips to standalone workflow

## Deployment considerations

- [x] This code change is ready for deployment on its own