### PR TITLE
itdove/devaiflow#507: agent_backend never persisted to metadata.json — all session-based resolution fails

### DIFF
--- a/devflow/cli/commands/open_command.py
+++ b/devflow/cli/commands/open_command.py
@@ -577,6 +577,11 @@ def open_session(
     effective_agent_backend = resolve_agent_backend(cli_override=agent, session=session, config=config)
     agent_name = get_agent_display_name(effective_agent_backend)
 
+    # Persist agent_backend to session if it changed (e.g., user reopened with --agent flag)
+    if effective_agent_backend != session.agent_backend:
+        session.agent_backend = effective_agent_backend
+        session_manager.update_session(session)
+
     if active_conv and active_conv.ai_agent_session_id and active_conv.project_path:
         # Check if the session exists using the agent-aware check
         # This handles both Claude (.jsonl file) and OpenCode (database query) correctly

--- a/devflow/cli/commands/rebuild_index_command.py
+++ b/devflow/cli/commands/rebuild_index_command.py
@@ -91,6 +91,7 @@ def rebuild_index(dry_run: bool = False, force: bool = False) -> None:
                 "conversations": conversations,
                 "working_directory": metadata.get("working_directory"),
                 "workspace_name": metadata.get("workspace_name"),
+                "agent_backend": metadata.get("agent_backend"),
                 "issue_tracker": metadata.get("issue_tracker", "jira"),
                 "issue_key": metadata.get("issue_key"),
                 "issue_updated": metadata.get("issue_updated"),

--- a/devflow/storage/file_backend.py
+++ b/devflow/storage/file_backend.py
@@ -166,6 +166,8 @@ class FileBackend(StorageBackend):
             "branch": branch,
             "status": session.status,
             "conversation_count": len(session.conversations),
+            # Agent backend used to create/reopen this session
+            "agent_backend": session.agent_backend,
             # Store full conversations structure for reliable rebuilds
             "conversations": conversations_dict,
         }

--- a/tests/test_session_agent_backend.py
+++ b/tests/test_session_agent_backend.py
@@ -150,6 +150,92 @@ class TestSessionManagerCreateWithAgentBackend:
         assert loaded_session is not None
         assert loaded_session.agent_backend == "opencode"
 
+    def test_agent_backend_persisted_in_metadata_json_file(self, tmp_path):
+        """Test that agent_backend is written to metadata.json on disk (issue #507)."""
+        from devflow.session.manager import SessionManager
+        from devflow.config.loader import ConfigLoader
+
+        config_dir = tmp_path / ".daf-sessions"
+        config_dir.mkdir()
+
+        config_loader = ConfigLoader(config_dir=config_dir)
+        session_manager = SessionManager(config_loader=config_loader)
+
+        session_manager.create_session(
+            name="test-persist",
+            goal="test goal",
+            agent_backend="opencode",
+        )
+
+        # Read the actual metadata.json file from disk
+        metadata_file = config_dir / "sessions" / "test-persist" / "metadata.json"
+        assert metadata_file.exists()
+
+        with open(metadata_file) as f:
+            metadata = json.load(f)
+
+        assert "agent_backend" in metadata
+        assert metadata["agent_backend"] == "opencode"
+
+    def test_metadata_without_agent_backend_loads_gracefully(self, tmp_path):
+        """Test backward compat: metadata.json without agent_backend defaults to None."""
+        from devflow.session.manager import SessionManager
+        from devflow.config.loader import ConfigLoader
+
+        config_dir = tmp_path / ".daf-sessions"
+        config_dir.mkdir()
+
+        config_loader = ConfigLoader(config_dir=config_dir)
+        session_manager = SessionManager(config_loader=config_loader)
+
+        # Create session normally, then strip agent_backend from metadata.json
+        session_manager.create_session(
+            name="test-compat",
+            goal="test goal",
+            agent_backend="claude",
+        )
+
+        metadata_file = config_dir / "sessions" / "test-compat" / "metadata.json"
+        with open(metadata_file) as f:
+            metadata = json.load(f)
+
+        del metadata["agent_backend"]
+
+        with open(metadata_file, "w") as f:
+            json.dump(metadata, f)
+
+        # Rebuild session from metadata — should not error, agent_backend should be None
+        session = Session(**metadata)
+        assert session.agent_backend is None
+
+    def test_update_session_persists_changed_agent_backend(self, tmp_path):
+        """Test that updating agent_backend and calling update_session persists to disk."""
+        from devflow.session.manager import SessionManager
+        from devflow.config.loader import ConfigLoader
+
+        config_dir = tmp_path / ".daf-sessions"
+        config_dir.mkdir()
+
+        config_loader = ConfigLoader(config_dir=config_dir)
+        session_manager = SessionManager(config_loader=config_loader)
+
+        session = session_manager.create_session(
+            name="test-reopen",
+            goal="test goal",
+            agent_backend="claude",
+        )
+
+        # Simulate reopening with --agent opencode
+        session.agent_backend = "opencode"
+        session_manager.update_session(session)
+
+        # Verify metadata.json on disk reflects the change
+        metadata_file = config_dir / "sessions" / "test-reopen" / "metadata.json"
+        with open(metadata_file) as f:
+            metadata = json.load(f)
+
+        assert metadata["agent_backend"] == "opencode"
+
 
 class TestEffectiveAgentBackendResolution:
     """Test the resolution logic: session.agent_backend > config.agent_backend > 'claude'."""


### PR DESCRIPTION
Got full context. Here's the filled template:

---

Jira Issue: <!-- This PR does not need a corresponding Jira item. -->

## Description

Fix `agent_backend` never being persisted to `metadata.json`, causing all session-based agent resolution to fail on reload. This was the root cause of recurring "Failed to generate commit message from diff" bugs (PRs #497, #501, #502, #506 addressed call sites but missed the persistence layer).

**Changes:**
- **`file_backend.py`** — Add `agent_backend` to the metadata dict in `save_session_metadata()` so it survives session save/load round-trips
- **`open_command.py`** — Persist `agent_backend` to session when reopening with a different agent (e.g., `daf open --agent claude` on a session originally created with opencode)
- **`rebuild_index_command.py`** — Include `agent_backend` when rebuilding the session index from metadata files
- **`test_session_agent_backend.py`** — Add 3 tests: metadata.json persistence, backward compatibility (missing field defaults to None), and update-on-reopen persistence

Fixes itdove/devaiflow#507

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run the test suite: `pytest tests/test_session_agent_backend.py -v`
3. Create a new session with explicit agent: `daf new --agent opencode -n test-persist -g "test"`
4. Inspect the metadata file and verify `agent_backend` is present: `cat ~/.daf-sessions/sessions/test-persist/metadata.json | python -m json.tool | grep agent_backend`
5. Reopen with a different agent: `daf open test-persist --agent claude`
6. Inspect metadata again — `agent_backend` should now be `"claude"`
7. Run `daf complete` and verify the correct agent CLI is used for commit message generation

### Scenarios tested
- New session persists `agent_backend` to `metadata.json` on disk
- Existing metadata.json without `agent_backend` field loads gracefully (backward compat, defaults to None)
- Reopening session with `--agent` flag updates and persists the new agent backend
- Rebuild index preserves `agent_backend` from metadata files
- `resolve_agent_backend()` returns correct value after session reload

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: