### PR TITLE
itdove/devaiflow#503: daf complete: 'No unpushed commits' when branch tracks stale remote ref

### DIFF
--- a/devflow/git/utils.py
+++ b/devflow/git/utils.py
@@ -577,41 +577,40 @@ class GitUtils:
 
     @staticmethod
     def has_unpushed_commits(path: Path, branch_name: str) -> bool:
-        """Check if a branch has local commits that haven't been pushed to remote.
+        """Check if a branch has commits ahead of the default branch on remote.
+
+        Compares against origin/{default_branch} rather than origin/{branch_name}
+        to avoid false negatives from stale remote tracking refs (e.g., when a
+        branch was previously pushed, merged, and deleted on remote but the
+        local ref origin/{branch} is still cached).
 
         Args:
             path: Repository path
             branch_name: Branch name to check
 
         Returns:
-            True if there are unpushed commits, False otherwise
+            True if there are commits ahead of the remote default branch
         """
         try:
-            # First check if the branch exists on remote
-            if not GitUtils.is_branch_pushed(path, branch_name):
-                # If branch doesn't exist on remote and we have commits, they're unpushed
-                # Check if we have any commits on this branch
-                result = subprocess.run(
-                    ["git", "rev-parse", "--verify", branch_name],
-                    cwd=path,
-                    capture_output=True,
-                    timeout=5,
-                )
-                return result.returncode == 0  # True if branch exists locally
-
-            # Branch exists on remote, check for unpushed commits
-            # Use git log to count commits ahead of remote
+            default_branch = GitUtils.get_default_branch(path) or "main"
             result = subprocess.run(
-                ["git", "log", f"origin/{branch_name}..{branch_name}", "--oneline"],
+                ["git", "log", f"origin/{default_branch}..{branch_name}", "--oneline"],
                 cwd=path,
                 capture_output=True,
                 text=True,
                 timeout=10,
             )
             if result.returncode == 0:
-                # Output is non-empty if there are unpushed commits
                 return bool(result.stdout.strip())
-            return False
+
+            # Fallback: origin/{default_branch} unavailable (no remote configured)
+            result = subprocess.run(
+                ["git", "rev-parse", "--verify", branch_name],
+                cwd=path,
+                capture_output=True,
+                timeout=5,
+            )
+            return result.returncode == 0
         except (subprocess.TimeoutExpired, FileNotFoundError):
             return False
 

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1351,8 +1351,8 @@ def test_has_unpushed_commits_with_unpushed_commits(tmp_path):
     # Get current branch
     current_branch = GitUtils.get_current_branch(tmp_path)
 
-    # Create a bare repo to act as remote
-    remote_path = tmp_path.parent / "remote"
+    # Create a bare repo to act as remote (use unique name to avoid test pollution)
+    remote_path = tmp_path / "remote.git"
     subprocess.run(["git", "init", "--bare", str(remote_path)], capture_output=True)
 
     # Add remote and push
@@ -1389,8 +1389,8 @@ def test_has_unpushed_commits_up_to_date(tmp_path):
     # Get current branch
     current_branch = GitUtils.get_current_branch(tmp_path)
 
-    # Create a bare repo to act as remote
-    remote_path = tmp_path.parent / "remote"
+    # Create a bare repo to act as remote (use unique name to avoid test pollution)
+    remote_path = tmp_path / "remote.git"
     subprocess.run(["git", "init", "--bare", str(remote_path)], capture_output=True)
 
     # Add remote and push
@@ -1401,6 +1401,91 @@ def test_has_unpushed_commits_up_to_date(tmp_path):
     result = GitUtils.has_unpushed_commits(tmp_path, current_branch)
 
     assert result is False
+
+
+@pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git not available"
+)
+def test_has_unpushed_commits_stale_remote_ref(tmp_path):
+    """Test has_unpushed_commits detects commits when remote tracking ref is stale.
+
+    Reproduces #503: branch previously pushed and merged, remote deletes it,
+    but local origin/{branch} ref is still cached. New commits on the reused
+    branch name should still be detected.
+    """
+    # Initialize repo with a default branch
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, capture_output=True)
+
+    (tmp_path / "test.txt").write_text("initial")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], cwd=tmp_path, capture_output=True)
+
+    default_branch = GitUtils.get_current_branch(tmp_path)
+
+    # Create bare remote and push default branch
+    remote_path = tmp_path.parent / "remote_stale"
+    subprocess.run(["git", "init", "--bare", str(remote_path)], capture_output=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote_path)], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "push", "-u", "origin", default_branch], cwd=tmp_path, capture_output=True)
+
+    # Create and push a feature branch (simulating first session)
+    subprocess.run(["git", "checkout", "-b", "feature-503"], cwd=tmp_path, capture_output=True)
+    (tmp_path / "feature.txt").write_text("feature work")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Feature work"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "push", "-u", "origin", "feature-503"], cwd=tmp_path, capture_output=True)
+
+    # Simulate GitHub auto-delete: remove branch from remote but keep local tracking ref
+    subprocess.run(
+        ["git", "push", "origin", "--delete", "feature-503"],
+        cwd=tmp_path, capture_output=True,
+    )
+    # Local origin/feature-503 ref is now stale
+
+    # Make a new commit on the local branch (simulating second session)
+    (tmp_path / "feature2.txt").write_text("new feature work")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "New feature work"], cwd=tmp_path, capture_output=True)
+
+    # Should return True — new commit ahead of default branch
+    result = GitUtils.has_unpushed_commits(tmp_path, "feature-503")
+    assert result is True
+
+
+@pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git not available"
+)
+def test_has_unpushed_commits_fresh_branch_no_remote_ref(tmp_path):
+    """Test has_unpushed_commits works for fresh branches with no remote ref."""
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, capture_output=True)
+
+    (tmp_path / "test.txt").write_text("initial")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], cwd=tmp_path, capture_output=True)
+
+    default_branch = GitUtils.get_current_branch(tmp_path)
+
+    # Create bare remote and push default branch
+    remote_path = tmp_path.parent / "remote_fresh"
+    subprocess.run(["git", "init", "--bare", str(remote_path)], capture_output=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote_path)], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "push", "-u", "origin", default_branch], cwd=tmp_path, capture_output=True)
+
+    # Create a fresh feature branch (never pushed)
+    subprocess.run(["git", "checkout", "-b", "fresh-branch"], cwd=tmp_path, capture_output=True)
+    (tmp_path / "new.txt").write_text("new work")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "New work"], cwd=tmp_path, capture_output=True)
+
+    # Should return True — commits ahead of default branch
+    result = GitUtils.has_unpushed_commits(tmp_path, "fresh-branch")
+    assert result is True
 
 
 def test_list_remote_branches_with_mock(monkeypatch, tmp_path):


### PR DESCRIPTION
Jira Issue: <https://github.com/itdove/devaiflow/issues/503>
<!-- This PR does not need a corresponding Jira item. -->

## Description

Fix false negative in `has_unpushed_commits()` when a branch tracks a stale remote ref.

**Problem:** When a branch was previously pushed, merged, and auto-deleted on GitHub, the local `origin/{branch}` tracking ref remains cached. On subsequent sessions reusing the same branch name, `git log origin/{branch}..{branch}` compared against the stale ref and found no new commits — causing `daf complete` to report "No unpushed commits" even though commits existed that hadn't been pushed.

**Fix:** Changed `has_unpushed_commits()` in `devflow/git/utils.py` to compare against `origin/{default_branch}` (e.g., `origin/main`) instead of `origin/{branch_name}`. This avoids stale tracking refs entirely — any commits ahead of the default branch on remote are correctly detected as unpushed. Added a fallback for repos with no remote configured.

**Tests:** Added two new test cases in `tests/test_git_utils.py`:
- `test_has_unpushed_commits_stale_remote_ref` — reproduces the exact #503 scenario (push, remote delete, new commit, stale ref)
- `test_has_unpushed_commits_fresh_branch_no_remote_ref` — verifies fresh branches with no prior remote ref are handled correctly

Also fixed existing test isolation by using `tmp_path`-relative paths for bare remote repos.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run `pytest tests/test_git_utils.py -k "has_unpushed" -v` to verify all four `has_unpushed_commits` tests pass
3. To reproduce the original bug scenario manually:
   - Create a branch and push it: `git checkout -b test-503 && git commit --allow-empty -m "test" && git push -u origin test-503`
   - Delete the branch on remote: `git push origin --delete test-503`
   - Make a new commit on the local branch: `git commit --allow-empty -m "new work"`
   - Run `daf complete` — should now correctly detect unpushed commits

### Scenarios tested
- Branch with stale remote tracking ref after remote deletion — correctly detects unpushed commits
- Fresh branch never pushed to remote — correctly detects unpushed commits
- Branch with commits pushed and up-to-date — correctly returns False
- Branch with new local commits ahead of pushed remote — correctly returns True

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: