### PR TITLE
itdove/devaiflow#496: daf info shows wrong agent backend: 'OpenCode Session UUID' for Claude Code sessions

### DIFF
--- a/devflow/cli/commands/info_command.py
+++ b/devflow/cli/commands/info_command.py
@@ -149,7 +149,7 @@ def _output_json_session_info(
         # Add conversation file paths 
         if session.conversations:
             config = config_loader.load_config()
-            _ab = resolve_agent_backend(config=config)
+            _ab = resolve_agent_backend(config=config, session=session)
             conversations_with_paths = []
             conv_number = 1
             for working_dir, conversation in session.conversations.items():
@@ -379,7 +379,7 @@ def _display_conversation(
     # Resolve agent display name for labels
     try:
         config = config_loader.load_config()
-        _agent_backend = resolve_agent_backend(config=config)
+        _agent_backend = resolve_agent_backend(config=config, session=session)
     except Exception:
         _agent_backend = "claude"
     _agent_name = get_agent_display_name(_agent_backend)
@@ -417,7 +417,7 @@ def _display_conversation(
         console.print(f"  [dim]Messages:[/dim] {conv.message_count}")
 
     # Display token usage if available
-    _display_token_usage(conv, config_loader)
+    _display_token_usage(conv, config_loader, session=session)
 
     # Display summary if available
     if conv.summary:
@@ -428,12 +428,13 @@ def _display_conversation(
         console.print(f"  [dim]PRs:[/dim] {', '.join(conv.prs)}")
 
 
-def _display_token_usage(conv: ConversationContext, config_loader: ConfigLoader) -> None:
+def _display_token_usage(conv: ConversationContext, config_loader: ConfigLoader, session: Optional[Session] = None) -> None:
     """Display token usage statistics for a conversation.
 
     Args:
         conv: ConversationContext object
         config_loader: ConfigLoader instance
+        session: Optional Session object for resolving agent backend
     """
     if not conv.project_path or not conv.ai_agent_session_id:
         return
@@ -441,7 +442,7 @@ def _display_token_usage(conv: ConversationContext, config_loader: ConfigLoader)
     try:
         # Create agent client
         config = config_loader.load_config()
-        agent_backend = resolve_agent_backend(config=config)
+        agent_backend = resolve_agent_backend(config=config, session=session)
         agent = create_agent_client(agent_backend)
 
         # Extract token usage

--- a/tests/test_info_command.py
+++ b/tests/test_info_command.py
@@ -910,3 +910,88 @@ def test_session_info_explicit_identifier_overrides_daf_session_name(temp_daf_ho
     # Should show explicit-session, NOT env-session
     assert "explicit-session" in captured.out
     assert "uuid-explicit" in captured.out
+
+
+def test_session_info_displays_correct_backend_for_claude_session(temp_daf_home, capsys):
+    """Test that daf info shows 'Claude Code' label for Claude sessions, not OpenCode.
+
+    Regression test for issue #496: resolve_agent_backend() was called without
+    the session parameter, falling back to config default instead of session's
+    actual agent_backend.
+    """
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session = session_manager.create_session(
+        name="claude-session",
+        goal="Claude Code work",
+        working_directory="project",
+        project_path="/path/to/project",
+        ai_agent_session_id="uuid-claude-123",
+    )
+    session.agent_backend = "claude"
+    session_manager.update_session(session)
+
+    session_info(identifier="claude-session", uuid_only=False, conversation_id=None)
+    captured = capsys.readouterr()
+
+    assert "Claude Code Session UUID" in captured.out
+    assert "OpenCode Session UUID" not in captured.out
+
+
+def test_session_info_displays_correct_backend_for_opencode_session(temp_daf_home, capsys):
+    """Test that daf info shows 'OpenCode' label for OpenCode sessions.
+
+    Regression test for issue #496.
+    """
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session = session_manager.create_session(
+        name="opencode-session",
+        goal="OpenCode work",
+        working_directory="project",
+        project_path="/path/to/project",
+        ai_agent_session_id="uuid-opencode-456",
+    )
+    session.agent_backend = "opencode"
+    session_manager.update_session(session)
+
+    session_info(identifier="opencode-session", uuid_only=False, conversation_id=None)
+    captured = capsys.readouterr()
+
+    assert "OpenCode Session UUID" in captured.out
+    assert "Claude Code Session UUID" not in captured.out
+
+
+def test_session_info_json_uses_session_backend(temp_daf_home, capsys):
+    """Test that JSON output uses session's agent_backend, not config default.
+
+    Regression test for issue #496.
+    """
+    import json
+
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session = session_manager.create_session(
+        name="json-backend-test",
+        goal="Backend in JSON",
+        working_directory="dir1",
+        project_path="/path/to/project",
+        ai_agent_session_id="uuid-json-backend",
+    )
+    session.agent_backend = "opencode"
+    session_manager.update_session(session)
+
+    session_info(identifier="json-backend-test", uuid_only=False, conversation_id=None, latest=False, output_json=True)
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+
+    assert output["success"] is True
+    conversations = output["data"]["session"].get("conversations_detail", [])
+    assert len(conversations) > 0
+    for conv in conversations:
+        conv_file = conv.get("conversation_file", "")
+        assert "opencode" in conv_file.lower() or ".db" in conv_file.lower()


### PR DESCRIPTION
Jira Issue: <https://github.com/itdove/devaiflow/issues/496>
<!-- This PR does not need a corresponding Jira item. -->

## Description
Fix `daf info` displaying wrong agent backend label for Claude Code sessions. The `resolve_agent_backend()` function was called without the `session` parameter in three places within `info_command.py`, causing it to fall back to the config default (often OpenCode) instead of using the session's actual `agent_backend` value. This resulted in Claude Code sessions incorrectly showing "OpenCode Session UUID" instead of "Claude Code Session UUID".

The fix passes the `session` object to all `resolve_agent_backend()` calls in `_output_json_session_info()`, `_display_conversation()`, and `_display_token_usage()`, ensuring the correct backend is resolved from session metadata.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Create a session with Claude Code backend: `daf new --name test-claude --goal "test" --project-path .`
3. Run `daf info test-claude` and verify the output shows "Claude Code Session UUID" (not "OpenCode Session UUID")
4. Run `daf info test-claude --json` and verify the JSON output references the correct agent backend in conversation file paths
5. Run the regression tests: `pytest tests/test_info_command.py::test_session_info_displays_correct_backend_for_claude_session tests/test_info_command.py::test_session_info_displays_correct_backend_for_opencode_session tests/test_info_command.py::test_session_info_json_uses_session_backend -v`

### Scenarios tested
- Claude Code session displays "Claude Code Session UUID" label correctly
- OpenCode session still displays "OpenCode Session UUID" label correctly
- JSON output resolves correct backend from session metadata, not config default

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: