### PR TITLE
itdove/devaiflow#486: Add AgentInterface methods for backend-specific behavior (resume cmd, text generation, storage type)

### DIFF
--- a/devflow/agent/aider_agent.py
+++ b/devflow/agent/aider_agent.py
@@ -330,3 +330,6 @@ class AiderAgent(AgentInterface):
         TODO: Implement token tracking if Aider provides usage data in chat history
         """
         return None
+
+    def get_manual_resume_command(self, session_id: str, project_path: str) -> str:
+        return f"aider --chat-history-file {self.chat_history_dir / f'{session_id}_chat.txt'}"

--- a/devflow/agent/continue_agent.py
+++ b/devflow/agent/continue_agent.py
@@ -314,3 +314,6 @@ class ContinueAgent(AgentInterface):
         TODO: Implement token tracking if Continue API provides usage data
         """
         return None
+
+    def get_manual_resume_command(self, session_id: str, project_path: str) -> str:
+        return f"code {project_path}"

--- a/devflow/agent/crush_agent.py
+++ b/devflow/agent/crush_agent.py
@@ -391,3 +391,9 @@ class CrushAgent(AgentInterface):
         TODO: Implement token tracking if Crush SQLite database stores usage data
         """
         return None
+
+    def get_manual_resume_command(self, session_id: str, project_path: str) -> str:
+        return f"crush --session {session_id}"
+
+    def uses_file_based_sessions(self) -> bool:
+        return False

--- a/devflow/agent/cursor_agent.py
+++ b/devflow/agent/cursor_agent.py
@@ -289,3 +289,6 @@ class CursorAgent(AgentInterface):
         TODO: Implement token tracking if Cursor API provides usage data
         """
         return None
+
+    def get_manual_resume_command(self, session_id: str, project_path: str) -> str:
+        return f"cursor {project_path}"

--- a/devflow/agent/github_copilot_agent.py
+++ b/devflow/agent/github_copilot_agent.py
@@ -277,3 +277,6 @@ class GitHubCopilotAgent(AgentInterface):
         TODO: Implement token tracking if GitHub Copilot API provides usage data
         """
         return None
+
+    def get_manual_resume_command(self, session_id: str, project_path: str) -> str:
+        return f"code {project_path}"

--- a/devflow/agent/interface.py
+++ b/devflow/agent/interface.py
@@ -282,6 +282,60 @@ class AgentInterface(ABC):
         """
         return True
 
+    def get_manual_resume_command(self, session_id: str, project_path: str) -> str:
+        """Get the CLI command a user would type to manually resume this session.
+
+        The returned string is the resume command only (no 'cd' prefix).
+
+        Args:
+            session_id: Session UUID or identifier
+            project_path: Absolute path to project
+
+        Returns:
+            Shell command string, e.g. "claude --resume <id>"
+        """
+        return f"claude --resume {session_id}"
+
+    def generate_text(self, prompt: str, timeout: int = 30) -> Optional[str]:
+        """Generate text by piping a prompt through the agent's CLI.
+
+        Args:
+            prompt: Text prompt to send
+            timeout: Maximum seconds to wait
+
+        Returns:
+            Generated text (stripped), or None on any failure
+        """
+        try:
+            from devflow.agent.factory import get_agent_cli_binary
+            cli_binary = get_agent_cli_binary(self.get_agent_name())
+            result = subprocess.run(
+                [cli_binary, "-p"],
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            if result.returncode == 0:
+                text = result.stdout.strip()
+                if text:
+                    return text
+            return None
+        except (FileNotFoundError, subprocess.TimeoutExpired, Exception):
+            return None
+
+    def uses_file_based_sessions(self) -> bool:
+        """Whether this agent stores sessions as files (e.g. .jsonl).
+
+        File-based agents need conversation files copied between directories
+        for temp-directory workflows. Database-backed agents (OpenCode, Crush)
+        skip this.
+
+        Returns:
+            True if file-based (default), False if database-backed.
+        """
+        return True
+
     @abstractmethod
     def extract_token_usage(self, session_id: str, project_path: str) -> Optional[Dict[str, Any]]:
         """Extract token usage statistics from a session.

--- a/devflow/agent/ollama_claude_agent.py
+++ b/devflow/agent/ollama_claude_agent.py
@@ -461,3 +461,6 @@ class OllamaClaudeAgent(AgentInterface):
         # Priority 3: Let Ollama use its default
         # (from ~/.ollama/config.json or Ollama's built-in default)
         return None
+
+    def get_manual_resume_command(self, session_id: str, project_path: str) -> str:
+        return f"ollama launch claude --resume {session_id}"

--- a/devflow/agent/opencode_agent.py
+++ b/devflow/agent/opencode_agent.py
@@ -429,3 +429,9 @@ class OpenCodeAgent(AgentInterface):
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             pass
         return self.opencode_dir
+
+    def get_manual_resume_command(self, session_id: str, project_path: str) -> str:
+        return f"opencode --session {session_id}"
+
+    def uses_file_based_sessions(self) -> bool:
+        return False

--- a/devflow/agent/windsurf_agent.py
+++ b/devflow/agent/windsurf_agent.py
@@ -289,3 +289,6 @@ class WindsurfAgent(AgentInterface):
         TODO: Implement token tracking if Windsurf API provides usage data
         """
         return None
+
+    def get_manual_resume_command(self, session_id: str, project_path: str) -> str:
+        return f"windsurf {project_path}"

--- a/devflow/cli/commands/complete_command.py
+++ b/devflow/cli/commands/complete_command.py
@@ -11,7 +11,6 @@ from rich.prompt import Confirm, Prompt
 
 from devflow.agent import get_agent_display_name
 from devflow.agent.factory import (
-    get_agent_cli_binary as _get_agent_cli_binary,
     get_generated_with_line as _get_generated_with_line,
     resolve_agent_backend,
 )
@@ -3016,27 +3015,16 @@ Generate a summary with 2-4 bullet points that:
 Format as markdown bullets. Return ONLY the bullet points, nothing else."""
 
         # Try using agent CLI for best quality
-        cli_binary = _get_agent_cli_binary(agent_backend)
-        result = subprocess.run(
-            [cli_binary, "-p"],
-            input=prompt,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
+        from devflow.agent import create_agent_client
+        agent = create_agent_client(agent_backend or "claude")
+        summary = agent.generate_text(prompt, timeout=30)
+        if summary:
+            console.print("[dim]Generated PR summary using AI[/dim]")
+            return summary
 
-        if result.returncode == 0:
-            summary = result.stdout.strip()
-            # Clean up any extra formatting
-            if summary:
-                console.print("[dim]Generated PR summary using AI[/dim]")
-                return summary
-
-        return None
-
-    except FileNotFoundError:
-        # Agent CLI not installed, try Anthropic API
+        # Agent CLI not available or failed, try Anthropic API
         return _generate_pr_summary_with_api(session, working_dir)
+
     except Exception as e:
         console.print(f"[dim]PR summary generation failed: {e}[/dim]")
         return None
@@ -3731,16 +3719,12 @@ def _generate_commit_message_from_diff(diff_content: str, status_summary: str, a
     Returns:
         Generated commit message or None if generation fails
     """
-    cli_binary = _get_agent_cli_binary(agent_backend)
-
     try:
         # Truncate diff if it's too large (keep first 5000 chars for context)
-        # This prevents token limits while still providing sufficient context
         truncated_diff = diff_content[:5000]
         if len(diff_content) > 5000:
             truncated_diff += "\n\n... (diff truncated for analysis)"
 
-        # Build prompt for agent CLI
         prompt = f"""Based on this git diff, generate a commit message in conventional commit format.
 
 Git Status:
@@ -3758,24 +3742,15 @@ Generate a commit message with:
 
 Return ONLY the commit message."""
 
-        # Call agent CLI
-        result = subprocess.run(
-            [cli_binary, "-p"],
-            input=prompt,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
+        from devflow.agent import create_agent_client
+        agent = create_agent_client(agent_backend or "claude")
+        result = agent.generate_text(prompt, timeout=30)
+        if result:
+            return strip_code_fences(result)
 
-        if result.returncode == 0:
-            commit_text = strip_code_fences(result.stdout.strip())
-            return commit_text
-
-        return None
-
-    except FileNotFoundError:
-        # Agent CLI not installed, try Anthropic API
+        # Agent CLI not available or failed, try Anthropic API
         return _generate_commit_message_from_diff_api(diff_content, status_summary)
+
     except Exception:
         return None
 
@@ -3849,21 +3824,17 @@ def _generate_commit_with_agent_cli(summary_data, agent_backend: Optional[str] =
     Returns:
         Generated commit message or None if CLI not available
     """
-    cli_binary = _get_agent_cli_binary(agent_backend)
     agent_name = get_agent_display_name(agent_backend)
 
     try:
-        # Check if there's actually any meaningful data
         has_file_changes = (summary_data.files_created or summary_data.files_modified)
         has_tool_activity = bool(summary_data.tool_call_stats)
 
         if not has_file_changes and not has_tool_activity:
             return None
 
-        # Combine files created and modified
         files_changed = list(summary_data.files_created) + list(summary_data.files_modified)
 
-        # Build context for AI
         context_parts = []
 
         if files_changed:
@@ -3886,7 +3857,6 @@ def _generate_commit_with_agent_cli(summary_data, agent_backend: Optional[str] =
 
         context = "\n".join(context_parts)
 
-        # Build prompt for agent CLI
         prompt = f"""Based on this development session, generate a detailed git commit message following conventional commit format.
 
 {context}
@@ -3916,25 +3886,16 @@ Short descriptive title (max 72 chars)
 
 Return ONLY the commit message in this exact format, nothing else."""
 
-        # Call agent CLI
-        result = subprocess.run(
-            [cli_binary, "-p"],
-            input=prompt,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-
-        if result.returncode == 0:
-            commit_text = strip_code_fences(result.stdout.strip())
+        from devflow.agent import create_agent_client
+        agent = create_agent_client(agent_backend or "claude")
+        result = agent.generate_text(prompt, timeout=30)
+        if result:
+            commit_text = strip_code_fences(result)
             console.print(f"[dim]Generated commit message using {agent_name} CLI[/dim]")
             return commit_text
 
         return None
 
-    except FileNotFoundError:
-        # Agent CLI not installed
-        return None
     except Exception as e:
         console.print(f"[dim]{agent_name} CLI generation failed: {e}[/dim]")
         return None

--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -1339,18 +1339,10 @@ def open_session(
 
         if active_conv and active_conv.ai_agent_session_id:
             # Show agent-specific manual resume instructions
-            if effective_agent_backend in ("opencode", "opencode-ai"):
-                console.print(f"\n[yellow]You can manually resume with:[/yellow]")
-                console.print(f"  cd {active_conv.project_path}")
-                console.print(f"  opencode --session {active_conv.ai_agent_session_id}")
-            elif effective_agent_backend in ("ollama", "ollama-claude"):
-                console.print(f"\n[yellow]You can manually resume with:[/yellow]")
-                console.print(f"  cd {active_conv.project_path}")
-                console.print(f"  ollama launch claude --resume {active_conv.ai_agent_session_id}")
-            else:
-                console.print(f"\n[yellow]You can manually resume with:[/yellow]")
-                console.print(f"  cd {active_conv.project_path}")
-                console.print(f"  claude --resume {active_conv.ai_agent_session_id}")
+            resume_cmd = agent.get_manual_resume_command(active_conv.ai_agent_session_id, active_conv.project_path)
+            console.print(f"\n[yellow]You can manually resume with:[/yellow]")
+            console.print(f"  cd {active_conv.project_path}")
+            console.print(f"  {resume_cmd}")
 
 
 def _check_and_warn_feature_orchestration(session, session_manager) -> bool:
@@ -3395,9 +3387,7 @@ def _copy_conversation_to_temp(session, temp_dir: str, config=None) -> bool:
     effective_backend = resolve_agent_backend(session=session, config=config)
     agent = create_agent_client(effective_backend)
 
-    # Conversation file copy only applies to file-based agents (claude, ollama)
-    # For agents that use databases (opencode), skip this operation
-    if effective_backend in ("opencode", "opencode-ai"):
+    if not agent.uses_file_based_sessions():
         console.print(f"[dim]Skipping conversation file copy ({agent.get_agent_name()} uses database storage)[/dim]")
         return False
 
@@ -3461,8 +3451,7 @@ def _copy_conversation_from_temp(session, temp_dir: str, config=None) -> bool:
     effective_backend = resolve_agent_backend(session=session, config=config)
     agent = create_agent_client(effective_backend)
 
-    # Conversation file copy only applies to file-based agents (claude, ollama)
-    if effective_backend in ("opencode", "opencode-ai"):
+    if not agent.uses_file_based_sessions():
         console.print(f"[dim]Skipping conversation file save ({agent.get_agent_name()} uses database storage)[/dim]")
         return False
 

--- a/tests/test_agent_interface.py
+++ b/tests/test_agent_interface.py
@@ -1937,3 +1937,156 @@ class TestGetAgentDisplayName:
             name = get_agent_display_name(backend)
             assert name != backend or backend in ("cursor", "windsurf", "aider", "continue", "crush"), \
                 f"Backend '{backend}' should have a human-readable display name"
+
+
+class TestGetManualResumeCommand:
+    """Test get_manual_resume_command() across all agent implementations (#486)."""
+
+    def test_claude_resume_command(self):
+        agent = ClaudeAgent()
+        cmd = agent.get_manual_resume_command("sess-123", "/home/user/project")
+        assert cmd == "claude --resume sess-123"
+
+    def test_ollama_resume_command(self):
+        agent = OllamaClaudeAgent()
+        cmd = agent.get_manual_resume_command("sess-123", "/home/user/project")
+        assert cmd == "ollama launch claude --resume sess-123"
+
+    def test_opencode_resume_command(self):
+        agent = OpenCodeAgent()
+        cmd = agent.get_manual_resume_command("ses_abc", "/home/user/project")
+        assert cmd == "opencode --session ses_abc"
+
+    def test_crush_resume_command(self):
+        agent = CrushAgent()
+        cmd = agent.get_manual_resume_command("sess-123", "/home/user/project")
+        assert cmd == "crush --session sess-123"
+
+    def test_aider_resume_command(self):
+        agent = AiderAgent()
+        cmd = agent.get_manual_resume_command("sess-123", "/home/user/project")
+        assert "aider --chat-history-file" in cmd
+        assert "sess-123" in cmd
+
+    def test_cursor_resume_command(self):
+        agent = CursorAgent()
+        cmd = agent.get_manual_resume_command("sess-123", "/home/user/project")
+        assert cmd == "cursor /home/user/project"
+
+    def test_windsurf_resume_command(self):
+        agent = WindsurfAgent()
+        cmd = agent.get_manual_resume_command("sess-123", "/home/user/project")
+        assert cmd == "windsurf /home/user/project"
+
+    def test_copilot_resume_command(self):
+        agent = GitHubCopilotAgent()
+        cmd = agent.get_manual_resume_command("sess-123", "/home/user/project")
+        assert cmd == "code /home/user/project"
+
+    def test_continue_resume_command(self):
+        agent = ContinueAgent()
+        cmd = agent.get_manual_resume_command("sess-123", "/home/user/project")
+        assert cmd == "code /home/user/project"
+
+
+class TestGenerateText:
+    """Test generate_text() on AgentInterface (#486)."""
+
+    @patch("subprocess.run")
+    def test_claude_generate_text_success(self, mock_run):
+        mock_run.return_value = Mock(returncode=0, stdout="Generated text\n")
+        agent = ClaudeAgent()
+        result = agent.generate_text("test prompt")
+        assert result == "Generated text"
+        mock_run.assert_called_once_with(
+            ["claude", "-p"],
+            input="test prompt",
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    @patch("subprocess.run")
+    def test_generate_text_returns_none_on_failure(self, mock_run):
+        mock_run.return_value = Mock(returncode=1, stdout="")
+        agent = ClaudeAgent()
+        result = agent.generate_text("test prompt")
+        assert result is None
+
+    @patch("subprocess.run")
+    def test_generate_text_returns_none_on_empty_output(self, mock_run):
+        mock_run.return_value = Mock(returncode=0, stdout="   \n")
+        agent = ClaudeAgent()
+        result = agent.generate_text("test prompt")
+        assert result is None
+
+    @patch("subprocess.run", side_effect=FileNotFoundError)
+    def test_generate_text_returns_none_when_cli_missing(self, mock_run):
+        agent = ClaudeAgent()
+        result = agent.generate_text("test prompt")
+        assert result is None
+
+    @patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=30))
+    def test_generate_text_returns_none_on_timeout(self, mock_run):
+        agent = ClaudeAgent()
+        result = agent.generate_text("test prompt")
+        assert result is None
+
+    @patch("subprocess.run")
+    def test_generate_text_custom_timeout(self, mock_run):
+        mock_run.return_value = Mock(returncode=0, stdout="result\n")
+        agent = ClaudeAgent()
+        result = agent.generate_text("prompt", timeout=60)
+        assert result == "result"
+        mock_run.assert_called_once_with(
+            ["claude", "-p"],
+            input="prompt",
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    @patch("subprocess.run")
+    def test_opencode_generate_text_uses_opencode_binary(self, mock_run):
+        mock_run.return_value = Mock(returncode=0, stdout="opencode result\n")
+        agent = OpenCodeAgent()
+        result = agent.generate_text("test prompt")
+        assert result == "opencode result"
+        mock_run.assert_called_once_with(
+            ["opencode", "-p"],
+            input="test prompt",
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+
+class TestUsesFileBasedSessions:
+    """Test uses_file_based_sessions() across all agent implementations (#486)."""
+
+    def test_claude_uses_file_sessions(self):
+        assert ClaudeAgent().uses_file_based_sessions() is True
+
+    def test_ollama_uses_file_sessions(self):
+        assert OllamaClaudeAgent().uses_file_based_sessions() is True
+
+    def test_opencode_uses_database_sessions(self):
+        assert OpenCodeAgent().uses_file_based_sessions() is False
+
+    def test_crush_uses_database_sessions(self):
+        assert CrushAgent().uses_file_based_sessions() is False
+
+    def test_aider_uses_file_sessions(self):
+        assert AiderAgent().uses_file_based_sessions() is True
+
+    def test_cursor_uses_file_sessions(self):
+        assert CursorAgent().uses_file_based_sessions() is True
+
+    def test_windsurf_uses_file_sessions(self):
+        assert WindsurfAgent().uses_file_based_sessions() is True
+
+    def test_copilot_uses_file_sessions(self):
+        assert GitHubCopilotAgent().uses_file_based_sessions() is True
+
+    def test_continue_uses_file_sessions(self):
+        assert ContinueAgent().uses_file_based_sessions() is True


### PR DESCRIPTION
Now I have full context. Here's the filled template:

Jira Issue: <!-- This PR does not need a corresponding Jira item. -->

## Description

Add three new methods to `AgentInterface` to encapsulate backend-specific behavior that was previously hardcoded via if/elif chains in CLI commands:

- **`get_manual_resume_command()`** — returns the agent-specific CLI command to resume a session (e.g., `claude --resume <id>`, `opencode --session <id>`, `ollama launch claude --resume <id>`)
- **`generate_text()`** — pipes a prompt through the agent's CLI binary and returns generated text, replacing inline `subprocess.run()` calls scattered across `complete_command.py`
- **`uses_file_based_sessions()`** — declares whether the agent uses file-based (`.jsonl`) or database-backed session storage, replacing hardcoded backend name checks in `open_command.py`

Each agent subclass (Aider, Continue, Crush, Cursor, GitHub Copilot, Ollama-Claude, OpenCode, Windsurf) provides its own override where behavior differs from the default. The CLI commands (`open_command.py`, `complete_command.py`) now call these methods instead of branching on backend name strings, removing ~76 lines of duplicated logic.

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `pytest tests/test_agent_interface.py -v` to verify all new interface method tests pass
3. Run `pytest tests/` to confirm no regressions across the full test suite
4. Verify `daf open` with different agent backends still shows correct manual resume instructions
5. Verify `daf complete` PR summary and commit message generation still works via `generate_text()`

### Scenarios tested
- All agent subclasses return correct resume commands (claude, opencode, crush, ollama, aider)
- `uses_file_based_sessions()` returns `False` for OpenCode and Crush (database-backed), `True` for all others
- `generate_text()` default implementation delegates to agent CLI binary
- Conversation file copy/save correctly skips database-backed agents

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: