### PR TITLE
itdove/devaiflow#453: Bump version from 2.3.0-dev to 3.0.0-dev

### DIFF
--- a/devflow/__init__.py
+++ b/devflow/__init__.py
@@ -1,3 +1,3 @@
 """DevAIFlow - AI-Powered Development Workflow Manager with JIRA integration."""
 
-__version__ = "2.3.0-dev"
+__version__ = "3.0.0-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "devaiflow"
-version = "2.3.0-dev"
+version = "3.0.0-dev"
 description = "DevAIFlow - Manage AI coding assistant sessions with optional issue tracker integration"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Jira Issue: This PR does not need a corresponding Jira item.

## Description

Bump version from 2.3.0-dev to 3.0.0-dev to align with the v3.0 breaking changes (removal of backward-compatibility commands and deprecated `daf upgrade` command).

Changes:
- Updated version string in `devflow/__init__.py`
- Updated version string in `pyproject.toml`

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `python -c "import devflow; print(devflow.__version__)"` and verify output is `3.0.0-dev`
3. Run `grep version pyproject.toml` and verify version is `3.0.0-dev`
4. Run `pip install -e .` and confirm `daf --version` reports `3.0.0-dev`

### Scenarios tested
- Verified version string updated in both `devflow/__init__.py` and `pyproject.toml`
- Confirmed package installs and reports correct version

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: