### PR TITLE
itdove/devaiflow#509: generate_text() swallows claude -p errors — no stderr logging for commit message failures

### DIFF
--- a/devflow/agent/interface.py
+++ b/devflow/agent/interface.py
@@ -11,10 +11,13 @@ It provides a common interface for operations like:
 Following the IssueTrackerClient pattern from devflow/issue_tracker/interface.py.
 """
 
+import logging
 import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional, Set, List, Dict, Any
+
+logger = logging.getLogger(__name__)
 
 
 class AgentInterface(ABC):
@@ -316,12 +319,27 @@ class AgentInterface(ABC):
                 text=True,
                 timeout=timeout,
             )
-            if result.returncode == 0:
-                text = result.stdout.strip()
-                if text:
-                    return text
+            if result.returncode != 0:
+                stderr_snippet = (result.stderr or "").strip()[:200]
+                logger.warning(
+                    "Agent CLI failed (exit %d): %s",
+                    result.returncode,
+                    stderr_snippet or "(no stderr)",
+                )
+                return None
+            text = result.stdout.strip()
+            if not text:
+                logger.warning("Agent CLI returned empty output")
+                return None
+            return text
+        except FileNotFoundError as e:
+            logger.warning("Agent CLI binary not found: %s", e)
             return None
-        except (FileNotFoundError, subprocess.TimeoutExpired, Exception):
+        except subprocess.TimeoutExpired:
+            logger.warning("Agent CLI timed out after %ds", timeout)
+            return None
+        except Exception as e:
+            logger.warning("Agent CLI unexpected error: %s: %s", type(e).__name__, e)
             return None
 
     def uses_file_based_sessions(self) -> bool:

--- a/devflow/cli/commands/complete_command.py
+++ b/devflow/cli/commands/complete_command.py
@@ -3624,19 +3624,26 @@ def _generate_commit_message(session, agent_backend: Optional[str] = None) -> st
             log_dir.mkdir(parents=True, exist_ok=True)
             log_file = log_dir / "complete.log"
 
-            # Create logger
-            logger = logging.getLogger("devflow.complete")
-            logger.setLevel(logging.DEBUG)
+            # Create logger under devflow namespace so child loggers
+            # (e.g. devflow.agent.interface) also write to complete.log
+            parent_logger = logging.getLogger("devflow")
+            parent_logger.setLevel(logging.DEBUG)
 
-            # Remove existing handlers to avoid duplicates
-            logger.handlers.clear()
+            # Remove existing file handlers to avoid duplicates
+            parent_logger.handlers = [
+                h for h in parent_logger.handlers
+                if not isinstance(h, logging.FileHandler)
+            ]
 
             # Add file handler
             fh = logging.FileHandler(log_file)
             fh.setLevel(logging.DEBUG)
             formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
             fh.setFormatter(formatter)
-            logger.addHandler(fh)
+            parent_logger.addHandler(fh)
+
+            logger = logging.getLogger("devflow.complete")
+            logger.setLevel(logging.DEBUG)
 
             console.print("[dim]Analyzing git diff to generate commit message...[/dim]")
             logger.info(f"Starting commit message generation for session: {session.name}")

--- a/tests/test_agent_interface.py
+++ b/tests/test_agent_interface.py
@@ -1,5 +1,6 @@
 """Tests for agent interface abstraction."""
 
+import logging
 import subprocess
 from pathlib import Path
 from unittest.mock import Mock, patch, ANY
@@ -2008,10 +2009,20 @@ class TestGenerateText:
 
     @patch("subprocess.run")
     def test_generate_text_returns_none_on_failure(self, mock_run):
-        mock_run.return_value = Mock(returncode=1, stdout="")
+        mock_run.return_value = Mock(returncode=1, stdout="", stderr="error msg")
         agent = ClaudeAgent()
         result = agent.generate_text("test prompt")
         assert result is None
+
+    @patch("subprocess.run")
+    def test_generate_text_logs_stderr_on_failure(self, mock_run, caplog):
+        mock_run.return_value = Mock(returncode=1, stdout="", stderr="rate limit exceeded")
+        agent = ClaudeAgent()
+        with caplog.at_level(logging.WARNING, logger="devflow.agent.interface"):
+            result = agent.generate_text("test prompt")
+        assert result is None
+        assert "exit 1" in caplog.text
+        assert "rate limit exceeded" in caplog.text
 
     @patch("subprocess.run")
     def test_generate_text_returns_none_on_empty_output(self, mock_run):
@@ -2020,17 +2031,51 @@ class TestGenerateText:
         result = agent.generate_text("test prompt")
         assert result is None
 
-    @patch("subprocess.run", side_effect=FileNotFoundError)
+    @patch("subprocess.run")
+    def test_generate_text_logs_empty_output(self, mock_run, caplog):
+        mock_run.return_value = Mock(returncode=0, stdout="   \n")
+        agent = ClaudeAgent()
+        with caplog.at_level(logging.WARNING, logger="devflow.agent.interface"):
+            result = agent.generate_text("test prompt")
+        assert result is None
+        assert "empty output" in caplog.text
+
+    @patch("subprocess.run", side_effect=FileNotFoundError("claude not found"))
     def test_generate_text_returns_none_when_cli_missing(self, mock_run):
         agent = ClaudeAgent()
         result = agent.generate_text("test prompt")
         assert result is None
+
+    @patch("subprocess.run", side_effect=FileNotFoundError("claude not found"))
+    def test_generate_text_logs_missing_binary(self, mock_run, caplog):
+        agent = ClaudeAgent()
+        with caplog.at_level(logging.WARNING, logger="devflow.agent.interface"):
+            result = agent.generate_text("test prompt")
+        assert result is None
+        assert "not found" in caplog.text
 
     @patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=30))
     def test_generate_text_returns_none_on_timeout(self, mock_run):
         agent = ClaudeAgent()
         result = agent.generate_text("test prompt")
         assert result is None
+
+    @patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=30))
+    def test_generate_text_logs_timeout(self, mock_run, caplog):
+        agent = ClaudeAgent()
+        with caplog.at_level(logging.WARNING, logger="devflow.agent.interface"):
+            result = agent.generate_text("test prompt")
+        assert result is None
+        assert "timed out" in caplog.text
+
+    @patch("subprocess.run", side_effect=OSError("unexpected"))
+    def test_generate_text_logs_unexpected_error(self, mock_run, caplog):
+        agent = ClaudeAgent()
+        with caplog.at_level(logging.WARNING, logger="devflow.agent.interface"):
+            result = agent.generate_text("test prompt")
+        assert result is None
+        assert "OSError" in caplog.text
+        assert "unexpected" in caplog.text
 
     @patch("subprocess.run")
     def test_generate_text_custom_timeout(self, mock_run):


### PR DESCRIPTION
I have enough context from the diff and commits. Here's the filled PR template:

---

Jira Issue: <https://github.com/itdove/devaiflow/issues/509>

## Description

`generate_text()` in `AgentInterface` previously caught all exceptions with a bare `except` clause and returned `None` without logging any diagnostic information. When the agent CLI (`claude -p`) failed — due to rate limits, missing binary, timeouts, or unexpected errors — the caller had no way to determine why commit message generation failed, making debugging difficult.

This PR adds structured `logging.WARNING` messages for each failure mode in `generate_text()`:
- Non-zero exit code: logs the exit code and first 200 chars of stderr
- Empty stdout: logs that the CLI returned no output
- `FileNotFoundError`: logs that the CLI binary was not found
- `TimeoutExpired`: logs the timeout duration
- Unexpected exceptions: logs the exception type and message

The logging configuration in `complete_command.py` is also updated to attach the file handler to the `devflow` parent logger (instead of only `devflow.complete`), so that child loggers like `devflow.agent.interface` also write to `complete.log`.

Tests are added for each logging scenario to verify that the correct diagnostic messages appear.

Assisted-by: Claude

## Testing

### Steps to test
1. Pull down the PR
2. Run the test suite: `pytest tests/test_agent_interface.py::TestGenerateText -v`
3. Verify all new logging tests pass (e.g., `test_generate_text_logs_stderr_on_failure`, `test_generate_text_logs_missing_binary`, `test_generate_text_logs_timeout`, `test_generate_text_logs_empty_output`, `test_generate_text_logs_unexpected_error`)
4. Optionally trigger a real failure by temporarily misconfiguring the agent backend, then run `daf complete` and check `.daf/logs/complete.log` for the new warning messages

### Scenarios tested
- CLI exits with non-zero code and stderr output — warning logged with exit code and stderr snippet
- CLI returns empty stdout — warning logged about empty output
- CLI binary not found (`FileNotFoundError`) — warning logged with the exception message
- CLI times out (`TimeoutExpired`) — warning logged with the timeout duration
- Unexpected exception (`OSError`) — warning logged with exception type and message
- Successful CLI invocation — no warnings logged, text returned as before

## Deployment considerations

- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: