### PR TITLE
itdove/devaiflow#512: daf config show: add --path flag to output config directory path

### DIFF
--- a/devflow/cli/main.py
+++ b/devflow/cli/main.py
@@ -2027,7 +2027,8 @@ def _show_sync_filters(config, output_json: bool) -> None:
 @click.option("--fields", is_flag=True, help="Show available JIRA custom fields from field_mappings")
 @click.option("--prompts", is_flag=True, help="Show prompt configuration settings")
 @click.option("--sync-filters", is_flag=True, help="Show sync filter configuration for 'daf sync'")
-def config_show(ctx: click.Context, format: str, validate: bool, fields: bool, prompts: bool, sync_filters: bool) -> None:
+@click.option("--paths", "show_paths", is_flag=True, help="Show config, data, and state directory paths (machine-readable)")
+def config_show(ctx: click.Context, format: str, validate: bool, fields: bool, prompts: bool, sync_filters: bool, show_paths: bool) -> None:
     """Show current configuration.
 
     By default, shows merged configuration from all config files.
@@ -2038,14 +2039,33 @@ def config_show(ctx: click.Context, format: str, validate: bool, fields: bool, p
         daf config show --fields           # Show available JIRA fields
         daf config show --prompts          # Show prompt settings
         daf config show --sync-filters     # Show sync filter configuration
+        daf config show --paths            # Show directory paths (for scripting)
         daf config show --format split     # Show split config files
         daf config show --validate         # Validate configuration
         daf config show --json             # Show as JSON
     """
     from devflow.config.loader import ConfigLoader
     from devflow.config.validator import ConfigValidator
+    from devflow.utils.paths import get_cs_config_home, get_cs_home, get_cs_state_home
     from pathlib import Path
     import json
+
+    if show_paths:
+        output_json = ctx.obj.get('output_json', False) if ctx.obj else False
+        config_dir = get_cs_config_home()
+        data_dir = get_cs_home()
+        state_dir = get_cs_state_home()
+        if output_json:
+            click.echo(json.dumps({
+                "config_dir": str(config_dir),
+                "data_dir": str(data_dir),
+                "state_dir": str(state_dir),
+            }))
+        else:
+            click.echo(f"config_dir={config_dir}")
+            click.echo(f"data_dir={data_dir}")
+            click.echo(f"state_dir={state_dir}")
+        return
 
     # Check for mutually exclusive flags
     specialized_flags = sum([fields, prompts, sync_filters])

--- a/devflow/cli_skills/daf-workflow/SKILL.md
+++ b/devflow/cli_skills/daf-workflow/SKILL.md
@@ -49,7 +49,11 @@ Replace `<number>` or `<issue_key>` with the actual value shown in `daf info` ou
 
 ### 3. Read Context Files
 
-First, discover the DevAIFlow config directory by running `daf config show` and noting the parent directory of `config.json` from the "Configuration Files" section (e.g., `/home/user/.config/devaiflow/`). Call this `CONFIG_DIR`.
+First, discover the DevAIFlow config directory:
+
+```bash
+CONFIG_DIR=$(daf config show --paths | grep config_dir | cut -d= -f2)
+```
 
 Then read the hierarchical context files if they exist in `CONFIG_DIR`:
 - `CONFIG_DIR/ENTERPRISE.md` (enterprise-wide policies and standards)
@@ -259,6 +263,7 @@ daf notes                       # View session notes
 
 ```bash
 daf config show                 # Merged configuration
+daf config show --paths         # Config, data, state directory paths
 daf config show --fields        # Custom fields (JIRA)
 daf config refresh-jira-fields  # Refresh from JIRA API
 ```

--- a/tests/test_config_show_paths.py
+++ b/tests/test_config_show_paths.py
@@ -1,0 +1,59 @@
+"""Tests for daf config show --paths flag (#512)."""
+
+import json
+
+from click.testing import CliRunner
+
+from devflow.cli.main import cli
+
+
+def test_paths_outputs_three_lines(temp_daf_home):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "show", "--paths"])
+    assert result.exit_code == 0
+    lines = result.output.strip().split("\n")
+    assert len(lines) == 3
+    assert lines[0].startswith("config_dir=")
+    assert lines[1].startswith("data_dir=")
+    assert lines[2].startswith("state_dir=")
+
+
+def test_paths_values_match_path_functions(temp_daf_home):
+    from devflow.utils.paths import get_cs_config_home, get_cs_home, get_cs_state_home
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "show", "--paths"])
+    assert result.exit_code == 0
+
+    paths = {}
+    for line in result.output.strip().split("\n"):
+        key, value = line.split("=", 1)
+        paths[key] = value
+
+    assert paths["config_dir"] == str(get_cs_config_home())
+    assert paths["data_dir"] == str(get_cs_home())
+    assert paths["state_dir"] == str(get_cs_state_home())
+
+
+def test_paths_json_output(temp_daf_home):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "show", "--paths", "--json"])
+    assert result.exit_code == 0
+
+    data = json.loads(result.output)
+    assert "config_dir" in data
+    assert "data_dir" in data
+    assert "state_dir" in data
+
+
+def test_paths_skips_config_loading(temp_daf_home):
+    """--paths should work without loading config (no config.json needed)."""
+    import shutil
+    config_file = temp_daf_home / "config.json"
+    if config_file.exists():
+        config_file.unlink()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "show", "--paths"])
+    assert result.exit_code == 0
+    assert "config_dir=" in result.output


### PR DESCRIPTION
Jira Issue: <https://github.com/itdove/devaiflow/issues/512>

## Description
itdove/devaiflow#512: daf config show: add --path flag to output config directory path

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR and verify changes build successfully
2. Review the changed files for correctness
3. Run the project's test suite

### Scenarios tested

## Deployment considerations
- [ ] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed:
