### PR TITLE
itdove/devaiflow#491: daf setup: detect ai-guardian and allowlist DAF env var patterns in global config

### DIFF
--- a/devflow/cli/commands/setup_command.py
+++ b/devflow/cli/commands/setup_command.py
@@ -140,6 +140,32 @@ def resolve_target_path(backend: str, scope: str) -> Path:
 
 SUPPORTED_OVERLAY_BACKENDS = ["claude", "opencode"]
 
+AI_GUARDIAN_OVERLAY = {
+    "secret_scanning": {
+        "allowlist_patterns": ["DAF_SESSION_NAME=", "DAF_COMMAND="],
+    },
+    "secret_redaction": {
+        "allowlist_patterns": ["DAF_SESSION_NAME=", "DAF_COMMAND="],
+    },
+}
+
+
+def resolve_ai_guardian_config_path() -> Path:
+    """Resolve ai-guardian global config path using XDG priority chain.
+
+    Priority:
+        1. $AI_GUARDIAN_CONFIG_DIR/ai-guardian.json
+        2. $XDG_CONFIG_HOME/ai-guardian/ai-guardian.json
+        3. ~/.config/ai-guardian/ai-guardian.json
+    """
+    explicit = os.environ.get("AI_GUARDIAN_CONFIG_DIR")
+    if explicit:
+        return Path(explicit) / "ai-guardian.json"
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg) / "ai-guardian" / "ai-guardian.json"
+    return Path.home() / ".config" / "ai-guardian" / "ai-guardian.json"
+
 
 def setup_agent_config(
     dry_run: bool = False,
@@ -166,21 +192,28 @@ def setup_agent_config(
             )
             if result > worst:
                 worst = result
-        return worst
+        exit_code = worst
+    else:
+        from devflow.config.loader import ConfigLoader
 
-    from devflow.config.loader import ConfigLoader
+        try:
+            config_loader = ConfigLoader()
+            config = config_loader.load_config(validate=False)
+            backend = resolve_agent_backend(config=config)
+        except Exception:
+            backend = "claude"
 
-    try:
-        config_loader = ConfigLoader()
-        config = config_loader.load_config(validate=False)
-        backend = resolve_agent_backend(config=config)
-    except Exception:
-        backend = "claude"
+        canonical = BACKEND_ALIASES.get(backend, backend)
+        exit_code = _setup_single_backend(
+            canonical, dry_run=dry_run, scope=scope, output_json=output_json
+        )
 
-    canonical = BACKEND_ALIASES.get(backend, backend)
-    return _setup_single_backend(
-        canonical, dry_run=dry_run, scope=scope, output_json=output_json
-    )
+    if scope == "global":
+        rc = _setup_ai_guardian(dry_run=dry_run, output_json=output_json)
+        if rc > exit_code:
+            exit_code = rc
+
+    return exit_code
 
 
 def _setup_single_backend(
@@ -306,3 +339,69 @@ def _write_config(path: Path, data: Dict[str, Any]) -> bool:
     except OSError as e:
         console.print(f"[red]Failed to write {path}: {e}[/red]")
         return False
+
+
+def _setup_ai_guardian(
+    dry_run: bool = False,
+    output_json: bool = False,
+) -> int:
+    """Add DAF env var allowlist patterns to ai-guardian config if present."""
+    config_path = resolve_ai_guardian_config_path()
+
+    if not config_path.exists():
+        return 0
+
+    try:
+        existing = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        if output_json:
+            print(json.dumps({
+                "success": False,
+                "error": f"Failed to read {config_path}: {e}",
+            }, indent=2))
+        else:
+            console.print(f"[red]Failed to read {config_path}: {e}[/red]")
+        return 1
+
+    merged, added = deep_merge(existing, AI_GUARDIAN_OVERLAY)
+
+    if output_json:
+        print(json.dumps({
+            "success": True,
+            "backend": "ai-guardian",
+            "target": str(config_path),
+            "scope": "global",
+            "dry_run": dry_run,
+            "added": added,
+            "skipped": _count_skipped(AI_GUARDIAN_OVERLAY, added),
+        }, indent=2))
+        if not dry_run and added:
+            _write_config(config_path, merged)
+        return 0
+
+    console.print(f"\n[bold]Setting up ai-guardian integration[/bold]")
+    console.print(f"  Target:  [cyan]{config_path}[/cyan]")
+
+    if not added:
+        console.print("\n[green]DAF allowlist patterns already present. Nothing to do.[/green]")
+        return 0
+
+    table = Table(title="Allowlist patterns to add", show_header=True, header_style="bold")
+    table.add_column("Path", style="cyan")
+    table.add_column("Status", width=10)
+
+    for path in added:
+        table.add_row(path, "[green]+ add[/green]")
+
+    console.print()
+    console.print(table)
+
+    if dry_run:
+        console.print("\n[yellow]Dry run — no changes written.[/yellow]")
+        return 0
+
+    if _write_config(config_path, merged):
+        console.print(f"\n[green]Wrote {len(added)} pattern(s) to {config_path}[/green]")
+        return 0
+
+    return 1

--- a/devflow/cli_skills/daf-workflow/SKILL.md
+++ b/devflow/cli_skills/daf-workflow/SKILL.md
@@ -12,6 +12,8 @@ Run this command to check the session environment:
 echo "DAF_SESSION_NAME=$DAF_SESSION_NAME" "DAF_COMMAND=$DAF_COMMAND"
 ```
 
+**Important:** Use this command exactly as written — the text must match the agent's permission pattern. Do not rephrase or restructure.
+
 If `DAF_SESSION_NAME` is set (non-empty), this is a managed DevAIFlow session — follow the initialization steps below. If empty, skip to the **Standalone Workflow Guide** section at the bottom.
 
 ---

--- a/devflow/templates/overlays/claude.jsonc
+++ b/devflow/templates/overlays/claude.jsonc
@@ -8,8 +8,14 @@
       // All daf CLI commands (read-safe from agent perspective)
       "Bash(daf active *)",
       "Bash(daf info *)",
+      "Bash(daf config show *)",
+      "Bash(daf note *)",
+      "Bash(daf list *)",
+      "Bash(daf status *)",
+      "Bash(daf jira view *)",
       "Bash(daf * view *)",
       // Issue tracker view-only commands
+      "Bash(gh issue view *)",
       "Bash(gh * view *)",
       "Bash(glab * view *)",
       // Git read-only operations

--- a/devflow/templates/overlays/opencode.jsonc
+++ b/devflow/templates/overlays/opencode.jsonc
@@ -9,8 +9,14 @@
       // All daf CLI commands (read-safe from agent perspective)
       "daf active *": "allow",
       "daf info *": "allow",
+      "daf config show *": "allow",
+      "daf note *": "allow",
+      "daf list *": "allow",
+      "daf status *": "allow",
+      "daf jira view *": "allow",
       "daf * view *": "allow",
       // Issue tracker view-only commands
+      "gh issue view *": "allow",
       "gh * view *": "allow",
       "glab * view *": "allow",
       // Git read-only operations

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -12,7 +12,9 @@ from devflow.cli.commands.setup_command import (
     load_overlay,
     deep_merge,
     resolve_target_path,
+    resolve_ai_guardian_config_path,
     setup_agent_config,
+    _setup_ai_guardian,
     SUPPORTED_OVERLAY_BACKENDS,
 )
 
@@ -166,10 +168,23 @@ class TestLoadOverlay:
         assert "permission" in overlay
         assert "bash" in overlay["permission"]
         assert "daf info *" in overlay["permission"]["bash"]
+        assert "daf config show *" in overlay["permission"]["bash"]
+        assert "daf note *" in overlay["permission"]["bash"]
+        assert "daf list *" in overlay["permission"]["bash"]
+        assert "daf status *" in overlay["permission"]["bash"]
+        assert "daf jira view *" in overlay["permission"]["bash"]
+        assert "gh issue view *" in overlay["permission"]["bash"]
 
     def test_load_claude_overlay(self):
         overlay = load_overlay("claude")
         assert overlay is not None
+        allow = overlay["permissions"]["allow"]
+        assert "Bash(daf config show *)" in allow
+        assert "Bash(daf note *)" in allow
+        assert "Bash(daf list *)" in allow
+        assert "Bash(daf status *)" in allow
+        assert "Bash(daf jira view *)" in allow
+        assert "Bash(gh issue view *)" in allow
 
     def test_load_nonexistent_overlay(self):
         overlay = load_overlay("nonexistent-backend")
@@ -439,3 +454,159 @@ class TestSetupAgentConfig:
         assert exit_code == 0
         assert (tmp_path / ".claude" / "settings.json").exists()
         assert (tmp_path / "opencode.json").exists()
+
+    def test_global_scope_triggers_ai_guardian(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        guardian_dir = tmp_path / "guardian_config"
+        guardian_dir.mkdir()
+        guardian_file = guardian_dir / "ai-guardian.json"
+        guardian_file.write_text(json.dumps({"secret_scanning": {}}, indent=2))
+        monkeypatch.setenv("AI_GUARDIAN_CONFIG_DIR", str(guardian_dir))
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg_config"))
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "opencode"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            exit_code = setup_agent_config(dry_run=False, scope="global")
+
+        assert exit_code == 0
+        data = json.loads(guardian_file.read_text())
+        assert "DAF_SESSION_NAME=" in data["secret_scanning"]["allowlist_patterns"]
+        assert "DAF_COMMAND=" in data["secret_scanning"]["allowlist_patterns"]
+        assert "DAF_SESSION_NAME=" in data["secret_redaction"]["allowlist_patterns"]
+
+    def test_project_scope_skips_ai_guardian(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        guardian_dir = tmp_path / "guardian_config"
+        guardian_dir.mkdir()
+        guardian_file = guardian_dir / "ai-guardian.json"
+        guardian_file.write_text(json.dumps({"secret_scanning": {}}, indent=2))
+        monkeypatch.setenv("AI_GUARDIAN_CONFIG_DIR", str(guardian_dir))
+
+        with patch("devflow.config.loader.ConfigLoader") as mock_loader:
+            mock_config = MagicMock()
+            mock_config.agent_backend = "opencode"
+            mock_loader.return_value.load_config.return_value = mock_config
+
+            setup_agent_config(dry_run=False, scope="project")
+
+        data = json.loads(guardian_file.read_text())
+        assert "allowlist_patterns" not in data.get("secret_scanning", {})
+
+
+class TestResolveAiGuardianConfigPath:
+    def test_default_path(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AI_GUARDIAN_CONFIG_DIR", None)
+            os.environ.pop("XDG_CONFIG_HOME", None)
+            path = resolve_ai_guardian_config_path()
+            assert path == Path.home() / ".config" / "ai-guardian" / "ai-guardian.json"
+
+    def test_xdg_config_home(self):
+        with patch.dict(os.environ, {"XDG_CONFIG_HOME": "/custom/config"}):
+            os.environ.pop("AI_GUARDIAN_CONFIG_DIR", None)
+            path = resolve_ai_guardian_config_path()
+            assert path == Path("/custom/config/ai-guardian/ai-guardian.json")
+
+    def test_explicit_env_var(self):
+        with patch.dict(os.environ, {"AI_GUARDIAN_CONFIG_DIR": "/explicit/guardian"}):
+            path = resolve_ai_guardian_config_path()
+            assert path == Path("/explicit/guardian/ai-guardian.json")
+
+    def test_explicit_overrides_xdg(self):
+        with patch.dict(os.environ, {
+            "AI_GUARDIAN_CONFIG_DIR": "/explicit/guardian",
+            "XDG_CONFIG_HOME": "/custom/config",
+        }):
+            path = resolve_ai_guardian_config_path()
+            assert path == Path("/explicit/guardian/ai-guardian.json")
+
+
+class TestSetupAiGuardian:
+    def test_no_config_skips(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AI_GUARDIAN_CONFIG_DIR", str(tmp_path / "nonexistent"))
+        rc = _setup_ai_guardian(dry_run=False)
+        assert rc == 0
+
+    def test_fresh_config_adds_patterns(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / "guardian"
+        config_dir.mkdir()
+        config_file = config_dir / "ai-guardian.json"
+        config_file.write_text(json.dumps({}, indent=2))
+        monkeypatch.setenv("AI_GUARDIAN_CONFIG_DIR", str(config_dir))
+
+        rc = _setup_ai_guardian(dry_run=False)
+        assert rc == 0
+        data = json.loads(config_file.read_text())
+        assert "DAF_SESSION_NAME=" in data["secret_scanning"]["allowlist_patterns"]
+        assert "DAF_COMMAND=" in data["secret_scanning"]["allowlist_patterns"]
+        assert "DAF_SESSION_NAME=" in data["secret_redaction"]["allowlist_patterns"]
+        assert "DAF_COMMAND=" in data["secret_redaction"]["allowlist_patterns"]
+
+    def test_existing_config_merges(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / "guardian"
+        config_dir.mkdir()
+        config_file = config_dir / "ai-guardian.json"
+        existing = {
+            "secret_scanning": {
+                "allowlist_patterns": ["EXISTING_PATTERN="],
+            },
+            "prompt_injection": {"enabled": True},
+        }
+        config_file.write_text(json.dumps(existing, indent=2))
+        monkeypatch.setenv("AI_GUARDIAN_CONFIG_DIR", str(config_dir))
+
+        rc = _setup_ai_guardian(dry_run=False)
+        assert rc == 0
+        data = json.loads(config_file.read_text())
+        patterns = data["secret_scanning"]["allowlist_patterns"]
+        assert "EXISTING_PATTERN=" in patterns
+        assert "DAF_SESSION_NAME=" in patterns
+        assert "DAF_COMMAND=" in patterns
+        assert data["prompt_injection"]["enabled"] is True
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / "guardian"
+        config_dir.mkdir()
+        config_file = config_dir / "ai-guardian.json"
+        config_file.write_text(json.dumps({}, indent=2))
+        monkeypatch.setenv("AI_GUARDIAN_CONFIG_DIR", str(config_dir))
+
+        _setup_ai_guardian(dry_run=False)
+        first = config_file.read_text()
+        _setup_ai_guardian(dry_run=False)
+        second = config_file.read_text()
+        assert first == second
+
+    def test_dry_run_no_write(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / "guardian"
+        config_dir.mkdir()
+        config_file = config_dir / "ai-guardian.json"
+        config_file.write_text(json.dumps({}, indent=2))
+        monkeypatch.setenv("AI_GUARDIAN_CONFIG_DIR", str(config_dir))
+
+        rc = _setup_ai_guardian(dry_run=True)
+        assert rc == 0
+        data = json.loads(config_file.read_text())
+        assert data == {}
+
+    def test_preserves_other_keys(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / "guardian"
+        config_dir.mkdir()
+        config_file = config_dir / "ai-guardian.json"
+        existing = {
+            "scan_pii": True,
+            "directory_rules": ["/private"],
+            "secret_scanning": {"enabled": True},
+        }
+        config_file.write_text(json.dumps(existing, indent=2))
+        monkeypatch.setenv("AI_GUARDIAN_CONFIG_DIR", str(config_dir))
+
+        _setup_ai_guardian(dry_run=False)
+        data = json.loads(config_file.read_text())
+        assert data["scan_pii"] is True
+        assert data["directory_rules"] == ["/private"]
+        assert data["secret_scanning"]["enabled"] is True
+        assert "DAF_SESSION_NAME=" in data["secret_scanning"]["allowlist_patterns"]


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
<!-- If you use any AI tool then provide that information here. The code assistant that you used, elaborating on how it was used.  -->

When ai-guardian is installed, its secret scanner flags DAF environment variables (`DAF_SESSION_NAME`, `DAF_COMMAND`) as potential secrets during agent sessions. This PR extends `daf setup --scope global` to detect an existing ai-guardian config and merge DAF env var patterns into the `secret_scanning.allowlist_patterns` and `secret_redaction.allowlist_patterns` lists, preventing false-positive blocks.

Key changes:
- **`setup_command.py`**: Add `resolve_ai_guardian_config_path()` using XDG priority chain (`$AI_GUARDIAN_CONFIG_DIR` > `$XDG_CONFIG_HOME` > `~/.config`). Add `_setup_ai_guardian()` that deep-merges DAF allowlist patterns into existing config. Only runs on `scope=global`; silently skips if no ai-guardian config exists. Idempotent — re-running does not duplicate patterns.
- **Overlay templates** (`claude.jsonc`, `opencode.jsonc`): Add missing permission entries for `daf config show`, `daf note`, `daf list`, `daf status`, `daf jira view`, and `gh issue view` commands.
- **`SKILL.md`**: Add note about using the env-check command exactly as written to match permission patterns.
- **Tests**: 159 lines of new tests covering config path resolution, fresh/merge/idempotent/dry-run scenarios, and integration with `setup_agent_config` for both global and project scopes.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Install ai-guardian globally if not already: `pip install ai-guardian`
3. Ensure ai-guardian config exists at `~/.config/ai-guardian/ai-guardian.json` (run `ai-guardian init` if needed)
4. Run `daf setup --scope global` and verify DAF allowlist patterns are added to the config
5. Run `daf setup --scope global` again and verify idempotency — no duplicate patterns
6. Run `daf setup --scope global --dry-run` on a fresh config and verify no file is written
7. Run `daf setup --scope project` and verify ai-guardian config is not modified
8. Run `pytest tests/test_setup_command.py -v` to verify all unit tests pass

### Scenarios tested
- ai-guardian config not present — setup silently skips with exit code 0
- Fresh empty config — both `secret_scanning` and `secret_redaction` allowlist patterns added
- Existing config with other patterns/keys — DAF patterns merged, existing content preserved
- Idempotent run — second invocation produces identical file
- Dry run — config file left unchanged
- `--scope project` — ai-guardian setup skipped entirely
- `--scope global` — ai-guardian setup runs after backend setup
- Config path resolution via `$AI_GUARDIAN_CONFIG_DIR`, `$XDG_CONFIG_HOME`, and default `~/.config`

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: