### PR TITLE
itdove/devaiflow#483: Extract resolve_agent_backend() helper to eliminate ~45 repeated expressions

### DIFF
--- a/devflow/agent/factory.py
+++ b/devflow/agent/factory.py
@@ -62,6 +62,36 @@ SELF_ID_BACKENDS = ("opencode", "opencode-ai")
 PENDING_CAPTURE_PLACEHOLDER = "pending-capture"
 
 
+def resolve_agent_backend(
+    cli_override: Optional[str] = None,
+    session=None,
+    config=None,
+) -> str:
+    """Resolve the effective agent backend from the fallback chain.
+
+    Priority: cli_override > session.agent_backend > config.agent_backend > "claude"
+
+    Args:
+        cli_override: Explicit backend from CLI ``--agent`` flag.
+        session: Session object with an ``agent_backend`` attribute.
+        config: Config object with an ``agent_backend`` attribute.
+
+    Returns:
+        Resolved backend identifier, never ``None``.
+    """
+    if cli_override:
+        return cli_override
+    if session:
+        backend = getattr(session, "agent_backend", None)
+        if backend:
+            return backend
+    if config:
+        backend = getattr(config, "agent_backend", None)
+        if backend:
+            return backend
+    return "claude"
+
+
 def is_self_id_backend(backend: str) -> bool:
     """Check if an agent backend generates its own session IDs.
 

--- a/devflow/backup/manager.py
+++ b/devflow/backup/manager.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from devflow.agent.factory import resolve_agent_backend
 from devflow.archive.base import ArchiveManagerBase
 from devflow.config.loader import ConfigLoader
 from devflow.config.models import Session
@@ -35,7 +36,7 @@ class BackupManager(ArchiveManagerBase):
         """
         try:
             config = self.config_loader.load_config()
-            return config.agent_backend if config else "claude"
+            return resolve_agent_backend(config=config)
         except Exception:
             return "claude"
 

--- a/devflow/cli/commands/active_command.py
+++ b/devflow/cli/commands/active_command.py
@@ -6,6 +6,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 from devflow.agent import create_agent_client, get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import get_active_conversation, output_json as json_output, serialize_session
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
@@ -109,7 +110,7 @@ def show_active(output_json: bool = False) -> None:
         # Get token usage if available
         token_usage = None
         if conversation.project_path and conversation.ai_agent_session_id:
-            agent_backend = config.agent_backend if config else "claude"
+            agent_backend = resolve_agent_backend(config=config)
             token_usage = _get_token_usage(
                 conversation.ai_agent_session_id,
                 conversation.project_path,
@@ -161,7 +162,7 @@ def show_active(output_json: bool = False) -> None:
     # Get token usage for display
     token_usage_display = None
     if conversation.project_path and conversation.ai_agent_session_id:
-        agent_backend = config.agent_backend if config else "claude"
+        agent_backend = resolve_agent_backend(config=config)
         token_usage_display = _get_token_usage(
             conversation.ai_agent_session_id,
             conversation.project_path,
@@ -228,7 +229,7 @@ def show_active(output_json: bool = False) -> None:
         padding=(1, 2),
     )
 
-    agent_backend = config.agent_backend if config else "claude"
+    agent_backend = resolve_agent_backend(config=config)
     agent_name = get_agent_display_name(agent_backend)
 
     console.print()

--- a/devflow/cli/commands/agent_commands.py
+++ b/devflow/cli/commands/agent_commands.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Optional, Any
 from rich.console import Console
 from rich.table import Table
 
-from devflow.agent.factory import create_agent_client, get_agent_display_name
+from devflow.agent.factory import create_agent_client, get_agent_display_name, resolve_agent_backend
 from devflow.cli.utils import require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.utils.dependencies import check_tool_available, get_tool_version
@@ -225,7 +225,7 @@ def list_agents(output_json: bool = False) -> None:
     config_loader = ConfigLoader()
     try:
         config = config_loader.load_config()
-        default_agent = config.agent_backend if config else "claude"
+        default_agent = resolve_agent_backend(config=config)
     except Exception:
         default_agent = "claude"
 
@@ -405,7 +405,7 @@ def test_agent(agent_name: Optional[str] = None, output_json: bool = False) -> N
         config_loader = ConfigLoader()
         try:
             config = config_loader.load_config()
-            agent_name = config.agent_backend if config else "claude"
+            agent_name = resolve_agent_backend(config=config)
         except Exception:
             agent_name = "claude"
 
@@ -490,7 +490,7 @@ def show_agent_info(agent_name: Optional[str] = None, output_json: bool = False)
         config_loader = ConfigLoader()
         try:
             config = config_loader.load_config()
-            agent_name = config.agent_backend if config else "claude"
+            agent_name = resolve_agent_backend(config=config)
         except Exception:
             agent_name = "claude"
 

--- a/devflow/cli/commands/cleanup_command.py
+++ b/devflow/cli/commands/cleanup_command.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.prompt import Confirm
 
 from devflow.agent import get_agent_display_name, create_agent_client
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
@@ -46,7 +47,7 @@ def cleanup_conversation(
     config_loader = ConfigLoader()
     config = config_loader.load_config()
     session_manager = SessionManager(config_loader)
-    agent_name = get_agent_display_name(config.agent_backend if config else None)
+    agent_name = get_agent_display_name(resolve_agent_backend(config=config))
 
     # Handle --latest flag
     if latest:
@@ -286,7 +287,7 @@ def _find_conversation_file(
     Returns:
         Path to conversation file if found, None otherwise
     """
-    agent_backend = config.agent_backend if config else "claude"
+    agent_backend = resolve_agent_backend(config=config)
     agent = create_agent_client(agent_backend)
 
     # If we have a project_path, try the direct path first

--- a/devflow/cli/commands/cleanup_sessions_command.py
+++ b/devflow/cli/commands/cleanup_sessions_command.py
@@ -7,6 +7,7 @@ from rich.console import Console
 from rich.prompt import Confirm
 from rich.table import Table
 
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import get_status_display, require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.session.capture import SessionCapture
@@ -32,7 +33,7 @@ def cleanup_sessions(dry_run: bool = False, force: bool = False) -> None:
     config = config_loader.load_config()
 
     from devflow.agent import create_agent_client
-    agent_backend = config.agent_backend if config else "claude"
+    agent_backend = resolve_agent_backend(config=config)
     agent = create_agent_client(agent_backend)
     capture = SessionCapture(agent=agent)
 

--- a/devflow/cli/commands/complete_command.py
+++ b/devflow/cli/commands/complete_command.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
 from devflow.agent import get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import add_jira_comment, get_session_with_prompt, get_status_display, is_non_interactive, require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.exceptions import ToolNotFoundError
@@ -246,7 +247,7 @@ def complete_session(
     config = config_loader.load_config()
 
     # Resolve agent backend for agent-agnostic messaging
-    agent_backend = config.agent_backend if config else None
+    agent_backend = resolve_agent_backend(config=config)
 
     # Get active conversation for accessing conversation-specific fields
     active_conv = session.active_conversation
@@ -1257,7 +1258,7 @@ def _add_session_summary_to_jira(issue_key: str, session_name: str, session, hou
                 prose_summary = generate_prose_summary(
                     summary_data,
                     mode="ai",
-                    agent_backend=config.agent_backend if config else None
+                    agent_backend=resolve_agent_backend(config=config)
                 )
                 if prose_summary:
                     # Add newlines before and after for better formatting
@@ -1334,7 +1335,7 @@ def _add_session_summary_to_github(issue_key: str, session_name: str, session, h
                 prose_summary = generate_prose_summary(
                     summary_data,
                     mode="ai",
-                    agent_backend=config.agent_backend if config else None
+                    agent_backend=resolve_agent_backend(config=config)
                 )
                 if prose_summary:
                     prose_summary = f"\n\n{prose_summary}\n"
@@ -1438,7 +1439,7 @@ def _sync_branch_for_export(session, issue_key: str, config_loader, yes: bool = 
         else:
             # Create WIP commit
             co_authored_by = get_co_authored_by_line(config, session.model_profile)
-            generated_with = _get_generated_with_line(config.agent_backend if config else None)
+            generated_with = _get_generated_with_line(resolve_agent_backend(config=config))
             commit_message = f"""WIP: Session export for {issue_key}
 
 {generated_with}
@@ -2977,7 +2978,7 @@ def _generate_pr_description(session, working_dir: Path, config_loader: ConfigLo
                 jira_section = f"Jira Issue: {jira_url}/browse/{session.issue_key}\n\n"
 
         # Try to generate AI-powered summary from session and git data
-        summary_bullets = _generate_pr_summary_bullets(session, working_dir, agent_backend=config.agent_backend if config else None)
+        summary_bullets = _generate_pr_summary_bullets(session, working_dir, agent_backend=resolve_agent_backend(config=config))
 
         # If AI summary failed, fall back to session goal
         if not summary_bullets:
@@ -2987,7 +2988,7 @@ def _generate_pr_description(session, working_dir: Path, config_loader: ConfigLo
 
         config = config_loader.load_config()
         co_authored_by = get_co_authored_by_line(config, session.model_profile)
-        generated_with = _get_generated_with_line(config.agent_backend if config else None)
+        generated_with = _get_generated_with_line(resolve_agent_backend(config=config))
         description = f"""{jira_section}{description_content}
 
 ## Test plan

--- a/devflow/cli/commands/delete_command.py
+++ b/devflow/cli/commands/delete_command.py
@@ -7,6 +7,7 @@ from rich.console import Console
 from rich.prompt import Confirm, IntPrompt
 
 from devflow.agent import get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import get_session_with_delete_all_option, get_status_display, require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
@@ -27,7 +28,7 @@ def delete_session(identifier: Optional[str] = None, delete_all: bool = False, f
     """
     config_loader = ConfigLoader()
     config = config_loader.load_config()
-    agent_name = get_agent_display_name(config.agent_backend if config else None)
+    agent_name = get_agent_display_name(resolve_agent_backend(config=config))
     session_manager = SessionManager(config_loader)
 
     # Handle --all flag
@@ -138,7 +139,7 @@ def _delete_all_sessions(session_manager: SessionManager, config_loader: ConfigL
         keep_metadata: Keep session files (notes, metadata) on disk
     """
     config = config_loader.load_config()
-    agent_name = get_agent_display_name(config.agent_backend if config else None)
+    agent_name = get_agent_display_name(resolve_agent_backend(config=config))
 
     # Get all sessions
     all_sessions = session_manager.list_sessions()

--- a/devflow/cli/commands/discover_command.py
+++ b/devflow/cli/commands/discover_command.py
@@ -4,6 +4,7 @@ from rich.console import Console
 from rich.table import Table
 
 from devflow.agent import get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.session.discovery import SessionDiscovery
@@ -17,7 +18,7 @@ def discover_sessions() -> None:
     """Discover existing AI agent sessions not managed by daf tool."""
     config_loader = ConfigLoader()
     config = config_loader.load_config()
-    agent_name = get_agent_display_name(config.agent_backend if config else None)
+    agent_name = get_agent_display_name(resolve_agent_backend(config=config))
     session_manager = SessionManager(config_loader)
     discovery = SessionDiscovery()
 

--- a/devflow/cli/commands/git_new_command.py
+++ b/devflow/cli/commands/git_new_command.py
@@ -12,6 +12,7 @@ from rich.prompt import Prompt, Confirm
 
 from devflow.cli.utils import console_print, get_workspace_path, is_json_mode, output_json, require_outside_claude, scan_workspace_repositories, select_workspace, should_launch_claude_code, unified_project_selection
 from devflow.agent import get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.commands.sync_command import issue_key_to_session_name
 from devflow.git.utils import GitUtils
 
@@ -586,7 +587,7 @@ def create_git_issue_session(
         working_directory=working_directory,
         project_path=project_path,
         branch=branch,
-        agent_backend=agent or (config.agent_backend if config else "claude"),
+        agent_backend=resolve_agent_backend(cli_override=agent, config=config),
     )
 
     # Set session_type to "ticket_creation"
@@ -652,7 +653,7 @@ def create_git_issue_session(
         return
 
     # Check if we should launch Claude Code
-    agent_name = get_agent_display_name(agent or (config.agent_backend if config else "claude"))
+    agent_name = get_agent_display_name(resolve_agent_backend(cli_override=agent, config=config))
     if not should_launch_claude_code(config=config, mock_mode=False):
         console_print(f"[yellow]⚠[/yellow] Session created but {agent_name} not launched.")
         console_print(f"  Run [cyan]daf open {name}[/cyan] to start working on it.")
@@ -660,7 +661,7 @@ def create_git_issue_session(
 
     # Generate a new agent session ID (agent-aware: placeholder for self-ID backends)
     from devflow.agent.factory import generate_agent_session_id
-    _agent_backend_for_id = agent or (config.agent_backend if config else "claude")
+    _agent_backend_for_id = resolve_agent_backend(cli_override=agent, config=config)
     ai_agent_session_id = generate_agent_session_id(_agent_backend_for_id)
 
     # Update session with Claude session ID
@@ -717,7 +718,7 @@ def create_git_issue_session(
         # Get agent backend from config
         from devflow.agent import create_agent_client
 
-        agent_backend = agent or (config.agent_backend if config else "claude")
+        agent_backend = resolve_agent_backend(cli_override=agent, config=config)
         agent_name = get_agent_display_name(agent_backend)
         agent_client = create_agent_client(agent_backend)
 
@@ -1116,7 +1117,7 @@ def _create_multi_project_git_session(
     session_manager.update_session(session)
 
     # Check if we should launch Claude Code
-    agent_name = get_agent_display_name(config.agent_backend if config else "claude")
+    agent_name = get_agent_display_name(resolve_agent_backend(config=config))
     if not should_launch_claude_code(config=config, mock_mode=False):
         console_print(f"[yellow]⚠[/yellow] Session created but {agent_name} not launched.")
         console_print(f"  Run [cyan]daf open {name}[/cyan] to start working on it.")

--- a/devflow/cli/commands/git_open_command.py
+++ b/devflow/cli/commands/git_open_command.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Optional
 from rich.console import Console
 
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import console_print, require_outside_claude, is_json_mode, output_json
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
@@ -148,7 +149,7 @@ def git_open_session(
         working_directory=working_directory,
         project_path=project_path,
         branch=None,  # Will be set when user starts working
-        agent_backend=config.agent_backend if config else "claude",
+        agent_backend=resolve_agent_backend(config=config),
     )
 
     # Set session_type to "development"

--- a/devflow/cli/commands/import_session_command.py
+++ b/devflow/cli/commands/import_session_command.py
@@ -7,6 +7,7 @@ from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
 from devflow.agent import get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import get_status_display, is_non_interactive, require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.session.discovery import SessionDiscovery
@@ -208,7 +209,7 @@ def import_session(uuid: str, issue_key: str = None, goal: str = None, path: str
     console.print(f"📂 Path: {project_path}")
     console.print(f"💬 Messages: {session.active_conversation.message_count if session.active_conversation else 0}")
     config = config_loader.load_config()
-    agent_name = get_agent_display_name(config.agent_backend if config else None)
+    agent_name = get_agent_display_name(resolve_agent_backend(config=config))
     console.print(f"🆔 {agent_name} Session ID: {uuid}")
     console.print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
     console.print()

--- a/devflow/cli/commands/info_command.py
+++ b/devflow/cli/commands/info_command.py
@@ -14,6 +14,7 @@ from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
 from devflow.config.models import Session, ConversationContext
 from devflow.agent import create_agent_client, get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 
 console = Console()
 
@@ -148,7 +149,7 @@ def _output_json_session_info(
         # Add conversation file paths 
         if session.conversations:
             config = config_loader.load_config()
-            _ab = config.agent_backend or "claude" if config else "claude"
+            _ab = resolve_agent_backend(config=config)
             conversations_with_paths = []
             conv_number = 1
             for working_dir, conversation in session.conversations.items():
@@ -378,7 +379,7 @@ def _display_conversation(
     # Resolve agent display name for labels
     try:
         config = config_loader.load_config()
-        _agent_backend = config.agent_backend or "claude"
+        _agent_backend = resolve_agent_backend(config=config)
     except Exception:
         _agent_backend = "claude"
     _agent_name = get_agent_display_name(_agent_backend)
@@ -440,7 +441,7 @@ def _display_token_usage(conv: ConversationContext, config_loader: ConfigLoader)
     try:
         # Create agent client
         config = config_loader.load_config()
-        agent_backend = config.agent_backend or "claude"
+        agent_backend = resolve_agent_backend(config=config)
         agent = create_agent_client(agent_backend)
 
         # Extract token usage

--- a/devflow/cli/commands/investigate_command.py
+++ b/devflow/cli/commands/investigate_command.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from rich.prompt import Prompt, Confirm
 
 from devflow.agent import get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import console_print, get_workspace_path, is_json_mode, output_json, require_outside_claude, resolve_workspace_path, scan_workspace_repositories, select_workspace, should_launch_claude_code, unified_project_selection
 from devflow.git.utils import GitUtils
 from devflow.utils.backend_detection import detect_backend_from_key
@@ -584,7 +585,7 @@ def create_investigation_session(
         project_path=project_path,
         branch=None,  # No branch for investigation sessions
         model_profile=model_profile,
-        agent_backend=agent or (config.agent_backend if config else "claude"),
+        agent_backend=resolve_agent_backend(cli_override=agent, config=config),
     )
 
     # Set session_type to "investigation"
@@ -628,7 +629,7 @@ def create_investigation_session(
         return
 
     # Resolve agent display name for user-facing messages
-    agent_backend = agent or (config.agent_backend if config else "claude")
+    agent_backend = resolve_agent_backend(cli_override=agent, config=config)
     agent_name = get_agent_display_name(agent_backend)
 
     # Check if we should launch Claude Code
@@ -708,7 +709,7 @@ def create_investigation_session(
         # Get agent backend from config
         from devflow.agent import create_agent_client
 
-        agent_backend = agent or (config.agent_backend if config else "claude")
+        agent_backend = resolve_agent_backend(cli_override=agent, config=config)
         agent_client = create_agent_client(agent_backend)
 
         # Get model provider profile if configured
@@ -1110,7 +1111,7 @@ def _create_multi_project_investigation_session(
     session_manager.update_session(session)
 
     # Resolve agent display name for user-facing messages
-    agent_backend = config.agent_backend if config else "claude"
+    agent_backend = resolve_agent_backend(config=config)
     agent_name = get_agent_display_name(agent_backend)
 
     # Check if we should launch the AI agent
@@ -1166,7 +1167,7 @@ def _create_multi_project_investigation_session(
         # Get agent backend from config
         from devflow.agent import create_agent_client
 
-        _agent_backend = config.agent_backend if config else "claude"
+        _agent_backend = resolve_agent_backend(config=config)
         agent_client = create_agent_client(_agent_backend)
 
         # Get model provider profile if configured

--- a/devflow/cli/commands/jira_new_command.py
+++ b/devflow/cli/commands/jira_new_command.py
@@ -12,6 +12,7 @@ from rich.prompt import Prompt, Confirm
 
 from devflow.cli.utils import console_print, get_workspace_path, is_json_mode, output_json, require_outside_claude, scan_workspace_repositories, select_workspace, should_launch_claude_code, unified_project_selection
 from devflow.agent import get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.git.utils import GitUtils
 
 # Import unified utilities
@@ -482,7 +483,7 @@ def create_jira_ticket_session(
         working_directory=working_directory,
         project_path=project_path,
         branch=branch,  # Use provided branch or None for no branch
-        agent_backend=agent or (config.agent_backend if config else "claude"),
+        agent_backend=resolve_agent_backend(cli_override=agent, config=config),
     )
 
     # Set session_type to "ticket_creation"
@@ -540,7 +541,7 @@ def create_jira_ticket_session(
         return
 
     # Check if we should launch Claude Code
-    agent_name = get_agent_display_name(agent or (config.agent_backend if config else "claude"))
+    agent_name = get_agent_display_name(resolve_agent_backend(cli_override=agent, config=config))
     if not should_launch_claude_code(config=config, mock_mode=False):
         console_print(f"[yellow]⚠[/yellow] Session created but {agent_name} not launched.")
         console_print(f"  Run [cyan]daf open {name}[/cyan] to start working on it.")
@@ -548,7 +549,7 @@ def create_jira_ticket_session(
 
     # Generate a new agent session ID (agent-aware: placeholder for self-ID backends)
     from devflow.agent.factory import generate_agent_session_id
-    _agent_backend_for_id = agent or (config.agent_backend if config else "claude")
+    _agent_backend_for_id = resolve_agent_backend(cli_override=agent, config=config)
     ai_agent_session_id = generate_agent_session_id(_agent_backend_for_id)
 
     # Update session with Claude session ID
@@ -608,7 +609,7 @@ def create_jira_ticket_session(
         # Get agent backend from config
         from devflow.agent import create_agent_client
 
-        agent_backend = agent or (config.agent_backend if config else "claude")
+        agent_backend = resolve_agent_backend(cli_override=agent, config=config)
         agent_name = get_agent_display_name(agent_backend)
         agent_client = create_agent_client(agent_backend)
 
@@ -1121,7 +1122,7 @@ def _create_multi_project_jira_session(
     )
 
     # Check if we should launch Claude Code
-    agent_name = get_agent_display_name(config.agent_backend if config else "claude")
+    agent_name = get_agent_display_name(resolve_agent_backend(config=config))
     if not should_launch_claude_code(config=config, mock_mode=False):
         console_print(f"[yellow]⚠[/yellow] Session created but {agent_name} not launched.")
         console_print(f"  Run [cyan]daf open {name}[/cyan] to start working on it.")

--- a/devflow/cli/commands/jira_open_command.py
+++ b/devflow/cli/commands/jira_open_command.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Optional
 from rich.console import Console
 
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import console_print, require_outside_claude, is_json_mode, output_json
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
@@ -125,7 +126,7 @@ def jira_open_session(issue_key: str, headless: bool = False, auto_approve: bool
         working_directory=working_directory,
         project_path=project_path,
         branch=None,  # No branch for ticket creation sessions
-        agent_backend=config.agent_backend if config else "claude",
+        agent_backend=resolve_agent_backend(config=config),
     )
 
     # Set session_type to "ticket_creation"

--- a/devflow/cli/commands/list_command.py
+++ b/devflow/cli/commands/list_command.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from devflow.agent import create_agent_client
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import get_active_conversation, get_status_display, output_json as json_output, serialize_session, serialize_sessions
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
@@ -122,7 +123,7 @@ def _display_page(
         active_session_name = active_session.name
 
     # Get agent backend for token extraction
-    agent_backend = config.agent_backend if config else "claude"
+    agent_backend = resolve_agent_backend(config=config)
 
     # Create table
     table = Table(title="Your Sessions", show_header=True, header_style="bold magenta")
@@ -420,7 +421,7 @@ def list_sessions(
 
         # Get agent backend for token extraction
         config = config_loader.load_config()
-        agent_backend = config.agent_backend if config else "claude"
+        agent_backend = resolve_agent_backend(config=config)
 
         # Output JSON with token usage data
         json_output(

--- a/devflow/cli/commands/new_command.py
+++ b/devflow/cli/commands/new_command.py
@@ -630,8 +630,8 @@ def create_new_session(
             branch = branch_result
 
     # Generate session ID upfront (agent-aware: placeholder for self-ID backends)
-    from devflow.agent.factory import generate_agent_session_id
-    _agent_backend_for_id = agent or (config.agent_backend if config else "claude")
+    from devflow.agent.factory import generate_agent_session_id, resolve_agent_backend
+    _agent_backend_for_id = resolve_agent_backend(cli_override=agent, config=config)
     session_id = generate_agent_session_id(_agent_backend_for_id)
 
     # Build concatenated goal for storage
@@ -779,7 +779,7 @@ def create_new_session(
             branch=branch,
             ai_agent_session_id=session_id,
             model_profile=model_profile,
-            agent_backend=agent or (config.agent_backend if config else "claude"),
+            agent_backend=resolve_agent_backend(cli_override=agent, config=config),
         )
 
         # Set base_branch to source_branch if available (fixes #139 - no sync prompt after creating branch)
@@ -821,7 +821,7 @@ def create_new_session(
         _display_session_banner(name, session.goal, working_directory, branch, project_path, session_id, issue_key, jira_url)
 
     # Resolve agent backend and display name
-    _agent_backend = agent or (config.agent_backend if config else "claude")
+    _agent_backend = resolve_agent_backend(cli_override=agent, config=config)
     agent_name = get_agent_display_name(_agent_backend)
 
     # Check if we should launch Claude Code
@@ -860,7 +860,7 @@ def create_new_session(
         # Get agent backend from config
         from devflow.agent import create_agent_client
 
-        agent_backend = agent or (config.agent_backend if config else "claude")
+        agent_backend = resolve_agent_backend(cli_override=agent, config=config)
         agent_client = create_agent_client(agent_backend)
 
         # Get model provider profile if configured

--- a/devflow/cli/commands/new_command_multiproject.py
+++ b/devflow/cli/commands/new_command_multiproject.py
@@ -9,6 +9,7 @@ from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
 from devflow.agent import get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import (
     console_print,
     get_status_display,
@@ -234,7 +235,7 @@ def create_multi_project_session(
     # Create new session with multi-project conversation
     # Use ONE shared session ID for all projects (agent-aware)
     from devflow.agent.factory import generate_agent_session_id
-    _agent_backend_for_id = config.agent_backend if config else "claude"
+    _agent_backend_for_id = resolve_agent_backend(config=config)
     session_id = generate_agent_session_id(_agent_backend_for_id)
 
     # Build projects_info dict for multi-project conversation
@@ -258,7 +259,7 @@ def create_multi_project_session(
         branch=None,
         ai_agent_session_id=None,  # Will be set by add_multi_project_conversation
         model_profile=model_profile,
-        agent_backend=config.agent_backend if config else "claude",
+        agent_backend=resolve_agent_backend(config=config),
     )
 
     # Add multi-project conversation (ONE conversation for all projects)
@@ -331,7 +332,7 @@ def create_multi_project_session(
     )
 
     # Launch AI agent at workspace level (not individual project)
-    agent_backend = config.agent_backend if config else "claude"
+    agent_backend = resolve_agent_backend(config=config)
     agent_name = get_agent_display_name(agent_backend)
     if should_launch_claude_code(config):
         console.print(f"[cyan]Launching {agent_name} at workspace level...[/cyan]\n")

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -22,6 +22,7 @@ from devflow.jira.exceptions import JiraError, JiraAuthError, JiraApiError, Jira
 from devflow.github import transition_on_start as github_transition_on_start
 from devflow.issue_tracker.exceptions import IssueTrackerApiError, IssueTrackerAuthError, IssueTrackerNotFoundError
 from devflow.agent import get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.utils.backend_detection import get_issue_tracker_backend
 from devflow.session.capture import SessionCapture
 from devflow.session.manager import SessionManager
@@ -474,7 +475,7 @@ def open_session(
             workspace=workspace_path,
         )
 
-        agent_name = get_agent_display_name(agent or (session.agent_backend if session else None) or (config.agent_backend if config else None))
+        agent_name = get_agent_display_name(resolve_agent_backend(cli_override=agent, session=session, config=config))
         console.print(f"[green]✓[/green] Created new conversation with fresh {agent_name} session")
         console.print(f"[dim]New session ID: {new_conv.ai_agent_session_id}[/dim]")
 
@@ -573,7 +574,7 @@ def open_session(
     is_first_launch = not has_real_session_id
 
     # Resolve effective agent backend: --agent flag > session-stored > config > "claude" (backward compatible)
-    effective_agent_backend = agent or session.agent_backend or (config.agent_backend if config else "claude")
+    effective_agent_backend = resolve_agent_backend(cli_override=agent, session=session, config=config)
     agent_name = get_agent_display_name(effective_agent_backend)
 
     if active_conv and active_conv.ai_agent_session_id and active_conv.project_path:
@@ -2422,7 +2423,7 @@ def _create_conversation_from_workspace_selection(
 
     # Generate a new session ID for this conversation (agent-aware)
     from devflow.agent.factory import generate_agent_session_id
-    _backend = session.agent_backend or "claude"
+    _backend = resolve_agent_backend(session=session)
     new_session_id = generate_agent_session_id(_backend)
 
     # Get workspace for portable paths
@@ -2448,7 +2449,7 @@ def _create_conversation_from_workspace_selection(
     # Save the session
     session_manager.update_session(session)
 
-    _agent_name = get_agent_display_name(getattr(session, 'agent_backend', None) or (config.agent_backend if config else None))
+    _agent_name = get_agent_display_name(resolve_agent_backend(session=session, config=config))
     console.print(f"[green]✓[/green] Created conversation for {repo_name}")
     console.print(f"[dim]Project path: {project_path}[/dim]")
     console.print(f"[dim]{_agent_name} session ID: {new_session_id}[/dim]")
@@ -2493,7 +2494,7 @@ def _create_conversation_for_path(
 
     # Generate a new session ID for this conversation (agent-aware)
     from devflow.agent.factory import generate_agent_session_id
-    _backend = session.agent_backend or "claude"
+    _backend = resolve_agent_backend(session=session)
     new_session_id = generate_agent_session_id(_backend)
 
     # Get workspace for portable paths
@@ -2520,7 +2521,7 @@ def _create_conversation_for_path(
     # Save the session
     session_manager.update_session(session)
 
-    _agent_name = get_agent_display_name(getattr(session, 'agent_backend', None) or (config.agent_backend if config else None))
+    _agent_name = get_agent_display_name(resolve_agent_backend(session=session, config=config))
     console.print(f"[green]✓[/green] Created conversation for {repo_name}")
     console.print(f"[dim]Project path: {project_path}[/dim]")
     console.print(f"[dim]{_agent_name} session ID: {new_session_id}[/dim]")
@@ -2579,7 +2580,7 @@ def _create_conversation_for_current_directory(
 
     # Generate a new session ID for this conversation (agent-aware)
     from devflow.agent.factory import generate_agent_session_id
-    _backend = session.agent_backend or "claude"
+    _backend = resolve_agent_backend(session=session)
     new_session_id = generate_agent_session_id(_backend)
 
     # Get workspace for portable paths
@@ -2606,7 +2607,7 @@ def _create_conversation_for_current_directory(
     # Save the session
     session_manager.update_session(session)
 
-    _agent_name = get_agent_display_name(getattr(session, 'agent_backend', None) or (config.agent_backend if config else None))
+    _agent_name = get_agent_display_name(resolve_agent_backend(session=session, config=config))
     console.print(f"[green]✓[/green] Created conversation for {repo_name}")
     console.print(f"[dim]Project path: {project_path}[/dim]")
     console.print(f"[dim]{_agent_name} session ID: {new_session_id}[/dim]")
@@ -2788,7 +2789,7 @@ def _create_multi_project_conversation_for_open(
 
     # Create ONE shared session ID for all projects (agent-aware)
     from devflow.agent.factory import generate_agent_session_id
-    _backend = session.agent_backend or "claude"
+    _backend = resolve_agent_backend(session=session)
     session_id = generate_agent_session_id(_backend)
 
     # Build projects_info dict for multi-project conversation
@@ -2944,7 +2945,7 @@ def _prompt_for_working_directory(
             workspace = config.repos.get_default_workspace_path() if config and config.repos else None
 
         from devflow.agent.factory import generate_agent_session_id
-        _backend = session.agent_backend or "claude"
+        _backend = resolve_agent_backend(session=session)
         session.add_conversation(
             working_dir=project_path.name,
             ai_agent_session_id=generate_agent_session_id(_backend),
@@ -3401,7 +3402,7 @@ def _copy_conversation_to_temp(session, temp_dir: str, config=None) -> bool:
     # Get conversation file from stable location (based on original_project_path)
     # Use session's stored agent_backend for correct path resolution
     from devflow.agent import create_agent_client
-    effective_backend = (session.agent_backend if hasattr(session, 'agent_backend') and session.agent_backend else None) or (config.agent_backend if config else "claude")
+    effective_backend = resolve_agent_backend(session=session, config=config)
     agent = create_agent_client(effective_backend)
 
     # Conversation file copy only applies to file-based agents (claude, ollama)
@@ -3467,7 +3468,7 @@ def _copy_conversation_from_temp(session, temp_dir: str, config=None) -> bool:
     # Use resolved path to handle macOS /var -> /private/var canonicalization
     # SessionCapture now correctly encodes underscores as dashes
     from devflow.agent import create_agent_client
-    effective_backend = (session.agent_backend if hasattr(session, 'agent_backend') and session.agent_backend else None) or (config.agent_backend if config else "claude")
+    effective_backend = resolve_agent_backend(session=session, config=config)
     agent = create_agent_client(effective_backend)
 
     # Conversation file copy only applies to file-based agents (claude, ollama)

--- a/devflow/cli/commands/setup_command.py
+++ b/devflow/cli/commands/setup_command.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from rich.console import Console
 from rich.table import Table
 
+from devflow.agent.factory import resolve_agent_backend
+
 console = Console()
 
 BACKEND_ALIASES = {
@@ -171,7 +173,7 @@ def setup_agent_config(
     try:
         config_loader = ConfigLoader()
         config = config_loader.load_config(validate=False)
-        backend = config.agent_backend or "claude"
+        backend = resolve_agent_backend(config=config)
     except Exception:
         backend = "claude"
 

--- a/devflow/cli/commands/summary_command.py
+++ b/devflow/cli/commands/summary_command.py
@@ -3,6 +3,7 @@
 from rich.console import Console
 
 from devflow.agent import get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import get_session_with_prompt, display_session_header
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
@@ -111,7 +112,7 @@ def show_summary(identifier: str = None, detail: bool = False, ai_summary: bool 
                     prose = generate_prose_summary(
                         summary,
                         mode=summary_mode,
-                        agent_backend=config.agent_backend if config else None
+                        agent_backend=resolve_agent_backend(config=config)
                     )
 
                     # Show indicator if using AI

--- a/devflow/cli/commands/ticket_creation_multiproject.py
+++ b/devflow/cli/commands/ticket_creation_multiproject.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional
 
 from rich.console import Console
 
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import console_print
 from devflow.git.utils import GitUtils
 from devflow.session.manager import SessionManager
@@ -61,7 +62,7 @@ def create_multi_project_ticket_creation_session(
 
     # Create ONE shared session ID for all projects (agent-aware)
     from devflow.agent.factory import generate_agent_session_id
-    _agent_backend_for_id = config.agent_backend if config else "claude"
+    _agent_backend_for_id = resolve_agent_backend(config=config)
     session_id = generate_agent_session_id(_agent_backend_for_id)
 
     # Build projects_info dict for multi-project conversation
@@ -96,7 +97,7 @@ def create_multi_project_ticket_creation_session(
         project_path=None,
         branch=None,
         ai_agent_session_id=None,  # Will be set by add_multi_project_conversation
-        agent_backend=config.agent_backend if config else "claude",
+        agent_backend=resolve_agent_backend(config=config),
     )
 
     # Set session_type to "ticket_creation"

--- a/devflow/cli/commands/update_command.py
+++ b/devflow/cli/commands/update_command.py
@@ -4,6 +4,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from devflow.agent import get_agent_display_name
+from devflow.agent.factory import resolve_agent_backend
 from devflow.cli.utils import require_outside_claude
 from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
@@ -60,5 +61,5 @@ def update_session(identifier: str, ai_agent_session_id: str = None) -> None:
 
     console.print(f"[green]✓[/green] Updated session '{session.name}'{issue_display}")
     config = config_loader.load_config()
-    agent_name = get_agent_display_name(config.agent_backend if config else None)
+    agent_name = get_agent_display_name(resolve_agent_backend(config=config))
     console.print(f"  {agent_name} session ID: {ai_agent_session_id}")

--- a/devflow/cli/utils.py
+++ b/devflow/cli/utils.py
@@ -14,6 +14,7 @@ import requests
 from rich.console import Console
 from rich.prompt import Confirm, IntPrompt
 
+from devflow.agent.factory import resolve_agent_backend
 from devflow.config.models import Config, ConversationContext, Session
 from devflow.jira import JiraClient
 from devflow.session.manager import SessionManager
@@ -1004,7 +1005,7 @@ def should_launch_claude_code(config: Optional[Config] = None, mock_mode: bool =
         # Check auto_launch_agent first (new field)
         if config.prompts.auto_launch_agent is not None:
             should_launch = config.prompts.auto_launch_agent
-            agent_name = getattr(config, 'agent_backend', 'claude').capitalize()
+            agent_name = resolve_agent_backend(config=config).capitalize()
             if should_launch:
                 console_print(f"[dim]Automatically launching {agent_name} (configured in prompts)[/dim]")
             else:

--- a/devflow/export/manager.py
+++ b/devflow/export/manager.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from devflow.agent.factory import resolve_agent_backend
 from devflow.archive.base import ArchiveManagerBase
 from devflow.config.loader import ConfigLoader
 from devflow.config.models import Session
@@ -35,7 +36,7 @@ class ExportManager(ArchiveManagerBase):
         """
         try:
             config = self.config_loader.load_config()
-            return config.agent_backend if config else "claude"
+            return resolve_agent_backend(config=config)
         except Exception:
             return "claude"
 

--- a/devflow/export/markdown.py
+++ b/devflow/export/markdown.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from devflow.agent import create_agent_client
+from devflow.agent.factory import resolve_agent_backend
 from devflow.config.loader import ConfigLoader
 from devflow.config.models import Session
 from devflow.session.summary import find_conversation_file, generate_session_summary, generate_prose_summary
@@ -319,7 +320,7 @@ class MarkdownExporter:
         prose = generate_prose_summary(
             summary,
             mode=mode,
-            agent_backend=config.agent_backend if config else None
+            agent_backend=resolve_agent_backend(config=config)
         )
 
         lines = [prose]
@@ -404,7 +405,7 @@ class MarkdownExporter:
             try:
                 # Get agent backend from config
                 config = self.config_loader.load_config()
-                agent_backend = config.agent_backend or "claude"
+                agent_backend = resolve_agent_backend(config=config)
                 agent_client = create_agent_client(agent_backend)
             except Exception:
                 pass  # Ignore errors creating agent client


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->

GitHub Issue: https://github.com/itdove/devaiflow/issues/483

## Description

Extract a `resolve_agent_backend()` helper function to eliminate ~45 repeated expressions across the codebase. The duplicated pattern — resolving the agent backend from config with a fallback default — was scattered across 27 files (CLI commands, factory, backup/export managers, and CLI utils). This refactor centralizes that logic into a single helper, improving maintainability and consistency.

**Changes:**
- Added `resolve_agent_backend()` helper that encapsulates the config-lookup-with-fallback pattern
- Replaced ~45 inline expressions across 27 files with calls to the new helper
- No behavioral changes — pure mechanical refactor

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run the test suite: `pytest`
3. Run `daf list` to verify session listing still resolves backends correctly
4. Run `daf info` on an existing session to confirm agent backend resolution
5. Run `daf new` to confirm new session creation picks up the correct backend
6. Verify with a non-default agent backend configured to ensure fallback logic is preserved

### Scenarios tested
- All existing unit tests pass with no modifications
- CLI commands that resolve agent backends produce identical output before and after the change

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: