### PR TITLE
itdove/devaiflow#476: Run /simplify pass across codebase before v3.0.0 release

### DIFF
--- a/devflow/agent/factory.py
+++ b/devflow/agent/factory.py
@@ -9,11 +9,7 @@ import uuid
 from pathlib import Path
 from typing import Optional, Set
 
-from rich.console import Console
-
 from devflow.agent.interface import AgentInterface
-
-console = Console()
 from devflow.agent.claude_agent import ClaudeAgent
 from devflow.agent.github_copilot_agent import GitHubCopilotAgent
 from devflow.agent.cursor_agent import CursorAgent
@@ -168,6 +164,8 @@ def capture_agent_session_id(
     """
     if not is_self_id_backend(agent_backend) or not launch_dir or not active_conv:
         return False
+    from rich.console import Console
+    console = Console()
     try:
         sessions_after = agent.get_existing_sessions(launch_dir)
         new_sessions = sessions_after - sessions_before

--- a/devflow/cli/commands/cleanup_command.py
+++ b/devflow/cli/commands/cleanup_command.py
@@ -267,23 +267,6 @@ def cleanup_conversation(
         console.print("[green]✓[/green] Restored from backup")
 
 
-def _find_session_by_agent_id(session_manager: SessionManager, agent_id: str):
-    """Find a session by its agent session ID.
-
-    Args:
-        session_manager: SessionManager instance
-        agent_id: Agent session UUID
-
-    Returns:
-        Session if found, None otherwise
-    """
-    all_sessions = session_manager.list_sessions()
-    for session in all_sessions:
-        active_conv = session.active_conversation
-        if active_conv and active_conv.ai_agent_session_id == agent_id:
-            return session
-    return None
-
 
 def _find_conversation_file(
     ai_agent_session_id: str,

--- a/devflow/cli/commands/new_command.py
+++ b/devflow/cli/commands/new_command.py
@@ -136,16 +136,16 @@ def _generate_initial_prompt(
         prompt += f"\nAlso read the issue tracker ticket with comments:\n"
         if backend == "github":
             # Use gh/glab CLI directly for GitHub/GitLab issues
-            import re as _re
-            _num_match = _re.search(r'(\d+)$', issue_key)
-            _issue_number = _num_match.group(1) if _num_match else issue_key
             _is_gitlab = config and hasattr(config, 'issue_tracker_backend') and config.issue_tracker_backend == "gitlab"
             _cli_tool = "glab" if _is_gitlab else "gh"
-            _repo_match = _re.match(r'^([^#]+)#\d+$', issue_key)
-            if _repo_match:
-                prompt += f"{_cli_tool} issue view {_issue_number} -R {_repo_match.group(1)} --comments\n"
+            if '#' in issue_key:
+                _repo, _issue_number = issue_key.rsplit('#', 1)
+                if _repo:
+                    prompt += f"{_cli_tool} issue view {_issue_number} -R {_repo} --comments\n"
+                else:
+                    prompt += f"{_cli_tool} issue view {_issue_number} --comments\n"
             else:
-                prompt += f"{_cli_tool} issue view {_issue_number} --comments\n"
+                prompt += f"{_cli_tool} issue view {issue_key} --comments\n"
         else:
             # JIRA or other backends
             prompt += f"daf jira view {issue_key} --comments\n"

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -967,9 +967,8 @@ def open_session(
         return
 
     # Display launch/resume message using correct agent name
-    from devflow.agent import create_agent_client as _create_agent
-    _display_agent = _create_agent(effective_agent_backend)
-    _display_agent_name = _display_agent.get_agent_name().title()
+    from devflow.agent.factory import get_agent_display_name as _get_display_name
+    _display_agent_name = _get_display_name(effective_agent_backend)
     if is_first_launch:
         console.print(f"\n[cyan]Launching {_display_agent_name} for the first time...[/cyan]")
     else:
@@ -1161,6 +1160,11 @@ def open_session(
             agent_backend = effective_agent_backend
             agent = create_agent_client(agent_backend)
 
+            # Initialize self-ID capture state (used by OpenCode resume path)
+            _resume_needs_capture = False
+            _resume_sessions_before = set()
+            oc_project_path = None
+
             # For Claude and Ollama agents, use resume with skills directories
             # Other agents may not support resume in the same way
             if agent_backend in ("claude", "ollama", "ollama-claude"):
@@ -1300,11 +1304,11 @@ def open_session(
                     console.print(f"\n[green]✓[/green] {_display_agent_name} session completed")
 
                     # Capture session ID for self-ID agents if launched via fallback path
-                    if '_resume_needs_capture' in dir() and _resume_needs_capture:
+                    if _resume_needs_capture:
                         from devflow.agent.factory import capture_agent_session_id as _cap_resume
                         _cap_resume(
                             agent, agent_backend,
-                            oc_project_path if 'oc_project_path' in dir() else None,
+                            oc_project_path,
                             active_conv, _resume_sessions_before,
                         )
 

--- a/devflow/cli/commands/setup_command.py
+++ b/devflow/cli/commands/setup_command.py
@@ -103,11 +103,6 @@ def _deep_merge_recursive(
                 if item not in base[key]:
                     base[key].append(item)
                     added.append(f"{path}[]")
-        elif isinstance(value, list) and isinstance(base[key], list):
-            for item in value:
-                if item not in base[key]:
-                    base[key].append(item)
-                    added.append(f"{path}[]")
 
 
 def resolve_target_path(backend: str, scope: str) -> Path:


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN>
<!-- This PR does not need a corresponding Jira item. -->

## Description
Run `/simplify` pass across the codebase before v3.0.0 release. Code quality cleanup with no functional changes:

- **factory.py**: Removed unused top-level `Console` import and `console` variable; moved to lazy import inside `capture_agent_session_id()` where actually used
- **cleanup_command.py**: Removed dead code — unused `_find_session_by_agent_id()` function
- **new_command.py**: Replaced regex-based GitHub/GitLab issue key parsing with simpler string split on `#`
- **open_command.py**: Replaced `create_agent_client()` instantiation (used only for display name) with lighter `get_agent_display_name()` call; initialized self-ID capture variables before the branch that uses them instead of relying on `dir()` checks
- **setup_command.py**: Removed duplicate `elif` branch in `_deep_merge_recursive()` that was identical to the preceding `if` branch

Net result: -20 lines, no behavior changes.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run `pytest` to confirm no regressions
3. Run `daf new` with a GitHub issue key containing `#` (e.g., `owner/repo#123`) and verify the generated prompt uses the correct `gh issue view` command
4. Run `daf open` to resume a session and verify agent display name shows correctly
5. Run `daf setup` and verify deep merge of list-type config values still works

### Scenarios tested
- All existing unit tests pass
- Issue key parsing handles `owner/repo#123`, `#123`, and bare `123` formats
- Agent display name resolution works without instantiating a full agent client

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: