### PR TITLE
itdove/devaiflow#510: Dashboard from stale pyenv creates ~/.daf-sessions, poisoning XDG config resolution

### DIFF
--- a/devflow/utils/paths.py
+++ b/devflow/utils/paths.py
@@ -4,12 +4,23 @@ import os
 from pathlib import Path
 
 
+def _is_valid_legacy_home(path: Path) -> bool:
+    """Check if a legacy ~/.daf-sessions directory is a genuine installation.
+
+    An empty ~/.daf-sessions/ (or one with only sessions/) can be created
+    accidentally by stale processes (e.g., an old dashboard). Only treat it
+    as a valid legacy home if it contains config files that indicate a real
+    installation.
+    """
+    return (path / "config.json").exists() or (path / "sessions.json").exists()
+
+
 def get_cs_home() -> Path:
     """Get the DevAIFlow home directory.
 
     Resolution priority:
         1. DEVAIFLOW_HOME env var (explicit override, highest priority)
-        2. ~/.daf-sessions exists (legacy compatibility, no silent data loss)
+        2. ~/.daf-sessions with config files (legacy compatibility)
         3. XDG_DATA_HOME/devaiflow (XDG Base Directory Specification)
         4. ~/.local/share/devaiflow (XDG default)
 
@@ -46,9 +57,9 @@ def get_cs_home() -> Path:
     if devaiflow_home:
         return Path(devaiflow_home).expanduser().resolve()
 
-    # 2. Legacy path exists (migration compat — don't silently move data)
+    # 2. Legacy path with valid config (migration compat — don't silently move data)
     legacy_path = Path.home() / ".daf-sessions"
-    if legacy_path.exists():
+    if legacy_path.exists() and _is_valid_legacy_home(legacy_path):
         return legacy_path
 
     # 3. XDG compliant
@@ -64,9 +75,13 @@ def _is_unified_mode() -> bool:
     """Check if DevAIFlow should use a single unified directory.
 
     Returns True when DEVAIFLOW_HOME is set or the legacy ~/.daf-sessions
-    directory exists. In unified mode, all XDG functions return the same path.
+    directory contains valid config files. An empty ~/.daf-sessions/ created
+    by a stale process does not trigger unified mode.
     """
-    return bool(os.getenv("DEVAIFLOW_HOME")) or (Path.home() / ".daf-sessions").exists()
+    if bool(os.getenv("DEVAIFLOW_HOME")):
+        return True
+    legacy_path = Path.home() / ".daf-sessions"
+    return legacy_path.exists() and _is_valid_legacy_home(legacy_path)
 
 
 def get_cs_config_home() -> Path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,6 +211,9 @@ def temp_daf_home(tmp_path, monkeypatch):
     daf_home = tmp_path / ".daf-sessions"
     daf_home.mkdir()
 
+    # Use DEVAIFLOW_HOME to ensure this directory is used as the home (#510)
+    monkeypatch.setenv("DEVAIFLOW_HOME", str(daf_home))
+
     # Create backends directory with minimal valid jira.json
     backends_dir = daf_home / "backends"
     backends_dir.mkdir()
@@ -322,6 +325,9 @@ def temp_daf_home_no_patches(tmp_path, monkeypatch):
 
     daf_home = tmp_path / ".daf-sessions"
     daf_home.mkdir()
+
+    # Use DEVAIFLOW_HOME to ensure this directory is used as the home (#510)
+    monkeypatch.setenv("DEVAIFLOW_HOME", str(daf_home))
 
     # Create backends directory with minimal valid jira.json
     backends_dir = daf_home / "backends"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 
 from devflow.utils.paths import (
+    _is_valid_legacy_home,
+    _is_unified_mode,
     get_cs_home,
     get_cs_config_home,
     get_cs_state_home,
@@ -28,13 +30,14 @@ def test_get_cs_home_default_xdg(monkeypatch, tmp_path):
 
 
 def test_get_cs_home_legacy_compat(monkeypatch, tmp_path):
-    """Test get_cs_home uses legacy ~/.daf-sessions when it exists."""
+    """Test get_cs_home uses legacy ~/.daf-sessions when it has config files."""
     monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     legacy_dir = tmp_path / ".daf-sessions"
     legacy_dir.mkdir()
+    (legacy_dir / "config.json").write_text("{}")
 
     result = get_cs_home()
 
@@ -49,6 +52,7 @@ def test_get_cs_home_legacy_overrides_xdg(monkeypatch, tmp_path):
 
     legacy_dir = tmp_path / ".daf-sessions"
     legacy_dir.mkdir()
+    (legacy_dir / "config.json").write_text("{}")
 
     result = get_cs_home()
 
@@ -99,8 +103,10 @@ def test_get_cs_home_devaiflow_home_overrides_all(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg-data"))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-    # Create legacy dir — should still be ignored
-    (tmp_path / ".daf-sessions").mkdir()
+    # Create valid legacy dir — should still be ignored when DEVAIFLOW_HOME is set
+    legacy = tmp_path / ".daf-sessions"
+    legacy.mkdir()
+    (legacy / "config.json").write_text("{}")
 
     result = get_cs_home()
 
@@ -205,11 +211,13 @@ def test_get_cs_config_home_unified_with_devaiflow_home(monkeypatch, tmp_path):
 
 
 def test_get_cs_config_home_unified_with_legacy(monkeypatch, tmp_path):
-    """Test get_cs_config_home returns same as get_cs_home when legacy dir exists."""
+    """Test get_cs_config_home returns same as get_cs_home when legacy dir has config."""
     monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    (tmp_path / ".daf-sessions").mkdir()
+    legacy = tmp_path / ".daf-sessions"
+    legacy.mkdir()
+    (legacy / "config.json").write_text("{}")
 
     assert get_cs_config_home() == get_cs_home()
 
@@ -263,11 +271,13 @@ def test_get_cs_state_home_unified_with_devaiflow_home(monkeypatch, tmp_path):
 
 
 def test_get_cs_state_home_unified_with_legacy(monkeypatch, tmp_path):
-    """Test get_cs_state_home returns same as get_cs_home when legacy dir exists."""
+    """Test get_cs_state_home returns same as get_cs_home when legacy dir has config."""
     monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
     monkeypatch.delenv("XDG_STATE_HOME", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    (tmp_path / ".daf-sessions").mkdir()
+    legacy = tmp_path / ".daf-sessions"
+    legacy.mkdir()
+    (legacy / "config.json").write_text("{}")
 
     assert get_cs_state_home() == get_cs_home()
 
@@ -424,3 +434,83 @@ def test_get_claude_config_dir_different_from_devaiflow_home(monkeypatch, tmp_pa
     assert claude_result != devaiflow_result
     assert claude_result == claude_path
     assert devaiflow_result == devaiflow_path
+
+
+# Tests for _is_valid_legacy_home() and stale legacy directory (#510)
+
+
+def test_is_valid_legacy_home_empty_dir(tmp_path):
+    """Empty directory is not a valid legacy home."""
+    legacy = tmp_path / ".daf-sessions"
+    legacy.mkdir()
+    assert _is_valid_legacy_home(legacy) is False
+
+
+def test_is_valid_legacy_home_sessions_subdir_only(tmp_path):
+    """Directory with only sessions/ subdir is not valid (stale dashboard scenario)."""
+    legacy = tmp_path / ".daf-sessions"
+    legacy.mkdir()
+    (legacy / "sessions").mkdir()
+    assert _is_valid_legacy_home(legacy) is False
+
+
+def test_is_valid_legacy_home_with_config_json(tmp_path):
+    """Directory with config.json is a valid legacy home."""
+    legacy = tmp_path / ".daf-sessions"
+    legacy.mkdir()
+    (legacy / "config.json").write_text("{}")
+    assert _is_valid_legacy_home(legacy) is True
+
+
+def test_is_valid_legacy_home_with_sessions_json(tmp_path):
+    """Directory with sessions.json is a valid legacy home."""
+    legacy = tmp_path / ".daf-sessions"
+    legacy.mkdir()
+    (legacy / "sessions.json").write_text("{}")
+    assert _is_valid_legacy_home(legacy) is True
+
+
+def test_stale_legacy_does_not_poison_config_resolution(monkeypatch, tmp_path):
+    """Issue #510: Stale dashboard creating ~/.daf-sessions must not poison XDG resolution."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    # Simulate stale dashboard creating empty dirs
+    legacy = tmp_path / ".daf-sessions"
+    legacy.mkdir()
+    (legacy / "sessions").mkdir()
+    (legacy / "state").mkdir()
+
+    # All paths should use XDG, not the stale legacy dir
+    assert get_cs_home() == tmp_path / ".local" / "share" / "devaiflow"
+    assert get_cs_config_home() == tmp_path / ".config" / "devaiflow"
+    assert get_cs_state_home() == tmp_path / ".local" / "state" / "devaiflow"
+    assert _is_unified_mode() is False
+
+
+def test_unified_mode_with_devaiflow_home_env(monkeypatch, tmp_path):
+    """DEVAIFLOW_HOME env var always triggers unified mode."""
+    monkeypatch.setenv("DEVAIFLOW_HOME", str(tmp_path / "custom"))
+    assert _is_unified_mode() is True
+
+
+def test_unified_mode_with_valid_legacy_home(monkeypatch, tmp_path):
+    """Valid legacy home with config.json triggers unified mode."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    legacy = tmp_path / ".daf-sessions"
+    legacy.mkdir()
+    (legacy / "config.json").write_text("{}")
+    assert _is_unified_mode() is True
+
+
+def test_unified_mode_not_triggered_by_empty_legacy(monkeypatch, tmp_path):
+    """Empty legacy directory does not trigger unified mode."""
+    monkeypatch.delenv("DEVAIFLOW_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    legacy = tmp_path / ".daf-sessions"
+    legacy.mkdir()
+    assert _is_unified_mode() is False


### PR DESCRIPTION
I have enough context from the diff and commits. Here's the filled template:

Jira Issue: itdove/devaiflow#510
<!-- This PR does not need a corresponding Jira item. -->

## Description
A stale dashboard process (e.g., from an old pyenv) can create an empty `~/.daf-sessions/` directory, which was enough to make `get_cs_home()` and `_is_unified_mode()` treat it as a valid legacy installation. This poisoned XDG config resolution — all paths collapsed into the empty legacy dir instead of using proper XDG locations (`~/.config/devaiflow`, `~/.local/share/devaiflow`, etc.).

This PR adds a `_is_valid_legacy_home()` check that requires `config.json` or `sessions.json` to exist inside `~/.daf-sessions/` before treating it as a genuine legacy home. An empty directory or one containing only subdirectories like `sessions/` is now ignored, allowing XDG resolution to proceed correctly.

Changes:
- **`devflow/utils/paths.py`**: Added `_is_valid_legacy_home()` validation function. Updated `get_cs_home()` and `_is_unified_mode()` to require config files before using the legacy path.
- **`tests/test_paths.py`**: Added 8 new tests covering `_is_valid_legacy_home()`, stale directory scenarios, and unified mode behavior. Updated existing legacy tests to create config files to match the new requirement.
- **`tests/conftest.py`**: Updated `temp_daf_home` and `temp_daf_home_no_patches` fixtures to set `DEVAIFLOW_HOME` so they don't depend on legacy directory detection.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run the full test suite: `pytest tests/test_paths.py -v`
3. Simulate the stale dashboard scenario:
   - Remove `DEVAIFLOW_HOME` from env if set
   - Create an empty `~/.daf-sessions/` directory (or one with only a `sessions/` subdir)
   - Run `python -c "from devflow.utils.paths import get_cs_home; print(get_cs_home())"` and verify it returns the XDG path (`~/.local/share/devaiflow`), not `~/.daf-sessions`
4. Verify legitimate legacy installs still work:
   - Place a `config.json` inside `~/.daf-sessions/`
   - Re-run the same command and verify it returns `~/.daf-sessions`

### Scenarios tested
- Empty `~/.daf-sessions/` directory is ignored (XDG paths used)
- `~/.daf-sessions/` with only `sessions/` subdir is ignored (stale dashboard scenario)
- `~/.daf-sessions/` with `config.json` is recognized as valid legacy home
- `~/.daf-sessions/` with `sessions.json` is recognized as valid legacy home
- `DEVAIFLOW_HOME` env var still takes highest priority regardless of legacy state
- Unified mode is not triggered by empty legacy directory
- All existing path resolution tests pass with updated fixtures

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: