### PR TITLE
itdove/devaiflow#499: daf complete: commit message generation fails — wrong agent backend in complete_command.py

### DIFF
--- a/devflow/cli/commands/complete_command.py
+++ b/devflow/cli/commands/complete_command.py
@@ -191,7 +191,7 @@ def complete_session(
     config = config_loader.load_config()
 
     # Resolve agent backend for agent-agnostic messaging
-    agent_backend = resolve_agent_backend(config=config)
+    agent_backend = resolve_agent_backend(config=config, session=session)
 
     # Get active conversation for accessing conversation-specific fields
     active_conv = session.active_conversation
@@ -1202,7 +1202,7 @@ def _add_session_summary_to_jira(issue_key: str, session_name: str, session, hou
                 prose_summary = generate_prose_summary(
                     summary_data,
                     mode="ai",
-                    agent_backend=resolve_agent_backend(config=config)
+                    agent_backend=resolve_agent_backend(config=config, session=session)
                 )
                 if prose_summary:
                     # Add newlines before and after for better formatting
@@ -1279,7 +1279,7 @@ def _add_session_summary_to_github(issue_key: str, session_name: str, session, h
                 prose_summary = generate_prose_summary(
                     summary_data,
                     mode="ai",
-                    agent_backend=resolve_agent_backend(config=config)
+                    agent_backend=resolve_agent_backend(config=config, session=session)
                 )
                 if prose_summary:
                     prose_summary = f"\n\n{prose_summary}\n"
@@ -1383,7 +1383,7 @@ def _sync_branch_for_export(session, issue_key: str, config_loader, yes: bool = 
         else:
             # Create WIP commit
             co_authored_by = get_co_authored_by_line(config, session.model_profile)
-            generated_with = _get_generated_with_line(resolve_agent_backend(config=config))
+            generated_with = _get_generated_with_line(resolve_agent_backend(config=config, session=session))
             commit_message = f"""WIP: Session export for {issue_key}
 
 {generated_with}
@@ -2922,7 +2922,7 @@ def _generate_pr_description(session, working_dir: Path, config_loader: ConfigLo
                 jira_section = f"Jira Issue: {jira_url}/browse/{session.issue_key}\n\n"
 
         # Try to generate AI-powered summary from session and git data
-        summary_bullets = _generate_pr_summary_bullets(session, working_dir, agent_backend=resolve_agent_backend(config=config))
+        summary_bullets = _generate_pr_summary_bullets(session, working_dir, agent_backend=resolve_agent_backend(config=config, session=session))
 
         # If AI summary failed, fall back to session goal
         if not summary_bullets:
@@ -2932,7 +2932,7 @@ def _generate_pr_description(session, working_dir: Path, config_loader: ConfigLo
 
         config = config_loader.load_config()
         co_authored_by = get_co_authored_by_line(config, session.model_profile)
-        generated_with = _get_generated_with_line(resolve_agent_backend(config=config))
+        generated_with = _get_generated_with_line(resolve_agent_backend(config=config, session=session))
         description = f"""{jira_section}{description_content}
 
 ## Test plan

--- a/tests/test_complete_command.py
+++ b/tests/test_complete_command.py
@@ -11,6 +11,7 @@ from devflow.config.loader import ConfigLoader
 from devflow.session.manager import SessionManager
 from devflow.jira.exceptions import JiraApiError, JiraNotFoundError, JiraValidationError
 from devflow.git.utils import GitUtils
+from devflow.agent.factory import resolve_agent_backend
 
 
 def test_complete_session_basic(temp_daf_home, monkeypatch, capsys):
@@ -4330,3 +4331,57 @@ def test_complete_session_fetch_origin_called_before_diff(temp_daf_home, tmp_pat
         fetch_idx = call_order.index("fetch_origin")
         changed_idx = call_order.index("get_changed_files")
         assert fetch_idx < changed_idx, "fetch_origin must be called before get_changed_files"
+
+
+def test_complete_session_passes_session_to_resolve_agent_backend(temp_daf_home, monkeypatch, capsys):
+    """Test that resolve_agent_backend receives the session object.
+
+    Regression test for issue #499: resolve_agent_backend() was called with
+    only config=config, missing session=session. This caused the backend to
+    fall back to the config default (e.g., "opencode") instead of using the
+    session's actual agent_backend (e.g., "claude").
+    """
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session = session_manager.create_session(
+        name="backend-test",
+        goal="Test backend resolution",
+        working_directory="test-dir",
+        project_path="/test",
+        ai_agent_session_id="uuid-backend-1",
+    )
+    session.agent_backend = "claude"
+    session_manager.update_session(session)
+
+    session_manager.start_work_session("backend-test")
+    session_manager.end_work_session("backend-test")
+
+    # Track all calls to resolve_agent_backend
+    calls = []
+    original_resolve = resolve_agent_backend
+
+    def tracking_resolve(**kwargs):
+        calls.append(kwargs)
+        return original_resolve(**kwargs)
+
+    monkeypatch.setattr(
+        "devflow.cli.commands.complete_command.resolve_agent_backend",
+        tracking_resolve,
+    )
+    monkeypatch.setattr(
+        "devflow.cli.commands.complete_command.Confirm.ask",
+        lambda *args, **kwargs: False,
+    )
+
+    complete_session("backend-test")
+
+    # Every call must include session parameter
+    assert len(calls) > 0, "resolve_agent_backend should have been called"
+    for i, call in enumerate(calls):
+        assert "session" in call, (
+            f"Call #{i+1} to resolve_agent_backend missing session parameter: {call}"
+        )
+        assert call["session"] is not None, (
+            f"Call #{i+1} to resolve_agent_backend passed session=None"
+        )


### PR DESCRIPTION
Jira Issue: <https://github.com/itdove/devaiflow/issues/499>
<!-- This PR does not need a corresponding Jira item. -->

## Description
Fix `daf complete` failing to generate commit messages with "Failed to generate commit message from diff". Root cause: `resolve_agent_backend(config=config)` was called without the `session` parameter at 6 call sites in `complete_command.py`, causing it to resolve to the config default backend (e.g., "opencode") instead of the session's actual backend (e.g., "claude"). This made `generate_text()` call the wrong CLI binary, which failed instantly.

Fixed all 6 call sites to pass `session=session` to `resolve_agent_backend()`. Added a regression test that verifies every call to `resolve_agent_backend` includes the `session` parameter.

Related: Same bug was fixed in `info_command.py` in PR #497 — this PR covers the remaining call sites in `complete_command.py`.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Create a DAF session with `agent_backend` set to "claude" (or any non-default backend)
3. Make changes and stage them
4. Run `daf complete <session-name>`
5. Verify commit message generation succeeds using the correct agent CLI binary
6. Run `pytest tests/test_complete_command.py::test_complete_session_passes_session_to_resolve_agent_backend -v`

### Scenarios tested
- Regression test confirms all `resolve_agent_backend()` calls include `session` parameter
- Test verifies `session` is never `None` in any call

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: