### PR TITLE
itdove/devaiflow#292: v3.0 Breaking Change: Remove hidden backward-compatibility commands

### DIFF
--- a/devflow/cli/commands/check_command.py
+++ b/devflow/cli/commands/check_command.py
@@ -1,4 +1,4 @@
-"""Implementation of 'daf check' command."""
+"""Implementation of 'daf init --check' command."""
 
 import json
 import sys

--- a/devflow/cli/commands/cleanup_command.py
+++ b/devflow/cli/commands/cleanup_command.py
@@ -1,4 +1,4 @@
-"""Implementation of 'daf cleanup-conversation' command."""
+"""Implementation of 'daf maintenance cleanup-conversation' command."""
 
 import json
 import os
@@ -63,9 +63,9 @@ def cleanup_conversation(
     # Determine which session to cleanup
     if not identifier:
         console.print("[red]Error: Session name or issue key required[/red]")
-        console.print("[dim]Usage: daf cleanup-conversation <NAME-or-JIRA-KEY> --older-than 8h[/dim]")
-        console.print("[dim]Example: daf cleanup-conversation PROJ-12345 --older-than 8h[/dim]")
-        console.print("[dim]Or use: daf cleanup-conversation --latest --older-than 8h[/dim]")
+        console.print("[dim]Usage: daf maintenance cleanup-conversation <NAME-or-JIRA-KEY> --older-than 8h[/dim]")
+        console.print("[dim]Example: daf maintenance cleanup-conversation PROJ-12345 --older-than 8h[/dim]")
+        console.print("[dim]Or use: daf maintenance cleanup-conversation --latest --older-than 8h[/dim]")
         return
 
     # Get session by identifier (handles multi-conversation sessions)
@@ -113,8 +113,8 @@ def cleanup_conversation(
     if not older_than and not keep_last:
         console.print("[red]Error: Must specify either --older-than or --keep-last[/red]")
         console.print("[dim]Examples:[/dim]")
-        console.print("[dim]  daf cleanup-conversation --older-than 2h[/dim]")
-        console.print("[dim]  daf cleanup-conversation --keep-last 50[/dim]")
+        console.print("[dim]  daf maintenance cleanup-conversation --older-than 2h[/dim]")
+        console.print("[dim]  daf maintenance cleanup-conversation --keep-last 50[/dim]")
         return
 
     if older_than and keep_last:
@@ -494,7 +494,7 @@ def _list_backups(ai_agent_session_id: str, session, agent_name: str = "Claude C
     console.print(f"[dim]Location: {backup_dir.relative_to(Path.home())}[/dim]")
     console.print()
     console.print("[bold]To restore a backup:[/bold]")
-    console.print(f"  daf cleanup-conversation {session.name if session else ai_agent_session_id} --restore-backup <timestamp>")
+    console.print(f"  daf maintenance cleanup-conversation {session.name if session else ai_agent_session_id} --restore-backup <timestamp>")
 
 
 def _restore_backup(
@@ -523,7 +523,7 @@ def _restore_backup(
         console.print()
         console.print("[green]To restore backup:[/green]")
         console.print(f"  1. Exit {agent_name} completely")
-        console.print("  2. Run: daf cleanup-conversation <NAME-or-JIRA-KEY> --restore-backup <timestamp>")
+        console.print("  2. Run: daf maintenance cleanup-conversation <NAME-or-JIRA-KEY> --restore-backup <timestamp>")
         console.print(f"  3. Reopen {agent_name} with: daf open <NAME-or-JIRA-KEY>")
         return
 
@@ -541,7 +541,7 @@ def _restore_backup(
         console.print(f"[red]Error: Backup not found: {timestamp}[/red]")
         console.print()
         console.print("[dim]List available backups with:[/dim]")
-        console.print(f"  daf cleanup-conversation {session.name if session else ai_agent_session_id} --list-backups")
+        console.print(f"  daf maintenance cleanup-conversation {session.name if session else ai_agent_session_id} --list-backups")
         return
 
     # Find conversation file

--- a/devflow/cli/commands/cleanup_sessions_command.py
+++ b/devflow/cli/commands/cleanup_sessions_command.py
@@ -1,4 +1,4 @@
-"""Implementation of 'daf cleanup-sessions' command."""
+"""Implementation of 'daf maintenance cleanup-sessions' command."""
 
 from pathlib import Path
 from typing import List, Tuple

--- a/devflow/cli/commands/discover_command.py
+++ b/devflow/cli/commands/discover_command.py
@@ -1,4 +1,4 @@
-"""Implementation of 'daf discover' command."""
+"""Implementation of 'daf maintenance discover' command."""
 
 from rich.console import Console
 from rich.table import Table

--- a/devflow/cli/commands/import_session_command.py
+++ b/devflow/cli/commands/import_session_command.py
@@ -42,7 +42,7 @@ def import_session(uuid: str, issue_key: str = None, goal: str = None, path: str
 
     if not session_to_import:
         console.print(f"[red]Session {uuid} not found[/red]")
-        console.print("[dim]Use 'daf discover' to see available sessions[/dim]")
+        console.print("[dim]Use 'daf maintenance discover' to see available sessions[/dim]")
         return
 
     # Check if already managed

--- a/devflow/cli/commands/rebuild_index_command.py
+++ b/devflow/cli/commands/rebuild_index_command.py
@@ -1,4 +1,4 @@
-"""Implementation of 'daf rebuild-index' command."""
+"""Implementation of 'daf maintenance rebuild-index' command."""
 
 import json
 from datetime import datetime

--- a/devflow/cli/commands/repair_conversation_command.py
+++ b/devflow/cli/commands/repair_conversation_command.py
@@ -147,12 +147,12 @@ def repair_conversation(
     if not identifier:
         console.print("[red]✗[/red] Please provide a session identifier, UUID, or use --check-all/--all/--latest")
         console.print("\nExamples:")
-        console.print("  daf repair-conversation PROJ-60039")
-        console.print("  daf repair-conversation --latest")
-        console.print("  daf repair-conversation my-session")
-        console.print("  daf repair-conversation f545206f-480f-4c2d-8823-c6643f0e693d")
-        console.print("  daf repair-conversation --check-all")
-        console.print("  daf repair-conversation --all")
+        console.print("  daf maintenance repair-conversation PROJ-60039")
+        console.print("  daf maintenance repair-conversation --latest")
+        console.print("  daf maintenance repair-conversation my-session")
+        console.print("  daf maintenance repair-conversation f545206f-480f-4c2d-8823-c6643f0e693d")
+        console.print("  daf maintenance repair-conversation --check-all")
+        console.print("  daf maintenance repair-conversation --all")
         return
 
     # Try to find session by name or issue key first

--- a/devflow/cli/main.py
+++ b/devflow/cli/main.py
@@ -681,10 +681,10 @@ def session_set_workspace(session_name: str, workspace_name: str) -> None:
 # ============================================================================
 
 
-@cli.group(hidden=True)
+@cli.group()
 @json_option
 def maintenance(ctx: click.Context) -> None:
-    """Maintenance and repair commands (hidden utilities)."""
+    """Maintenance and repair commands."""
     pass
 
 
@@ -1072,27 +1072,6 @@ def info_cmd(ctx: click.Context, identifier: str, uuid_only: bool, conversation_
     session_info(identifier, uuid_only, conversation_id, latest=latest, output_json=ctx.obj.get('output_json', False))
 
 
-@cli.command(hidden=True)
-@click.argument("identifier", required=True, shell_complete=complete_session_identifiers)
-def edit(identifier: str) -> None:
-    """[Hidden] Edit session metadata interactively via TUI.
-
-    Use 'daf open <identifier> --edit' instead.
-
-    IDENTIFIER can be a session name or issue key.
-
-    \b
-    Examples:
-        daf edit PROJ-60989          # Edit by issue key (old)
-        daf open PROJ-60989 --edit   # Edit by issue key (new)
-        daf edit my-session          # Edit by session name (old)
-        daf open my-session --edit   # Edit by session name (new)
-    """
-    from devflow.ui.session_editor_tui import run_session_editor_tui
-
-    run_session_editor_tui(identifier)
-
-
 @cli.command()
 @json_option
 def status(ctx: click.Context) -> None:
@@ -1302,18 +1281,6 @@ def import_cmd(ctx: click.Context, export_file: str, merge: bool, force: bool) -
     import_sessions(export_file, merge=merge, force=force)
 
 
-@cli.command(hidden=True)
-@json_option
-def discover(ctx: click.Context) -> None:
-    """[Hidden] Discover existing Claude Code sessions not managed by daf tool.
-
-    Use 'daf maintenance discover' instead.
-    """
-    from devflow.cli.commands.discover_command import discover_sessions
-
-    discover_sessions()
-
-
 @cli.command(name="import-session")
 @click.argument("uuid")
 @click.option("--jira", help="issue tracker key (will prompt if not provided)")
@@ -1328,7 +1295,7 @@ def import_session_cmd(ctx: click.Context, uuid: str, jira: str, goal: str, goal
     This registers a Claude Code session (created manually with 'claude --session-id')
     with daf tool so you can manage it using daf commands.
 
-    Use 'daf discover' to find available session UUIDs on your machine.
+    Use 'daf maintenance discover' to find available session UUIDs on your machine.
 
     Note: This is different from 'daf import', which imports sessions from export files.
     """
@@ -1371,189 +1338,6 @@ def unlink(ctx: click.Context, name: str, force: bool) -> None:
     from devflow.cli.commands.link_command import unlink_jira
 
     unlink_jira(name, force)
-
-
-@cli.command(name="cleanup-sessions", hidden=True)
-@click.option("--dry-run", is_flag=True, help="Show what would be cleaned without actually cleaning")
-@click.option("--force", is_flag=True, help="Skip confirmation prompt")
-@json_option
-def cleanup_sessions_cmd(ctx: click.Context, dry_run: bool, force: bool) -> None:
-    """[Hidden] Find and fix orphaned sessions (sessions with missing conversation files).
-
-    Use 'daf maintenance cleanup-sessions' instead.
-
-    Scans all sessions and identifies ones where the conversation file no longer exists.
-    This can happen when:
-    - Session was interrupted during creation
-    - Claude Code crashed before creating the conversation file
-    - Conversation files were manually deleted
-
-    \b
-    What it does:
-        - Scans all sessions for orphaned ai_agent_session_ids
-        - Clears the orphaned IDs from session metadata
-        - Next 'daf open' will generate fresh UUIDs
-
-    \b
-    Examples:
-        daf cleanup-sessions --dry-run    # Preview what would be cleaned
-        daf cleanup-sessions              # Clean with confirmation
-        daf cleanup-sessions --force      # Clean without confirmation
-    """
-    from devflow.cli.commands.cleanup_sessions_command import cleanup_sessions
-
-    cleanup_sessions(dry_run=dry_run, force=force)
-
-
-@cli.command(name="rebuild-index", hidden=True)
-@click.option("--dry-run", is_flag=True, help="Show what would be rebuilt without actually rebuilding")
-@click.option("--force", is_flag=True, help="Skip confirmation prompt")
-@json_option
-def rebuild_index_cmd(ctx: click.Context, dry_run: bool, force: bool) -> None:
-    """[Hidden] Rebuild sessions.json index from session directories.
-
-    Use 'daf maintenance rebuild-index' instead.
-
-    Scans all session directories and rebuilds the sessions.json index file
-    from their metadata.json files. This is useful when:
-    - The sessions.json file was corrupted or deleted
-    - Sessions exist but don't appear in 'daf list'
-    - The index got out of sync with actual session data
-
-    \b
-    What it does:
-        - Scans all session directories
-        - Reads metadata.json from each directory
-        - Rebuilds sessions.json with all valid sessions
-        - Creates backup of existing sessions.json
-
-    \b
-    Examples:
-        daf rebuild-index --dry-run    # Preview what would be rebuilt
-        daf rebuild-index              # Rebuild with confirmation
-        daf rebuild-index --force      # Rebuild without confirmation
-    """
-    from devflow.cli.commands.rebuild_index_command import rebuild_index
-
-    rebuild_index(dry_run=dry_run, force=force)
-
-
-@cli.command(name="repair-conversation", hidden=True)
-@click.argument("identifier", required=False, shell_complete=complete_session_identifiers)
-@click.option("--conversation-id", type=int, help="Repair specific conversation by number (1, 2, 3...)")
-@click.option("--max-size", type=int, default=10000, help="Maximum size for content truncation (default: 10000 chars)")
-@click.option("--check-all", is_flag=True, help="Check all sessions for corruption (dry run)")
-@click.option("--all", "repair_all", is_flag=True, help="Repair all corrupted sessions found")
-@click.option("--dry-run", is_flag=True, help="Report issues without making changes")
-@click.option("--latest", is_flag=True, help="Use the most recently active session")
-@json_option
-def repair_conversation_cmd(ctx: click.Context, identifier: str, conversation_id: int, max_size: int, check_all: bool, repair_all: bool, dry_run: bool, latest: bool) -> None:
-    """[Hidden] Repair corrupted Claude Code conversation files.
-
-    Use 'daf maintenance repair-conversation' instead.
-
-    IDENTIFIER can be a session name, issue key, or Claude Code UUID.
-    If not provided or --latest is specified, uses the most recently active session.
-
-    This tool repairs corrupted .jsonl conversation files by:
-    - Detecting and fixing invalid JSON lines
-    - Removing invalid Unicode surrogate pairs
-    - Truncating oversized tool results
-    - Creating automatic backups before repair
-
-    \b
-    Examples:
-        daf repair-conversation PROJ-60039                    # Repair by issue key
-        daf repair-conversation --latest                     # Repair most recent session
-        daf repair-conversation my-session                   # Repair by session name
-        daf repair-conversation f545206f-480f-4c2d-8823      # Repair by UUID
-        daf repair-conversation PROJ-60039 --conversation-id 1  # Repair specific conversation
-        daf repair-conversation --check-all                  # Scan for corruption (dry run)
-        daf repair-conversation --all                        # Repair all corrupted sessions
-        daf repair-conversation PROJ-60039 --max-size 15000   # Custom truncation size
-        daf repair-conversation PROJ-60039 --dry-run          # Preview changes
-
-    \b
-    Identifier types:
-        - Session name (e.g., 'implement-backup-feature')
-        - issue key (e.g., 'PROJ-60039')
-        - Claude UUID (e.g., 'f545206f-480f-4c2d-8823-c6643f0e693d')
-
-    \b
-    Repair actions:
-        - Automatically creates .jsonl.backup-TIMESTAMP before repair
-        - Truncates large tool results to configurable size
-        - Removes invalid Unicode surrogate pairs
-        - Validates repaired file is valid JSON
-        - Reports what was fixed (line numbers, truncation stats)
-
-    \b
-    Note: You'll need to restart Claude Code after repair for changes to take effect.
-    """
-    from devflow.cli.commands.repair_conversation_command import repair_conversation
-
-    repair_conversation(
-        identifier=identifier,
-        conversation_id=conversation_id,
-        max_size=max_size,
-        check_all=check_all,
-        repair_all=repair_all,
-        dry_run=dry_run,
-        latest=latest,
-    )
-
-
-@cli.command(name="cleanup-conversation", hidden=True)
-@click.argument("identifier", required=False, shell_complete=complete_session_identifiers)
-@click.option("--older-than", help="Remove messages older than duration (e.g., '2h', '1d', '30m')")
-@click.option("--keep-last", type=int, help="Keep only the last N messages")
-@click.option("--dry-run", is_flag=True, help="Show what would be removed without actually removing")
-@click.option("--force", is_flag=True, help="Skip confirmation prompt")
-@click.option("--list-backups", is_flag=True, help="List available backups for this session")
-@click.option("--restore-backup", help="Restore from a specific backup (timestamp)")
-@click.option("--latest", is_flag=True, help="Use the most recently active session")
-@json_option
-def cleanup_conversation_cmd(ctx: click.Context, identifier: str, older_than: str, keep_last: int, dry_run: bool, force: bool, list_backups: bool, restore_backup: str, latest: bool) -> None:
-    """[Hidden] Clean up Claude Code conversation history to reduce context size.
-
-    Use 'daf maintenance cleanup-conversation' instead.
-
-    IDENTIFIER can be either a session group name or issue tracker key.
-    If not provided or --latest is specified, uses the most recently active session.
-
-    This is useful when you hit the 413 "Prompt is too long" error during long sessions.
-    The command removes old messages from the conversation file while keeping recent context.
-
-    \b
-    Examples:
-        daf cleanup-conversation PROJ-12345 --older-than 2h        # Remove messages older than 2 hours
-        daf cleanup-conversation --latest --older-than 2h         # Clean most recent session
-        daf cleanup-conversation PROJ-12345 --keep-last 50         # Keep only last 50 messages
-        daf cleanup-conversation my-session --older-than 1d --dry-run  # Preview changes
-        daf cleanup-conversation PROJ-12345 --older-than 8h --force  # Skip confirmation
-
-    \b
-    Backup management:
-        daf cleanup-conversation PROJ-12345 --list-backups              # List all backups
-        daf cleanup-conversation PROJ-12345 --restore-backup 20251120-163147  # Restore from backup
-
-    \b
-    A backup is automatically created before cleanup (stored in $DEVAIFLOW_HOME/backups/).
-    Old backups are automatically cleaned up (keeping last 5 by default).
-    You'll need to restart Claude Code to see the effect (conversation is cached).
-    """
-    from devflow.cli.commands.cleanup_command import cleanup_conversation
-
-    cleanup_conversation(
-        identifier,
-        older_than=older_than,
-        keep_last=keep_last,
-        dry_run=dry_run,
-        force=force,
-        list_backups=list_backups,
-        restore_backup=restore_backup,
-        latest=latest,
-    )
 
 
 @cli.group()
@@ -3617,113 +3401,6 @@ def _get_config_changes(old_config, new_config) -> list:
             changes.append(f"Keyword '{keyword}' mapping changed")
 
     return changes
-
-
-@cli.command(hidden=True)
-@json_option
-def check(ctx: click.Context) -> None:
-    """[Hidden] Check external tool dependencies.
-
-    Use 'daf init --check' instead.
-
-    Verifies that all required and optional external tools are installed
-    and available in PATH. Displays version information for available tools
-    and installation URLs for missing tools.
-
-    \b
-    Required dependencies:
-      - git: Version control operations
-      - claude: Claude Code CLI for session launching
-
-    \b
-    Optional dependencies:
-      - gh: GitHub CLI for PR creation
-      - glab: GitLab CLI for MR creation
-      - pytest: Python testing framework
-
-    \b
-    Examples:
-      daf check              # Check all dependencies
-      daf check --json       # JSON output for automation
-
-    \b
-    Exit codes:
-      0: All required dependencies available
-      1: One or more required dependencies missing
-    """
-    from devflow.cli.commands.check_command import check_dependencies
-
-    output_json = ctx.obj.get('output_json', False) if ctx.obj else False
-    exit_code = check_dependencies(output_json=output_json)
-    raise SystemExit(exit_code)
-
-
-@cli.command(hidden=True)
-@json_option
-@click.argument("shell", type=click.Choice(["bash", "zsh", "fish"], case_sensitive=False), required=False)
-def completion(ctx: click.Context, shell: str) -> None:
-    """[Hidden] Install shell completion for daf command.
-
-    Shell completion is now automatically offered during 'daf init'.
-    This command remains available for manual setup if needed.
-
-    SHELL can be bash, zsh, or fish. If not specified, auto-detects your shell.
-
-    Installation instructions:
-
-    Bash:
-      Add to ~/.bashrc:
-      eval "$(_DAF_COMPLETE=bash_source daf)"
-
-    Zsh:
-      Add to ~/.zshrc:
-      eval "$(_DAF_COMPLETE=zsh_source daf)"
-
-    Fish:
-      Save to ~/.config/fish/completions/daf.fish:
-      _DAF_COMPLETE=fish_source daf > ~/.config/fish/completions/daf.fish
-
-    See COMPLETION.md for detailed instructions.
-    """
-    import os
-
-    # Auto-detect shell if not specified
-    if not shell:
-        shell_env = os.environ.get("SHELL", "")
-        if "bash" in shell_env:
-            shell = "bash"
-        elif "zsh" in shell_env:
-            shell = "zsh"
-        elif "fish" in shell_env:
-            shell = "fish"
-        else:
-            console.print("[red]Could not auto-detect shell. Please specify: daf completion [bash|zsh|fish][/red]")
-            return
-
-    shell = shell.lower()
-
-    if shell == "bash":
-        console.print("[bold]Bash Completion Setup[/bold]\n")
-        console.print("Add the following line to your ~/.bashrc:\n")
-        console.print('  [cyan]eval "$(_DAF_COMPLETE=bash_source daf)"[/cyan]\n')
-        console.print("Then reload your shell:")
-        console.print("  [cyan]source ~/.bashrc[/cyan]\n")
-
-    elif shell == "zsh":
-        console.print("[bold]Zsh Completion Setup[/bold]\n")
-        console.print("Add the following line to your ~/.zshrc:\n")
-        console.print('  [cyan]eval "$(_DAF_COMPLETE=zsh_source daf)"[/cyan]\n')
-        console.print("Then reload your shell:")
-        console.print("  [cyan]source ~/.zshrc[/cyan]\n")
-
-    elif shell == "fish":
-        console.print("[bold]Fish Completion Setup[/bold]\n")
-        console.print("Run the following command:\n")
-        console.print('  [cyan]_DAF_COMPLETE=fish_source daf > ~/.config/fish/completions/daf.fish[/cyan]\n')
-        console.print("Then reload:")
-        console.print("  [cyan]source ~/.config/fish/config.fish[/cyan]\n")
-
-    console.print("[dim]See COMPLETION.md for more details and troubleshooting.[/dim]")
 
 
 @cli.command(name="purge-mock-data", hidden=True)

--- a/devflow/session/repair.py
+++ b/devflow/session/repair.py
@@ -170,7 +170,7 @@ def truncate_content(content: any, max_size: int = 10000) -> Tuple[any, bool]:
     """
     if isinstance(content, str):
         if len(content) > max_size:
-            return content[:max_size] + f"\n\n[TRUNCATED: {len(content) - max_size} chars removed by daf repair-conversation]", True
+            return content[:max_size] + f"\n\n[TRUNCATED: {len(content) - max_size} chars removed by daf maintenance repair-conversation]", True
         return content, False
 
     elif isinstance(content, dict):

--- a/docs/migration/v3.0-migration.md
+++ b/docs/migration/v3.0-migration.md
@@ -1,0 +1,62 @@
+# v3.0 Migration Guide
+
+## Breaking Changes
+
+v3.0 removes all backward-compatibility command aliases that were hidden in v2.x. If your scripts or workflows use any of the old commands below, update them to the new syntax.
+
+## Removed Commands
+
+### Deprecated Aliases
+
+| Old Command (removed) | New Command |
+|---|---|
+| `daf sessions list` | `daf list` |
+| `daf config tui` | `daf config edit` |
+| `daf completion` | `daf init` (auto-offers shell completion) |
+
+### Merged Commands
+
+| Old Command (removed) | New Command |
+|---|---|
+| `daf edit <session>` | `daf open <session> --edit` |
+| `daf check` | `daf init --check` |
+
+### Maintenance Commands (Direct Access Removed)
+
+These commands are still available via the `daf maintenance` group:
+
+| Old Command (removed) | New Command |
+|---|---|
+| `daf cleanup-conversation` | `daf maintenance cleanup-conversation` |
+| `daf cleanup-sessions` | `daf maintenance cleanup-sessions` |
+| `daf discover` | `daf maintenance discover` |
+| `daf rebuild-index` | `daf maintenance rebuild-index` |
+| `daf repair-conversation` | `daf maintenance repair-conversation` |
+
+### Developer Utilities
+
+| Command | Status |
+|---|---|
+| `daf purge-mock-data` | Unchanged (remains hidden, developer-only) |
+
+## Other Removed Commands
+
+These commands were removed in earlier v2.x releases:
+
+| Command | Removed In | Replacement |
+|---|---|---|
+| `daf upgrade` | v2.x (#479) | `pip install --upgrade devaiflow` |
+| `daf git create` | v2.x (#474) | `gh issue create` / `glab issue create` + `daf link` |
+| `daf git check-auth` | v2.x (#473) | `gh auth status` / `glab auth status` |
+| `daf git add-comment` | v2.x (#471) | `gh issue comment` / `glab issue note` |
+
+## Migration Steps
+
+1. Search your scripts for any old command names listed above
+2. Replace with the corresponding new command
+3. Test that the new commands work as expected
+
+```bash
+# Example: find old commands in your scripts
+grep -rn 'daf edit\|daf check\b\|daf completion\|daf discover\b\|daf cleanup-sessions\|daf rebuild-index\|daf repair-conversation\|daf cleanup-conversation\|daf sessions list\|daf config tui' ~/bin/ ~/.bashrc ~/.zshrc
+```

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -4740,33 +4740,7 @@ daf open --edit broken-session
 
 ---
 
-### daf completion - Shell Auto-Completion
-
-Install shell auto-completion for daf command.
-
-```bash
-daf completion [SHELL]
-```
-
-**Supported shells:** bash, zsh, fish
-
-**Examples:**
-```bash
-# Auto-detect shell
-daf completion
-
-# Specific shell
-daf completion bash
-daf completion zsh
-daf completion fish
-```
-
-**Features:**
-- Auto-complete session names and JIRA keys
-- Auto-complete working directories, sprints, tags
-- File path completion for exports/imports
-
-See [Installation Guide](../getting-started/installation.md) for setup instructions.
+> **Removed in v3.0:** `daf completion` has been removed. Shell completion is now automatically offered during `daf init`. See [Installation Guide](../getting-started/installation.md) for manual setup instructions.
 
 ---
 
@@ -5589,8 +5563,7 @@ daf complete PROJ-12345      # Finish work
 ### Setup Commands (One-Time)
 
 ```bash
-daf init                    # Initialize config
-daf completion              # Setup auto-completion
+daf init                    # Initialize config (includes auto-completion setup)
 ```
 
 ### Maintenance (As Needed)
@@ -5655,9 +5628,12 @@ daf backup                  # Backup everything
 | `daf template` | Manage templates | No |
 | `daf open --edit` | Interactive metadata editor | No |
 | `daf update` | CLI metadata updates | No |
-| `daf completion` | Auto-completion (hidden) | No |
-| `daf check` | Check dependencies (hidden) | No |
-| `daf edit` | Metadata editor (hidden, use daf open --edit) | No |
+| `daf init --check` | Check dependencies | No |
+| `daf maintenance cleanup-conversation` | Fix 413 errors | No |
+| `daf maintenance cleanup-sessions` | Fix orphaned sessions | No |
+| `daf maintenance rebuild-index` | Rebuild session index | No |
+| `daf maintenance repair-conversation` | Repair corrupted conversations | No |
+| `daf maintenance discover` | Find unmanaged sessions | No |
 
 ## Next Steps
 

--- a/tests/test_check_command.py
+++ b/tests/test_check_command.py
@@ -1,4 +1,4 @@
-"""Tests for daf check command."""
+"""Tests for daf init --check command."""
 
 import json
 import pytest

--- a/tests/test_cleanup_sessions_command.py
+++ b/tests/test_cleanup_sessions_command.py
@@ -1,4 +1,4 @@
-"""Tests for daf cleanup-sessions command."""
+"""Tests for daf maintenance cleanup-sessions command."""
 
 import pytest
 from datetime import datetime

--- a/tests/test_discover_command.py
+++ b/tests/test_discover_command.py
@@ -1,4 +1,4 @@
-"""Tests for daf discover command."""
+"""Tests for daf maintenance discover command."""
 
 import pytest
 from datetime import datetime

--- a/tests/test_import_session_command.py
+++ b/tests/test_import_session_command.py
@@ -42,7 +42,7 @@ def test_import_session_not_found(temp_daf_home, monkeypatch, capsys):
 
     captured = capsys.readouterr()
     assert "Session nonexistent-uuid not found" in captured.out
-    assert "daf discover" in captured.out
+    assert "daf maintenance discover" in captured.out
 
 
 def test_import_session_already_managed(temp_daf_home, monkeypatch, capsys, mock_discovered_session):

--- a/tests/test_repair_conversation_command.py
+++ b/tests/test_repair_conversation_command.py
@@ -1,4 +1,4 @@
-"""Tests for daf repair-conversation command."""
+"""Tests for daf maintenance repair-conversation command."""
 
 import pytest
 from pathlib import Path

--- a/tests/test_session_editor_tui.py
+++ b/tests/test_session_editor_tui.py
@@ -504,7 +504,7 @@ def test_add_conversation_screen_edit_mode():
 def test_session_editor_tui_with_active_time_tracking(tmp_path, mock_session_manager, mock_config_loader):
     """Test SessionEditorTUI can open sessions with time_tracking_state='active'.
 
-    Regression test for PROJ-61017: daf edit crashes with InvalidSelectValueError
+    Regression test for PROJ-61017: daf open --edit crashes with InvalidSelectValueError
     when session has time_tracking_state='active'.
     """
     # Create a session with active time tracking state


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->
GitHub Issue: https://github.com/itdove/devaiflow/issues/292

## Description

V3.0 Breaking Change: Remove hidden backward-compatibility commands that were preserved during the v2.0→v3.0 migration period.

These hidden aliases allowed old command names to continue working silently, but they obscure the actual CLI surface and create maintenance burden. With v3.0 stable, the compatibility shims are no longer needed.

Changes:
- Remove hidden backward-compatibility command registrations from `devflow/cli/main.py`
- Clean up command implementations across `check`, `cleanup`, `cleanup_sessions`, `discover`, `import_session`, `rebuild_index`, and `repair_conversation` commands
- Update `devflow/session/repair.py` to reflect removed compatibility paths
- Update migration guide (`docs/migration/v3.0-migration.md`) and command reference (`docs/reference/commands.md`)
- Update tests to remove expectations for hidden aliases

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `daf --help` and verify only current v3.0 commands are listed (no hidden aliases)
3. Run old command names (e.g., any previously aliased commands) and confirm they produce an error or "unknown command" message instead of silently redirecting
4. Run the test suite: `pytest tests/test_check_command.py tests/test_cleanup_sessions_command.py tests/test_discover_command.py tests/test_import_session_command.py tests/test_repair_conversation_command.py tests/test_session_editor_tui.py`
5. Verify all tests pass

### Scenarios tested
- Confirmed hidden backward-compatibility commands no longer register in the CLI
- Verified existing v3.0 commands continue to work as expected
- Verified test suite passes after removing compatibility expectations

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: