### PR TITLE
itdove/devaiflow#504: daf complete: pass session agent_backend to resolve_agent_backend instead of config-only fallback

### DIFF
--- a/tests/test_complete_command.py
+++ b/tests/test_complete_command.py
@@ -4385,3 +4385,53 @@ def test_complete_session_passes_session_to_resolve_agent_backend(temp_daf_home,
         assert call["session"] is not None, (
             f"Call #{i+1} to resolve_agent_backend passed session=None"
         )
+
+
+def test_complete_resolves_session_agent_over_config_default(temp_daf_home, monkeypatch, capsys):
+    """Verify resolve_agent_backend returns session's agent when it differs from config.
+
+    Regression test for issue #504: when session.agent_backend="claude" but
+    config.agent_backend="opencode", complete_command must use "claude".
+    """
+    config_loader = ConfigLoader()
+    session_manager = SessionManager(config_loader)
+
+    session = session_manager.create_session(
+        name="agent-override-test",
+        goal="Test session agent overrides config",
+        working_directory="test-dir",
+        project_path="/test",
+        ai_agent_session_id="uuid-override-1",
+    )
+    session.agent_backend = "claude"
+    session_manager.update_session(session)
+
+    session_manager.start_work_session("agent-override-test")
+    session_manager.end_work_session("agent-override-test")
+
+    resolved_backends = []
+
+    def tracking_resolve(**kwargs):
+        config_obj = kwargs.get("config")
+        if config_obj is not None:
+            config_obj.agent_backend = "opencode"
+        result = resolve_agent_backend(**kwargs)
+        resolved_backends.append(result)
+        return result
+
+    monkeypatch.setattr(
+        "devflow.cli.commands.complete_command.resolve_agent_backend",
+        tracking_resolve,
+    )
+    monkeypatch.setattr(
+        "devflow.cli.commands.complete_command.Confirm.ask",
+        lambda *args, **kwargs: False,
+    )
+
+    complete_session("agent-override-test")
+
+    assert len(resolved_backends) > 0, "resolve_agent_backend should have been called"
+    for i, backend in enumerate(resolved_backends):
+        assert backend == "claude", (
+            f"Call #{i+1} returned '{backend}' instead of session agent 'claude'"
+        )


### PR DESCRIPTION
Jira Issue: https://github.com/itdove/devaiflow/issues/504

## Description

Pass the session's `agent_backend` to `resolve_agent_backend()` instead of relying on config-only fallback. This ensures the complete command uses the correct agent backend from the active session context rather than potentially falling back to a different default from configuration.

Changes are limited to test coverage in `tests/test_complete_command.py` to verify the session agent_backend is correctly propagated.

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run `pytest tests/test_complete_command.py -v` to verify all complete command tests pass
3. Confirm session-level `agent_backend` is passed through to `resolve_agent_backend` in test assertions

### Scenarios tested
- Complete command uses session agent_backend when available
- Fallback behavior when session agent_backend is not set

## Deployment considerations

- [x] This code change is ready for deployment on its own